### PR TITLE
Remove dynamic calls

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,7 @@ linter:
   rules:
   - always_require_non_null_named_parameters
   - annotate_overrides
+  - avoid_dynamic_calls
   - avoid_empty_else
   - avoid_function_literals_in_foreach_calls
   - avoid_init_to_null

--- a/protobuf/analysis_options.yaml
+++ b/protobuf/analysis_options.yaml
@@ -2,6 +2,7 @@ include: package:lints/recommended.yaml
 
 linter:
   rules:
+    - avoid_dynamic_calls
     - comment_references
     - directives_ordering
     - prefer_relative_imports

--- a/protobuf/benchmarks/common.dart
+++ b/protobuf/benchmarks/common.dart
@@ -8,6 +8,10 @@
 /// both on the VM and when compiled to JavaScript.
 library common;
 
+// TODO(https://github.com/google/protobuf.dart/issues/578): Remove remaining
+// dynamic calls.
+// ignore_for_file: avoid_dynamic_calls
+
 import 'dart:typed_data';
 
 import 'package:benchmark_harness/benchmark_harness.dart';

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -195,7 +195,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
 }
 
 void _readPackable(BuilderInfo meta, _FieldSet fs, CodedBufferReader input,
-    int wireType, FieldInfo fi, Function readFunc) {
+    int wireType, FieldInfo fi, Object Function() readFunc) {
   void readToList(List list) => list.add(readFunc());
   _readPackableToList(meta, fs, input, wireType, fi, readToList);
 }
@@ -222,8 +222,13 @@ void _readPackableToListEnum(
   _readPackableToList(meta, fs, input, wireType, fi, readToList);
 }
 
-void _readPackableToList(BuilderInfo meta, _FieldSet fs,
-    CodedBufferReader input, int wireType, FieldInfo fi, Function readToList) {
+void _readPackableToList(
+    BuilderInfo meta,
+    _FieldSet fs,
+    CodedBufferReader input,
+    int wireType,
+    FieldInfo fi,
+    void Function(List<Object?>) readToList) {
   var list = fs._ensureRepeatedField(meta, fi);
 
   if (wireType == WIRETYPE_LENGTH_DELIMITED) {

--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -35,7 +35,7 @@ class CodedBufferReader {
 
   bool isAtEnd() => _bufferPos >= _currentLimit;
 
-  void _withLimit(int byteLimit, callback) {
+  void _withLimit(int byteLimit, void Function() callback) {
     if (byteLimit < 0) {
       throw ArgumentError(
           'CodedBufferReader encountered an embedded string or message'

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -172,10 +172,10 @@ class _ExtensionFieldSet {
     _isReadOnly = true;
     for (var field in _info.values) {
       if (field.isRepeated) {
-        final entries = _values[field.tagNumber];
+        final entries = _values[field.tagNumber] as PbList<GeneratedMessage>?;
         if (entries == null) continue;
         if (field.isGroupOrMessage) {
-          for (var subMessage in entries as List<GeneratedMessage>) {
+          for (var subMessage in entries) {
             subMessage.freeze();
           }
         }

--- a/protobuf/lib/src/protobuf/extension_registry.dart
+++ b/protobuf/lib/src/protobuf/extension_registry.dart
@@ -134,7 +134,7 @@ T _reparseMessage<T extends GeneratedMessage>(
         resultMap ??= ensureResult()._fieldSet._values[field.index!];
 
     if (field.isRepeated) {
-      final messageEntries = message._fieldSet._values[field.index!];
+      final messageEntries = message._fieldSet._values[field.index!] as List?;
       if (messageEntries == null) continue;
       if (field.isGroupOrMessage) {
         for (var i = 0; i < messageEntries.length; i++) {
@@ -146,7 +146,7 @@ T _reparseMessage<T extends GeneratedMessage>(
         }
       }
     } else if (field is MapFieldInfo) {
-      final messageMap = message._fieldSet._values[field.index!];
+      final messageMap = message._fieldSet._values[field.index!] as PbMap?;
       if (messageMap == null) continue;
       if (_isGroupOrMessage(field.valueFieldType!)) {
         for (var key in messageMap.keys) {

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -175,7 +175,7 @@ class _FieldSet {
     _frozenState = true;
     for (var field in _meta.sortedByTag) {
       if (field.isRepeated) {
-        final entries = _values[field.index!];
+        final entries = _values[field.index!] as PbList?;
         if (entries == null) continue;
         if (field.isGroupOrMessage) {
           for (var subMessage in entries as List<GeneratedMessage>) {
@@ -668,7 +668,9 @@ class _FieldSet {
       } else if (!_isEnum(fi.type)) {
         hash = _HashUtils._combine(hash, value.hashCode);
       } else if (fi.isRepeated) {
-        hash = _HashUtils._hashObjects(value.map((enm) => enm.value));
+        value as List;
+        hash = _HashUtils._hashObjects(
+            value.map((enm) => (enm as ProtobufEnum).value));
       } else {
         ProtobufEnum enm = value;
         hash = _HashUtils._combine(hash, enm.value);
@@ -802,6 +804,7 @@ class _FieldSet {
     var mustClone = _isGroupOrMessage(otherFi.type);
 
     if (fi!.isMapField) {
+      fieldValue as Map;
       var f = fi as MapFieldInfo<dynamic, dynamic>;
       mustClone = _isGroupOrMessage(f.valueFieldType!);
       var map = f._ensureMapField(meta, this) as PbMap<dynamic, dynamic>;
@@ -832,7 +835,7 @@ class _FieldSet {
     }
 
     if (otherFi.isGroupOrMessage) {
-      final currentFi = isExtension!
+      GeneratedMessage? currentFi = isExtension!
           ? _ensureExtensions()._getFieldOrNull(fi as Extension<dynamic>)
           : _values[fi.index!];
 

--- a/protobuf/lib/src/protobuf/json.dart
+++ b/protobuf/lib/src/protobuf/json.dart
@@ -5,10 +5,11 @@
 part of protobuf;
 
 Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
-  dynamic convertToMap(dynamic fieldValue, int fieldType) {
+  dynamic convertToMap(Object? fieldValue, int fieldType) {
     var baseType = PbFieldType._baseType(fieldType);
 
     if (_isRepeated(fieldType)) {
+      fieldValue as List;
       return List.from(fieldValue.map((e) => convertToMap(e, baseType)));
     }
 
@@ -27,6 +28,7 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
         // Encode 'bytes' as a base64-encoded string.
         return base64Encode(fieldValue as List<int>);
       case PbFieldType._ENUM_BIT:
+        fieldValue as ProtobufEnum;
         return fieldValue.value; // assume |value| < 2^52
       case PbFieldType._INT64_BIT:
       case PbFieldType._SINT64_BIT:
@@ -34,16 +36,18 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
         return fieldValue.toString();
       case PbFieldType._UINT64_BIT:
       case PbFieldType._FIXED64_BIT:
+        fieldValue as Int64;
         return fieldValue.toStringUnsigned();
       case PbFieldType._GROUP_BIT:
       case PbFieldType._MESSAGE_BIT:
+        fieldValue as GeneratedMessage;
         return fieldValue.writeToJsonMap();
       default:
         throw 'Unknown type $fieldType';
     }
   }
 
-  List _writeMap(dynamic fieldValue, MapFieldInfo fi) =>
+  List _writeMap(Map<Object?, Object?> fieldValue, MapFieldInfo fi) =>
       List.from(fieldValue.entries.map((MapEntry e) => {
             '${PbMap._keyFieldNumber}': convertToMap(e.key, fi.keyFieldType!),
             '${PbMap._valueFieldNumber}':

--- a/protobuf/lib/src/protobuf/utils.dart
+++ b/protobuf/lib/src/protobuf/utils.dart
@@ -31,7 +31,7 @@ bool _areMapsEqual(Map lhs, Map rhs) {
 }
 
 bool _areByteDataEqual(ByteData lhs, ByteData rhs) {
-  Uint8List asBytes(d) =>
+  Uint8List asBytes(ByteData d) =>
       Uint8List.view(d.buffer, d.offsetInBytes, d.lengthInBytes);
   return _areListsEqual(asBytes(lhs), asBytes(rhs));
 }

--- a/protobuf/test/json_test.dart
+++ b/protobuf/test/json_test.dart
@@ -3,6 +3,10 @@
 // There are more JSON tests in the dart-protoc-plugin package.
 library json_test;
 
+// TODO(https://github.com/google/protobuf.dart/issues/578): Remove remaining
+// dynamic calls.
+// ignore_for_file: avoid_dynamic_calls
+
 import 'dart:convert';
 
 import 'package:fixnum/fixnum.dart' show Int64;

--- a/protobuf/test/list_test.dart
+++ b/protobuf/test/list_test.dart
@@ -92,6 +92,9 @@ void main() {
 
   test('PbList validates items', () {
     expect(() {
+      // TODO(https://github.com/google/protobuf.dart/issues/578): Remove
+      // remaining dynamic calls.
+      // ignore: avoid_dynamic_calls
       (PbList<int>() as dynamic).add('hello');
     }, throwsA(TypeMatcher<TypeError>()));
   });

--- a/protobuf/test/map_mixin_test.dart
+++ b/protobuf/test/map_mixin_test.dart
@@ -7,6 +7,10 @@
 // There are more tests in the dart-protoc-plugin package.
 library map_mixin_test;
 
+// TODO(https://github.com/google/protobuf.dart/issues/578): Remove remaining
+// dynamic calls.
+// ignore_for_file: avoid_dynamic_calls
+
 import 'dart:collection' show MapMixin;
 
 import 'package:protobuf/protobuf.dart';

--- a/protobuf/test/message_test.dart
+++ b/protobuf/test/message_test.dart
@@ -22,6 +22,9 @@ class Rec extends MockMessage {
 Matcher throwsError(Type expectedType, String expectedMessage) =>
     throwsA(predicate((dynamic x) {
       expect(x.runtimeType, expectedType);
+      // TODO(https://github.com/google/protobuf.dart/issues/578): Remove
+      // remaining dynamic calls.
+      // ignore: avoid_dynamic_calls
       expect(x!.message, expectedMessage);
       return true;
     }));

--- a/protobuf/test/readonly_message_test.dart
+++ b/protobuf/test/readonly_message_test.dart
@@ -18,6 +18,9 @@ import 'package:test/test.dart';
 Matcher throwsError(Type expectedType, Matcher expectedMessage) =>
     throwsA(predicate((dynamic x) {
       expect(x.runtimeType, expectedType);
+      // TODO(https://github.com/google/protobuf.dart/issues/578): Remove
+      // remaining dynamic calls.
+      // ignore: avoid_dynamic_calls
       expect(x!.message, expectedMessage);
       return true;
     }));


### PR DESCRIPTION
Work towards https://github.com/google/protobuf.dart/issues/578

Many of these fixes were guesses. Function `f` takes a `dynamic` which is later indexed with `[]` in a sub-path of the function. Function `g` passes a value to function `f` but that value is also `dynamic`. `dynamic` all the way down. The bright side is that these guesses are less guess-y than dynamic invocations. :)

I did not land any fixes in tests. This PR is to improve app size.