### PR TITLE
Apply avoidInitialUnderscore to field names.

### DIFF
--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -452,7 +452,7 @@ String _fieldMethodSuffix(FieldDescriptorProto field) {
   if (name.isNotEmpty) return _capitalize(name);
 
   if (field.type != FieldDescriptorProto_Type.TYPE_GROUP) {
-    return underscoresToCamelCase(field.name);
+    return underscoresToCamelCase(avoidInitialUnderscore(field.name));
   }
 
   // For groups, use capitalization of 'typeName' rather than 'name'.

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -133,6 +133,10 @@ void main() {
     expect(names.avoidInitialUnderscore('__6E'), 'x6E__');
   });
 
+  test('startsWithDigit', () {
+    expect(names.avoidInitialUnderscore('_500'), 'x500_');
+  });
+
   test('legalDartIdentifier', () {
     expect(names.legalDartIdentifier("foo"), "foo");
     expect(names.legalDartIdentifier("_foo"), "_foo");


### PR DESCRIPTION
This pull request is intended to address issue: #335 