### PR TITLE
Avoid runtime checks when possible in BuilderInfo.add

### DIFF
--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -53,6 +53,27 @@ class BuilderInfo {
     _addField(fieldInfo);
   }
 
+  void addWithDefaultFunc<T>(
+      int tagNumber,
+      String name,
+      int? fieldType,
+      MakeDefaultFunc? defaultFunc,
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      {String? protoName}) {
+    var index = byIndex.length;
+    final fieldInfo = (tagNumber == 0)
+        ? FieldInfo.dummy(index)
+        : FieldInfo<T>.withDefaultFunc(
+            name, tagNumber, index, fieldType!, defaultFunc,
+            subBuilder: subBuilder,
+            valueOf: valueOf,
+            enumValues: enumValues,
+            protoName: protoName);
+    _addField(fieldInfo);
+  }
+
   void addMapField<K, V>(
       int tagNumber,
       String name,
@@ -177,7 +198,7 @@ class BuilderInfo {
 
   void aOM<T extends GeneratedMessage>(int tagNumber, String name,
       {T Function()? subBuilder, String? protoName}) {
-    add<T>(
+    addWithDefaultFunc<T>(
         tagNumber,
         name,
         PbFieldType.OM,
@@ -190,7 +211,7 @@ class BuilderInfo {
 
   void aQM<T extends GeneratedMessage>(int tagNumber, String name,
       {T Function()? subBuilder, String? protoName}) {
-    add<T>(
+    addWithDefaultFunc<T>(
         tagNumber,
         name,
         PbFieldType.QM,

--- a/protobuf/lib/src/protobuf/field_info.dart
+++ b/protobuf/lib/src/protobuf/field_info.dart
@@ -64,6 +64,21 @@ class FieldInfo<T> {
             _isMapField(type)),
         assert(!_isEnum(type) || valueOf != null);
 
+  FieldInfo.withDefaultFunc(
+      this.name, this.tagNumber, this.index, this.type, this.makeDefault,
+      {this.subBuilder,
+      this.valueOf,
+      this.enumValues,
+      this.defaultEnumValue,
+      String? protoName})
+      : check = null,
+        protoName = protoName ?? _unCamelCase(name),
+        assert(type != 0),
+        assert(!_isGroupOrMessage(type) ||
+            subBuilder != null ||
+            _isMapField(type)),
+        assert(!_isEnum(type) || valueOf != null);
+
   // Represents a field that has been removed by a program transformation.
   FieldInfo.dummy(this.index)
       : name = '<removed field>',


### PR DESCRIPTION
This avoids casting default value builders to dynamic in Builder.add
when possible.

Fixes #575