### PR TITLE
Add map for resolving of type by enum for oneof

### DIFF
--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -314,6 +314,20 @@ class MessageGenerator extends ProtobufContainer {
           out.println('0 : ${oneof.oneofEnumName}.notSet');
         });
       }
+
+      for (OneofNames oneof in _oneofNames) {
+        out.addBlock(
+            'static const $_coreImportPrefix.Map<${oneof.oneofEnumName}, $_coreImportPrefix.Type> ${oneof.typeByEnumMapName} = {',
+            '};', () {
+          for (ProtobufField field in _oneofFields[oneof.index]) {
+            final oneofMemberName =
+                oneofEnumMemberName(field.memberNames.fieldName);
+            out.println(
+                '${oneof.oneofEnumName}.${oneofMemberName} : ${field.baseType.getDartType(fileGen)},');
+          }
+        });
+      }
+
       out.addBlock(
           'static final $_protobufImportPrefix.BuilderInfo _i = '
               '$_protobufImportPrefix.BuilderInfo(\'${messageName}\'$packageClause'

--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -69,8 +69,14 @@ class OneofNames {
   ///  Identifier for the TypeByX map.
   final String typeByEnumMapName;
 
-  OneofNames(this.descriptor, this.index, this.clearMethodName,
-      this.whichOneofMethodName, this.oneofEnumName, this.byTagMapName, this.typeByEnumMapName);
+  OneofNames(
+      this.descriptor,
+      this.index,
+      this.clearMethodName,
+      this.whichOneofMethodName,
+      this.oneofEnumName,
+      this.byTagMapName,
+      this.typeByEnumMapName);
 }
 
 // For performance reasons, use code units instead of Regex.
@@ -331,8 +337,14 @@ MemberNames messageMemberNames(DescriptorProto descriptor,
     String typeMapName = disambiguateName(
         'TypeBy${oneofEnumName}', existingNames, defaultSuffixes());
 
-    takeOneofNames(OneofNames(oneof, i, _defaultClearMethodName(oneofName),
-        _defaultWhichMethodName(oneofName), oneofEnumName, enumMapName, typeMapName));
+    takeOneofNames(OneofNames(
+        oneof,
+        i,
+        _defaultClearMethodName(oneofName),
+        _defaultWhichMethodName(oneofName),
+        oneofEnumName,
+        enumMapName,
+        typeMapName));
   }
 
   return MemberNames(fieldNames, oneofNames);

--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -66,8 +66,11 @@ class OneofNames {
   ///  Identifier for the _XByTag map.
   final String byTagMapName;
 
+  ///  Identifier for the TypeByX map.
+  final String typeByEnumMapName;
+
   OneofNames(this.descriptor, this.index, this.clearMethodName,
-      this.whichOneofMethodName, this.oneofEnumName, this.byTagMapName);
+      this.whichOneofMethodName, this.oneofEnumName, this.byTagMapName, this.typeByEnumMapName);
 }
 
 // For performance reasons, use code units instead of Regex.
@@ -325,8 +328,11 @@ MemberNames messageMemberNames(DescriptorProto descriptor,
     String enumMapName = disambiguateName(
         '_${oneofEnumName}ByTag', existingNames, defaultSuffixes());
 
+    String typeMapName = disambiguateName(
+        'TypeBy${oneofEnumName}', existingNames, defaultSuffixes());
+
     takeOneofNames(OneofNames(oneof, i, _defaultClearMethodName(oneofName),
-        _defaultWhichMethodName(oneofName), oneofEnumName, enumMapName));
+        _defaultWhichMethodName(oneofName), oneofEnumName, enumMapName, typeMapName));
   }
 
   return MemberNames(fieldNames, oneofNames);


### PR DESCRIPTION
What was added: A new static const map in class that is built on 'oneof'
Why was added: This map allows to resolve this object to the specific type it holds: using whichSubtype() as the map index, you get the specific class type. 

Example: Very useful for implementation of an Api Bus which can dispatch messages to callbacks according to the message type:

```

class ApiBus {
  Map _callbackByMessageType = new Map<Type, List<Function>>();

  void publish(ApiObj msg) {
    var type = ApiObj.TypeByApiObj_Subtype[msg.whichSubtype()];

    var callbacks = _callbackByMessageType[type];
    if (null == callbacks) {
      return;
    }
    for (int c = 0; c < callbacks.length; c++) {
      callbacks[c](msg);
    }
  }

  void subscribe<T>(void callback(ApiObj message)) {
    if (null == _callbackByMessageType[T]) {
      _callbackByMessageType[T] = List<Function>();
    }
    _callbackByMessageType[T].add(callback);
  }
}

```