### PR TITLE
Properly type generated proto extensions.

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 20.0.0
+
+* Breaking: generate properly typed extension fields.
+
 ## 19.0.2
 
 * Fix: escape the special character `$` in descriptor's `json_name`.

--- a/protoc_plugin/lib/extension_generator.dart
+++ b/protoc_plugin/lib/extension_generator.dart
@@ -129,13 +129,13 @@ class ExtensionGenerator {
     }
     assert(invocation != null);
     out.printAnnotated(
-        'static final $_protobufImportPrefix.Extension $name = '
+        'static final $name = '
         '$invocation(${ProtobufField._formatArguments(positionals, named)});\n',
         [
           NamedLocation(
               name: name,
               fieldPathSegment: List.from(fieldPath),
-              start: 'static final $_protobufImportPrefix.Extension '.length)
+              start: 'static final '.length)
         ]);
   }
 }

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 19.0.2
+version: 20.0.0
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf
 

--- a/protoc_plugin/test/all_tests.dart
+++ b/protoc_plugin/test/all_tests.dart
@@ -11,6 +11,7 @@ import 'client_generator_test.dart' as client_generator;
 import 'const_generator_test.dart' as const_generator;
 import 'enum_generator_test.dart' as enum_generator;
 import 'extension_test.dart' as extension_test;
+import 'extension_generator_test.dart' as extension_generator_test;
 import 'file_generator_test.dart' as file_generator;
 import 'generated_message_test.dart' as generated_message;
 import 'hash_code_test.dart' as hash_code;
@@ -42,6 +43,7 @@ void main() {
   const_generator.main();
   enum_generator.main();
   extension_test.main();
+  extension_generator_test.main();
   file_generator.main();
   generated_message.main();
   hash_code.main();

--- a/protoc_plugin/test/extension_generator_test.dart
+++ b/protoc_plugin/test/extension_generator_test.dart
@@ -1,0 +1,50 @@
+#!/usr/bin/env dart
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library extension_generator_test;
+
+import 'package:protoc_plugin/indenting_writer.dart';
+import 'package:protoc_plugin/protoc.dart';
+import 'package:protoc_plugin/src/descriptor.pb.dart' as pb;
+import 'package:protoc_plugin/src/plugin.pb.dart' as pb;
+import 'package:test/test.dart';
+
+import 'golden_file.dart';
+
+void main() {
+  test('testExtensionGenerator', () {
+    final extensionFieldDescriptor = pb.FieldDescriptorProto()
+      ..name = 'client_info'
+      ..number = 261486461
+      ..label = pb.FieldDescriptorProto_Label.LABEL_OPTIONAL
+      ..type = pb.FieldDescriptorProto_Type.TYPE_STRING
+      ..extendee = 'Card';
+    final messageDescriptor = pb.DescriptorProto()
+      ..name = 'Card'
+      ..extension.add(extensionFieldDescriptor);
+    final fileDescriptor = pb.FileDescriptorProto()
+      ..messageType.add(messageDescriptor);
+
+    final fileGenerator = FileGenerator(fileDescriptor, GenerationOptions());
+    final extensionGenerator = ExtensionGenerator.topLevel(
+      extensionFieldDescriptor,
+      fileGenerator,
+      <String>{},
+      0,
+    );
+    final options = parseGenerationOptions(
+        pb.CodeGeneratorRequest(), pb.CodeGeneratorResponse());
+    final generationContext = GenerationContext(options);
+    extensionGenerator.resolve(generationContext);
+
+    final writer = IndentingWriter(filename: 'sample.proto');
+    extensionGenerator.generate(writer);
+
+    expectMatchesGoldenFile(writer.toString(),
+        'test/goldens/extension');
+    expectMatchesGoldenFile(writer.sourceLocationInfo.toString(),
+        'test/goldens/extension.meta');
+  });
+}

--- a/protoc_plugin/test/goldens/extension
+++ b/protoc_plugin/test/goldens/extension
@@ -1,0 +1,1 @@
+static final clientInfo = $pb.Extension<$core.String>('', '', 261486461, $pb.PbFieldType.OS, protoName: 'client_info');

--- a/protoc_plugin/test/goldens/extension.meta
+++ b/protoc_plugin/test/goldens/extension.meta
@@ -1,0 +1,7 @@
+annotation: {
+  path: 7
+  path: 0
+  sourceFile: sample.proto
+  begin: 13
+  end: 23
+}


### PR DESCRIPTION
Sync from internal repo--by removing the unnecessary and unparameterized `Extension` type on the LHS of the generated extension fields, the proper type should be inferred by Dart type system.