### PR TITLE
Correctly combine hash codes for repeated enums.

### DIFF
--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -668,7 +668,8 @@ class _FieldSet {
       } else if (!_isEnum(fi.type)) {
         hash = _HashUtils._combine(hash, value.hashCode);
       } else if (fi.isRepeated) {
-        hash = _HashUtils._hashObjects(value.map((enm) => enm.value));
+        hash = _HashUtils._combine(
+            hash, _HashUtils._hashObjects(value.map((enm) => enm.value)));
       } else {
         ProtobufEnum enm = value;
         hash = _HashUtils._combine(hash, enm.value);


### PR DESCRIPTION
The existing logic in `hashField` is overriding the previously computed hash codes, which could include values from other fields within the message. Any message with a repeated enum field with a (relatively) high tag number will generate a poor hash code which doesn't reflect other fields.