### PR TITLE
Support 0/1 boolean values when deserializing dart messages

### DIFF
--- a/lib/src/protobuf/generated_message.dart
+++ b/lib/src/protobuf/generated_message.dart
@@ -759,7 +759,7 @@ abstract class GeneratedMessage {
         } else if (value == 0) {
           return false;
         }
-        expectedType = 'num, 0, or 1';
+        expectedType = 'bool, 0, or 1';
       }
       break;
     case _BYTES_BIT:


### PR DESCRIPTION
This is already supported by other serialization libraries and will make it easier to reuse serialized messages from other frameworks.
