### PR TITLE
Don't use reserved words as identifier

### DIFF
--- a/lib/generated_message.dart
+++ b/lib/generated_message.dart
@@ -283,8 +283,8 @@ abstract class GeneratedMessage {
     int hash;
 
     void hashEnumList(PbList enums) {
-      enums.forEach((ProtobufEnum enum) {
-        hash = (31 * hash + enum.value) & 0x3fffffff;
+      enums.forEach((ProtobufEnum protobufEnum) {
+        hash = (31 * hash + protobufEnum.value) & 0x3fffffff;
       });
     }
 
@@ -300,8 +300,8 @@ abstract class GeneratedMessage {
         } else if ((fieldType & _REPEATED_BIT) != 0) {
           hashEnumList(value);
         } else {
-          ProtobufEnum enum = value;
-          hash = ((53 * hash) + enum.value) & 0x3fffffff;
+          ProtobufEnum protobufEnum = value;
+          hash = ((53 * hash) + protobufEnum.value) & 0x3fffffff;
         }
       }
     }


### PR DESCRIPTION
This bug took me some time to figure out. I got very strage errors in combination with `pub build` that I couldn't figure out first:

```
ERR : Error on line 286 of protobuf|lib/generated_message.dart: Expected to find
 ')'
    |       enums.forEach((ProtobufEnum enum) {
    |                                   ^^^^
    |
    | Error on line 286 of protobuf|lib/generated_message.dart: Expected to find
 ')'
    |       enums.forEach((ProtobufEnum enum) {
    |                                   ^^^^
    |
    | Error on line 286 of protobuf|lib/generated_message.dart: Expected to find
 ';'
    |       enums.forEach((ProtobufEnum enum) {
    |                      ^^^^^^^^^^^^
    |
    | Error on line 286 of protobuf|lib/generated_message.dart: Expected a state
ment
    |       enums.forEach((ProtobufEnum enum) {
    |                                   ^^^^
    |
    | Error on line 286 of protobuf|lib/generated_message.dart: Unexpected token
 'enum'
    |       enums.forEach((ProtobufEnum enum) {
    |                                   ^^^^
    |
    | Error on line 286 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |       enums.forEach((ProtobufEnum enum) {
    |                                       ^
    |
    | Error on line 286 of protobuf|lib/generated_message.dart: Expected to find
 ';'
    |       enums.forEach((ProtobufEnum enum) {
    |                                   ^^^^
    |
    | Error on line 286 of protobuf|lib/generated_message.dart: Unexpected token
 ')'
    |       enums.forEach((ProtobufEnum enum) {
    |                                       ^
    |
    | Error on line 287 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |         hash = (31 * hash + enum.value) & 0x3fffffff;
    |                             ^^^^
    |
    | Error on line 287 of protobuf|lib/generated_message.dart: Expected to find
 ';'
    |         hash = (31 * hash + enum.value) & 0x3fffffff;
    |                           ^
    |
    | Error on line 287 of protobuf|lib/generated_message.dart: Expected a state
ment
    |         hash = (31 * hash + enum.value) & 0x3fffffff;
    |                             ^^^^
    |
    | Error on line 287 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |         hash = (31 * hash + enum.value) & 0x3fffffff;
    |                                 ^
    |
    | Error on line 287 of protobuf|lib/generated_message.dart: Expected to find
 ';'
    |         hash = (31 * hash + enum.value) & 0x3fffffff;
    |                                  ^^^^^
    |
    | Error on line 287 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |         hash = (31 * hash + enum.value) & 0x3fffffff;
    |                                       ^
    |
    | Error on line 287 of protobuf|lib/generated_message.dart: Expected to find
 ';'
    |         hash = (31 * hash + enum.value) & 0x3fffffff;
    |                                  ^^^^^
    |
    | Error on line 287 of protobuf|lib/generated_message.dart: Unexpected token
 ')'
    |         hash = (31 * hash + enum.value) & 0x3fffffff;
    |                                       ^
    |
    | Error on line 287 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |         hash = (31 * hash + enum.value) & 0x3fffffff;
    |                                         ^
    |
    | Error on line 288 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |       });
    |        ^
    |
    | Error on line 288 of protobuf|lib/generated_message.dart: Expected to find
 ';'
    |       });
    |       ^
    |
    | Error on line 288 of protobuf|lib/generated_message.dart: Unexpected token
 ')'
    |       });
    |        ^
    |
    | Error on line 303 of protobuf|lib/generated_message.dart: Expected to find
 ';'
    |           ProtobufEnum enum = value;
    |           ^^^^^^^^^^^^
    |
    | Error on line 303 of protobuf|lib/generated_message.dart: Expected a state
ment
    |           ProtobufEnum enum = value;
    |                        ^^^^
    |
    | Error on line 303 of protobuf|lib/generated_message.dart: Unexpected token
 'enum'
    |           ProtobufEnum enum = value;
    |                        ^^^^
    |
    | Error on line 303 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |           ProtobufEnum enum = value;
    |                             ^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                                 ^^^^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Expected to find
 ')'
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                                 ^^^^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Expected to find
 ';'
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                               ^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Expected a state
ment
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                                 ^^^^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Unexpected token
 'enum'
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                                 ^^^^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                                     ^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Expected to find
 ';'
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                                      ^^^^^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                                           ^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Expected to find
 ';'
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                                      ^^^^^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Unexpected token
 ')'
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                                           ^
    |
    | Error on line 304 of protobuf|lib/generated_message.dart: Expected an iden
tifier
    |           hash = ((53 * hash) + enum.value) & 0x3fffffff;
    |                                             ^
    |

```

But this morning I found [this](https://groups.google.com/a/dartlang.org/forum/#!topic/misc/AbSe5N_x1bc) post on the Dart Misc mailing list. That post got me on the right track. I took a look into the language spec of Dart. [Looks like](https://www.dartlang.org/docs/spec/latest/dart-language-specification.html#h.huusvrzea3q) `enum` is a reserved word in Dart and can not be used as an identifier (enum isn't used yet, but probably reserved for future use).

This pull request only renames the identifer from `enum` to `protobufEnum` to solve the problem.
