### PR TITLE
Add type signature of operator ==

### DIFF
--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -168,7 +168,7 @@ abstract class PbListBase<E> extends ListBase<E> {
         check = _checkNotNull;
 
   @override
-  bool operator ==(other) =>
+  bool operator ==(dynamic other) =>
       (other is PbListBase) && _areListsEqual(other, this);
 
   @override


### PR DESCRIPTION
Otherwise our projects tests do not build. I have tried to provide a minimal example to
demonstrate this issue as we do not understand the problem, but unfortunately I failed doing this :/.