### PR TITLE
Treat empty and uninitialized Maps the same in equality checks

### DIFF
--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -635,6 +635,11 @@ class _FieldSet {
     // This is because accessing a repeated field automatically creates it.
     // We don't want reading a field to change equality comparisons.
     if (val is List && val.isEmpty) return true;
+      
+    // An empty map field is the same as uninitialized.
+    // This is because accessing a map field automatically creates it.
+    // We don't want reading a field to change equality comparisons.
+    if (val is Map && val.isEmpty) return true;
 
     // For now, initialized and uninitialized fields are different.
     // TODO(skybrian) consider other cases; should we compare with the
@@ -658,6 +663,10 @@ class _FieldSet {
     int hashField(int hash, FieldInfo fi, value) {
       if (value is List && value.isEmpty) {
         return hash; // It's either repeated or an empty byte array.
+      }
+        
+      if (value is Map && value.isEmpty) {
+        return hash;
       }
 
       hash = _HashUtils._combine(hash, fi.tagNumber);


### PR DESCRIPTION
Treat an empty Map the same as an uninitialized Map when performing equality checks. This ensures that reading a map field does not alter the hashCode or equality comparisons of the message itself.