### PR TITLE
Make `protoName` unCamelCase lazy

### DIFF
--- a/protobuf/lib/src/protobuf/field_info.dart
+++ b/protobuf/lib/src/protobuf/field_info.dart
@@ -29,7 +29,12 @@ class FieldInfo<T> {
   /// ```
   /// `protoName` for the `result_per_page` field above is `"result_per_page"`.
   /// This will typically consist of words separated with underscores.
-  final String protoName;
+  String get protoName {
+    _protoName ??= _unCamelCase(name);
+    return _protoName!;
+  }
+
+  String? _protoName;
 
   /// Field number as specified in the proto definition. Example:
   /// ```proto
@@ -80,7 +85,7 @@ class FieldInfo<T> {
       String? protoName})
       : makeDefault = findMakeDefault(type, defaultOrMaker),
         check = null,
-        protoName = protoName ?? _unCamelCase(name),
+        _protoName = protoName,
         assert(type != 0),
         assert(!_isGroupOrMessage(type) ||
             subBuilder != null ||
@@ -90,7 +95,7 @@ class FieldInfo<T> {
   // Represents a field that has been removed by a program transformation.
   FieldInfo.dummy(this.index)
       : name = '<removed field>',
-        protoName = '<removed field>',
+        _protoName = '<removed field>',
         tagNumber = 0,
         type = 0,
         makeDefault = null,
@@ -104,7 +109,7 @@ class FieldInfo<T> {
       this.check, this.subBuilder,
       {this.valueOf, this.enumValues, this.defaultEnumValue, String? protoName})
       : makeDefault = (() => PbList<T>(check: check!)),
-        protoName = protoName ?? _unCamelCase(name) {
+        _protoName = protoName {
     ArgumentError.checkNotNull(name, 'name');
     ArgumentError.checkNotNull(tagNumber, 'tagNumber');
     assert(_isRepeated(type));

--- a/protobuf/lib/src/protobuf/field_info.dart
+++ b/protobuf/lib/src/protobuf/field_info.dart
@@ -30,8 +30,7 @@ class FieldInfo<T> {
   /// `protoName` for the `result_per_page` field above is `"result_per_page"`.
   /// This will typically consist of words separated with underscores.
   String get protoName {
-    _protoName ??= _unCamelCase(name);
-    return _protoName!;
+    return _protoName ??= _unCamelCase(name);
   }
 
   String? _protoName;


### PR DESCRIPTION
In a large 1p Flutter android application, package:protobuf accounts for ~220ms (8%) of the CPU time during startup. This `_uncamelCase` operation takes up ~25ms, or 11% of this 220ms which occurs whenever a proto is constructed.

Looking through the code, it appears that this `protoName` field is only needed for conversion to JSON which is less common. As such, make it a lazy getter to avoid this.

[Internal link](http://pprof/user-profile?id=d8d43f484e3e7b4064a29737cbdabf77&tab=flame&flamesearch=unCamel&pivot=Precompiled_____unCamelCase_19070143_4307) to pivot profile view which highlights this method (top half shows callers, bottom half shows callees)