### PR TITLE
protoc_plugin README fixes and tweaks:

### DIFF
--- a/protoc_plugin/README.md
+++ b/protoc_plugin/README.md
@@ -64,7 +64,7 @@ your `PATH` with name `protoc-gen-dart`, or pass the path to it to `protoc`'s
 ## How to use
 
 Once you have `protoc-gen-dart` in the `PATH` the protocol buffer compiler can
-be invoked like this:
+be invoked like this to generate Dart for the proto file `test.proto`:
 
     $ protoc --dart_out=. test.proto
 
@@ -106,21 +106,25 @@ re-export the relevant protocol buffer classes.
 Say we have the file `m1.proto` with the following content
 
 ```proto
+syntax = "proto3";
+
 message M1 {
-  optional string a;
+  optional string a = 1;
 }
 ```
 
 and `m2.proto` containing
 
 ```proto
+syntax = "proto3";
+
 message M2 {
-  optional string b;
+  optional string b = 1;
 }
 ```
 
 Compiling these to Dart will produce two libraries in `m1.pb.dart` and
-`m2.pb.dart`. The following code shows a library M which combines
+`m2.pb.dart`. The following code shows a library `M` which combines
 these two protocol buffer libraries, exposes the classes `M1` and `M2` and
 adds some additional methods.
 

--- a/protoc_plugin/README.md
+++ b/protoc_plugin/README.md
@@ -109,7 +109,7 @@ Say we have the file `m1.proto` with the following content
 syntax = "proto3";
 
 message M1 {
-  optional string a = 1;
+  string a = 1;
 }
 ```
 
@@ -119,7 +119,7 @@ and `m2.proto` containing
 syntax = "proto3";
 
 message M2 {
-  optional string b = 1;
+  string b = 1;
 }
 ```
 


### PR DESCRIPTION
- Fix proto syntax

- Add `syntax = "proto3"` in proto examples. proto3 is used instead of
  proto3 is newer. Removed `optional`s.

- Minor rewording

Closes #208