### PR TITLE
JSON serialization emitDefuaults option

### DIFF
--- a/protobuf/lib/protobuf.dart
+++ b/protobuf/lib/protobuf.dart
@@ -13,6 +13,7 @@ import 'dart:typed_data' show TypedData, Uint8List, ByteData, Endian;
 import 'package:fixnum/fixnum.dart' show Int64;
 
 import 'src/protobuf/json_parsing_context.dart';
+import 'src/protobuf/json_serialization_context.dart';
 import 'src/protobuf/permissive_compare.dart';
 import 'src/protobuf/type_registry.dart';
 export 'src/protobuf/type_registry.dart' show TypeRegistry;

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -233,8 +233,9 @@ abstract class GeneratedMessage {
   /// message encoding a type not in [typeRegistry] is encountered, an
   /// error is thrown.
   Object? toProto3Json(
-          {TypeRegistry typeRegistry = const TypeRegistry.empty()}) =>
-      _writeToProto3Json(_fieldSet, typeRegistry);
+          {TypeRegistry typeRegistry = const TypeRegistry.empty(),
+          bool emitDefaults = false}) =>
+      _writeToProto3Json(_fieldSet, typeRegistry, emitDefaults);
 
   /// Merges field values from [json], a JSON object using proto3 encoding.
   ///

--- a/protobuf/lib/src/protobuf/json_serialization_context.dart
+++ b/protobuf/lib/src/protobuf/json_serialization_context.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+class JsonSerializationContext {
+  final bool emitDefaults;
+
+  JsonSerializationContext(this.emitDefaults);
+}

--- a/protobuf/test/json_test.dart
+++ b/protobuf/test/json_test.dart
@@ -115,6 +115,64 @@ void main() {
     final decoded = T()..mergeFromJsonMap(encoded);
     expect(decoded.int64, value);
   });
+
+  test('testToProto3Json', () {
+    var json = jsonEncode(example.toProto3Json());
+    checkProto3JsonMap(jsonDecode(json), 3);
+  });
+
+  test('testToProto3JsonEmitDefaults', () {
+    var json = jsonEncode(example.toProto3Json(emitDefaults: true));
+    checkProto3JsonMap(jsonDecode(json), 6);
+    expect(json.contains('"child":null'), isTrue);
+  });
+
+  test('testToProto3JsonEmitDefaultsNoValues', () {
+    final exampleAllDefaults = T();
+    var json = jsonEncode(exampleAllDefaults.toProto3Json(emitDefaults: true));
+    Map m = jsonDecode(json);
+    expect(m.length, 6);
+  });
+
+  test('testToProto3JsonEmitDefaultsWithChild', () {
+    var child = example;
+
+    var parent = T()
+      ..val = 123
+      ..str = 'hello'
+      ..int32s.addAll(<int>[1, 2, 3])
+      ..child = example;
+    var parentJson = jsonEncode(parent.toProto3Json(emitDefaults: true));
+    var childJson = jsonEncode(child.toProto3Json(emitDefaults: true));
+    checkProto3JsonMap(jsonDecode(parentJson), 6);
+    expect(parentJson.contains(childJson), isTrue);
+  });
+
+  test('testToProto3JsonEmitDefaultsWithNullList', () {
+    var exampleEmptyList = T()
+      ..val = example.val
+      ..str = example.str;
+
+    var json = jsonEncode(exampleEmptyList.toProto3Json(emitDefaults: true));
+    expect(json.contains('"int32s":[]'), isTrue);
+  });
+
+  test('testToProto3JsonEmitDefaultsWithEmptyList', () {
+    var exampleEmptyList = T()
+      ..val = example.val
+      ..str = example.str
+      ..int32s.addAll(<int>[]);
+
+    var json = jsonEncode(exampleEmptyList.toProto3Json(emitDefaults: true));
+    expect(json.contains('"int32s":[]'), isTrue);
+  });
+}
+
+void checkProto3JsonMap(Map m, int expectedLength) {
+  expect(m.length, expectedLength);
+  expect(m['val'], 123);
+  expect(m['str'], 'hello');
+  expect(m['int32s'], [1, 2, 3]);
 }
 
 void checkJsonMap(Map m) {


### PR DESCRIPTION
Similar to the existing JsonParsingContext for customizing deserialization of JSON via mergeFromProto3Json, this PR adds a new JsonSerializationContext for customizing the serialization of JSON via toProto3Json.

This addresses https://github.com/google/protobuf.dart/issues/585. Tests have been added for common uses cases to ensure that the proper default values are serialized for each use case.