### PR TITLE
Remove lazy `final` fields for `BuilderInfo`s

### DIFF
--- a/protoc_plugin/lib/src/message_generator.dart
+++ b/protoc_plugin/lib/src/message_generator.dart
@@ -328,8 +328,8 @@ class MessageGenerator extends ProtobufContainer {
       }
       final conditionalMessageName = configurationDependent(
           'protobuf.omit_message_names', quoted(messageName));
-      out.addBlock(
-          'static final $protobufImportPrefix.BuilderInfo _i = '
+      out.println('static $protobufImportPrefix.BuilderInfo? __i;');
+      out.addBlock('static $protobufImportPrefix.BuilderInfo get _i => __i ??='
               '$protobufImportPrefix.BuilderInfo($conditionalMessageName'
               '$packageClause'
               ', createEmptyInstance: create'


### PR DESCRIPTION
The JS implementation for lazy `final` adds significant overhead, since these fields are accessed many times. Removing these shows a significant improvement on all JS benchmarks, and no noticeable change for VM benchmarks.

**Baseline**
```
JS
FromBinary(RunTime): 30283.582089552237 us.
FromBinary(RunTime): 30892.30769230769 us.
FromBinary(RunTime): 32387.09677419355 us.
FromBinary(RunTime): 34827.58620689655 us.
FromBinary(RunTime): 37240.74074074074 us.
FromJson(RunTime): 31593.75 us.
FromJson(RunTime): 31656.25 us.
FromJson(RunTime): 31761.904761904763 us.
FromJson(RunTime): 31920.634920634922 us.
FromJson(RunTime): 32983.60655737705 us.
HashCode(RunTime): 8004 us.
HashCode(RunTime): 8060.240963855422 us.
HashCode(RunTime): 8125.506072874494 us.
HashCode(RunTime): 8130.081300813008 us.
HashCode(RunTime): 8204.918032786885 us.
ToBinary(RunTime): 23928.571428571428 us.
ToBinary(RunTime): 24035.714285714286 us.
ToBinary(RunTime): 24120.481927710844 us.
ToBinary(RunTime): 24646.341463414636 us.
ToBinary(RunTime): 26684.21052631579 us.
ToJson(RunTime): 42312.5 us.
ToJson(RunTime): 42914.89361702128 us.
ToJson(RunTime): 43212.765957446805 us.
ToJson(RunTime): 43255.31914893617 us.
ToJson(RunTime): 45000 us.
VM
FromBinary(RunTime): 5354.949197860962 us.
FromBinary(RunTime): 5366.573726541555 us.
FromBinary(RunTime): 5370.890080428954 us.
FromBinary(RunTime): 5472.729508196721 us.
FromBinary(RunTime): 5755.841954022989 us.
FromJson(RunTime): 22949.93181818182 us.
FromJson(RunTime): 23011.597701149425 us.
FromJson(RunTime): 23056.80459770115 us.
FromJson(RunTime): 23155.74712643678 us.
FromJson(RunTime): 23522.54651162791 us.
HashCode(RunTime): 2391.1648745519715 us.
HashCode(RunTime): 2393.464114832536 us.
HashCode(RunTime): 2411.990361445783 u
HashCode(RunTime): 2443.6862026862027 us.
HashCode(RunTime): 2486.2360248447203 us.
ToBinary(RunTime): 7549.607547169811 us.
ToBinary(RunTime): 7625.9087452471485 us.
ToBinary(RunTime): 7708.157692307693 us.
ToBinary(RunTime): 7708.346153846154 us.
ToBinary(RunTime): 7813.46875 us.
ToJson(RunTime): 27943.38888888889 us.
ToJson(RunTime): 27996.277777777777 us.
ToJson(RunTime): 28084.083333333332 us.
ToJson(RunTime): 28084.291666666668 us.
ToJson(RunTime): 30565.484848484848 us.
```

**Results**
```
JS
FromBinary(RunTime): 29455.882352941175 us.
FromBinary(RunTime): 29808.823529411766 us.
FromBinary(RunTime): 30164.17910447761 us.
FromBinary(RunTime): 30238.805970149253 us.
FromBinary(RunTime): 32174.603174603173 us.
FromJson(RunTime): 30515.151515151516 us.
FromJson(RunTime): 30636.363636363636 us.
FromJson(RunTime): 30984.615384615383 us.
FromJson(RunTime): 31061.53846153846 us.
FromJson(RunTime): 31123.076923076922 us.
HashCode(RunTime): 6766.891891891892 us.
HashCode(RunTime): 6786.440677966101 us.
HashCode(RunTime): 6832.764505119454 us.
HashCode(RunTime): 6839.590443686006 us.
HashCode(RunTime): 6996.5034965034965 us.
ToBinary(RunTime): 23011.494252873563 us.
ToBinary(RunTime): 23091.954022988506 us.
ToBinary(RunTime): 23195.402298850575 us.
ToBinary(RunTime): 23406.976744186046 us.
ToBinary(RunTime): 23928.571428571428 us.
ToJson(RunTime): 41895.833333333336 us.
ToJson(RunTime): 42125 us.
ToJson(RunTime): 42914.89361702128 us.
ToJson(RunTime): 42936.17021276596 us.
ToJson(RunTime): 43042.55319148936 us.
VM
FromBinary(RunTime): 5443.002717391304 us.
FromBinary(RunTime): 5446.54347826087 us.
FromBinary(RunTime): 5452.6294277929155 us.
FromBinary(RunTime): 5455.095367847412 us.
FromBinary(RunTime): 5490.687671232877 us.
FromJson(RunTime): 22822.852272727272 us.
FromJson(RunTime): 22969.886363636364 us.
FromJson(RunTime): 23052.80459770115 us.
FromJson(RunTime): 23121.206896551725 us.
FromJson(RunTime): 23203.83908045977 us.
HashCode(RunTime): 2455.564417177914 us.
HashCode(RunTime): 2470.9407407407407 us.
HashCode(RunTime): 2508.3258145363407 us.
HashCode(RunTime): 2511.6298619824342 us.
HashCode(RunTime): 2517.8503144654087 us.
ToBinary(RunTime): 7760.333333333333 us.
ToBinary(RunTime): 7788.229571984436 us.
ToBinary(RunTime): 7803.949416342412 us.
ToBinary(RunTime): 7832.19921875 us.
ToBinary(RunTime): 7907.565217391304 us.
ToJson(RunTime): 28000.375 us.
ToJson(RunTime): 28015.0 us.
ToJson(RunTime): 28067.86111111111 us.
ToJson(RunTime): 28132.722222222223 us.
ToJson(RunTime): 28150.291666666668 us.
```