### PR TITLE
Remove redundant check in PbMap equality check

### DIFF
--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -52,11 +52,6 @@ class PbMap<K, V> extends MapBase<K, V> {
       return false;
     }
     for (final key in keys) {
-      if (!other.containsKey(key)) {
-        return false;
-      }
-    }
-    for (final key in keys) {
       if (other[key] != this[key]) {
         return false;
       }


### PR DESCRIPTION
Since we check that both maps have same number of keys, the check
comparing each key in one of the maps with the value of the key in the
other map is enough to make sure both maps have the same set of keys.