### PR TITLE
Refactor _mergeFromCodedBuffer for consistency with other _mergeFrom functions

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -26,9 +26,10 @@ void _writeToCodedBufferWriter(_FieldSet fs, CodedBufferWriter out) {
   }
 }
 
-void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
-    CodedBufferReader input, ExtensionRegistry registry) {
+void _mergeFromCodedBufferReader(
+    _FieldSet fs, CodedBufferReader input, ExtensionRegistry registry) {
   ArgumentError.checkNotNull(registry);
+  final BuilderInfo meta = fs._meta;
   while (true) {
     var tag = input.readTag();
     if (tag == 0) return;

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -177,8 +177,7 @@ abstract class GeneratedMessage {
 
   void mergeFromCodedBufferReader(CodedBufferReader input,
       [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
-    final meta = _fieldSet._meta;
-    _mergeFromCodedBufferReader(meta, _fieldSet, input, extensionRegistry);
+    _mergeFromCodedBufferReader(_fieldSet, input, extensionRegistry);
   }
 
   /// Merges serialized protocol buffer data into this message.
@@ -192,8 +191,7 @@ abstract class GeneratedMessage {
   void mergeFromBuffer(List<int> input,
       [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
     var codedInput = CodedBufferReader(input);
-    final meta = _fieldSet._meta;
-    _mergeFromCodedBufferReader(meta, _fieldSet, codedInput, extensionRegistry);
+    _mergeFromCodedBufferReader(_fieldSet, codedInput, extensionRegistry);
     codedInput.checkLastTagWas(0);
   }
 

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -97,7 +97,7 @@ class PbMap<K, V> extends MapBase<K, V> {
     var oldLimit = input._currentLimit;
     input._currentLimit = input._bufferPos + length;
     final entryFieldSet = _FieldSet(null, mapEntryMeta, null);
-    _mergeFromCodedBufferReader(mapEntryMeta, entryFieldSet, input, registry!);
+    _mergeFromCodedBufferReader(entryFieldSet, input, registry!);
     input.checkLastTagWas(0);
     input._currentLimit = oldLimit;
     var key =


### PR DESCRIPTION
`_mergeFromProto3Json`, `_mergeFromJsonMap`, and `_mergeFromMessage` all
use `BuilderInfo` from the `_FieldInfo` argument. Update
`_mergeFromCodedBuffer` so that it also uses the `BuilderInfo` from the
`_FieldInfo` argument, for consistency.

It also eliminates the possibility of passing an incorrect `BuilderInfo`
with the `_FieldInfo` when calling `_mergeFromCodedBuffer`.