### PR TITLE
Add a benchmark for computing hashCodes.

### DIFF
--- a/protobuf/benchmarks/benchmark_js.dart
+++ b/protobuf/benchmarks/benchmark_js.dart
@@ -26,4 +26,5 @@ void main(List<String> arguments) {
   ToBinaryBenchmark(datasets).report();
   ToJsonBenchmark(datasets).report();
   FromJsonBenchmark(datasets).report();
+  HashCodeBenchmark(datasets).report();
 }

--- a/protobuf/benchmarks/benchmark_vm.dart
+++ b/protobuf/benchmarks/benchmark_vm.dart
@@ -24,4 +24,5 @@ void main(List<String> arguments) {
   ToBinaryBenchmark(datasets).report();
   ToJsonBenchmark(datasets).report();
   FromJsonBenchmark(datasets).report();
+  HashCodeBenchmark(datasets).report();
 }

--- a/protobuf/benchmarks/common.dart
+++ b/protobuf/benchmarks/common.dart
@@ -164,3 +164,17 @@ class ToJsonBenchmark extends _ProtobufBenchmark {
     }
   }
 }
+
+/// HashCode computation benchmark.
+class HashCodeBenchmark extends _ProtobufBenchmark {
+  HashCodeBenchmark(datasets) : super(datasets, 'HashCode');
+
+  @override
+  void run() {
+    for (final dataset in datasets) {
+      for (final unpacked in dataset.unpacked) {
+        unpacked.hashCode;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Computing hash codes is incredibly slow in the current Dart protobuf implementation. We have in-product cases where computing a hash code for a message is nearly as slow as parsing that message from JSON. I'm working on some improvements, so I'm adding a benchmark to track these improvements.