### PR TITLE
Update file_generator.dart

### DIFF
--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -599,6 +599,7 @@ class FileGenerator extends ProtobufContainer {
 //
 // @dart = 2.12
 // ignore_for_file: ${ignores.join(',')}
+// ignore_for_file: type=lint
 ''');
   }
 


### PR DESCRIPTION
add `ignore_for_file: type=lint` available from dart 2.15 to disable linter warning for generated files
see https://github.com/dart-lang/sdk/issues/46957#issuecomment-992068403