### PR TITLE
Add map for resolving of type by enum of oneof

### DIFF
--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -71,8 +71,17 @@ class OneofNames {
   ///  Identifier for the _XByTag map.
   final String byTagMapName;
 
-  OneofNames(this.descriptor, this.index, this.clearMethodName,
-      this.whichOneofMethodName, this.oneofEnumName, this.byTagMapName);
+  ///  Identifier for the TypeByX map.
+  final String typeByEnumMapName;
+
+  OneofNames(
+      this.descriptor,
+      this.index,
+      this.clearMethodName,
+      this.whichOneofMethodName,
+      this.oneofEnumName,
+      this.byTagMapName,
+      this.typeByEnumMapName);
 }
 
 // For performance reasons, use code units instead of Regex.
@@ -332,8 +341,17 @@ MemberNames messageMemberNames(DescriptorProto descriptor,
     var enumMapName = disambiguateName(
         '_${oneofEnumName}ByTag', existingNames, defaultSuffixes());
 
-    takeOneofNames(OneofNames(oneof, i, _defaultClearMethodName(oneofName),
-        _defaultWhichMethodName(oneofName), oneofEnumName, enumMapName));
+    String typeMapName = disambiguateName(
+        'TypeBy${oneofEnumName}', existingNames, defaultSuffixes());
+
+    takeOneofNames(OneofNames(
+        oneof,
+        i,
+        _defaultClearMethodName(oneofName),
+        _defaultWhichMethodName(oneofName),
+        oneofEnumName,
+        enumMapName,
+        typeMapName));
   }
 
   return MemberNames(fieldNames, oneofNames);

--- a/protoc_plugin/lib/src/message_generator.dart
+++ b/protoc_plugin/lib/src/message_generator.dart
@@ -326,6 +326,19 @@ class MessageGenerator extends ProtobufContainer {
           out.println('0 : ${oneof.oneofEnumName}.notSet');
         });
       }
+      for (var oneof in _oneofNames) {
+        out.addBlock(
+            'static const $coreImportPrefix.Map<${oneof.oneofEnumName}, $coreImportPrefix.Type> ${oneof.typeByEnumMapName} = {',
+            '};', () {
+          for (var field in _oneofFields[oneof.index]) {
+            final oneofMemberName =
+                oneofEnumMemberName(field.memberNames.fieldName);
+            out.println(
+                '${oneof.oneofEnumName}.${oneofMemberName} : ${field.baseType.getDartType(fileGen)},');
+          }
+        });
+      }
+
       final conditionalMessageName = configurationDependent(
           'protobuf.omit_message_names', quoted(messageName));
       out.addBlock(


### PR DESCRIPTION
Added: A new static const map in class that is built on 'oneof'
Why: This map allows to resolve this object to the specific type it holds: using whichSubtype() as the map index, you get the specific class type.
**Important**: This PR does not change or remove any existing features, only adds a new field.

The field created will be (for example):
```
  static const $core.Map<ApiObj_Subtype, $core.Type> TypeByApiObj_Subtype = {
    ApiObj_Subtype.batchApiObj : BatchApiObj,
    ApiObj_Subtype.authenticationRequest : AuthenticationRequest,
    ApiObj_Subtype.authenticationResponse : AuthenticationResponse,
  };
```

Example: Very useful for implementation of an Api Bus which can dispatch messages to callbacks according to the message type:

```
class ApiBus {
  Map _callbackByMessageType = new Map<Type, List<Function>>();

  void publish(ApiObj msg) {
    var type = ApiObj.TypeByApiObj_Subtype[msg.whichSubtype()];

    var callbacks = _callbackByMessageType[type];
    if (null == callbacks) {
      return;
    }
    for (int c = 0; c < callbacks.length; c++) {
      callbacks[c](msg);
    }
  }

  void subscribe<T>(void callback(ApiObj message)) {
    if (null == _callbackByMessageType[T]) {
      _callbackByMessageType[T] = List<Function>();
    }
    _callbackByMessageType[T].add(callback);
  }
}
```