### PR TITLE
Testing: don't return static methods in findMemberNames

### DIFF
--- a/protobuf/lib/meta.dart
+++ b/protobuf/lib/meta.dart
@@ -60,7 +60,6 @@ const GeneratedMessage_reservedNames = <String>[
   'writeToCodedBufferWriter',
   'writeToJson',
   'writeToJsonMap',
-  r'$_defaultFor',
   r'$_ensure',
   r'$_get',
   r'$_getI64',
@@ -91,7 +90,6 @@ const ProtobufEnum_reservedNames = <String>[
   'Object',
   'ProtobufEnum',
   'hashCode',
-  'initByValue',
   'noSuchMethod',
   'runtimeType',
   'toString'

--- a/protoc_plugin/test/mirror_util.dart
+++ b/protoc_plugin/test/mirror_util.dart
@@ -26,7 +26,8 @@ Set<String> findMemberNames(String importName, Symbol classSymbol) {
     for (var decl in cls.declarations.values) {
       if (!decl.isPrivate &&
           decl is! VariableMirror &&
-          decl is! TypeVariableMirror) {
+          decl is! TypeVariableMirror &&
+          !(decl is MethodMirror && decl.isStatic)) {
         result.add(chooseName(decl.simpleName));
       }
     }
@@ -37,18 +38,5 @@ Set<String> findMemberNames(String importName, Symbol classSymbol) {
     cls = cls.superclass;
   }
 
-  return result..removeAll(_staticMethods);
+  return result;
 }
-
-// We don't consider static methods as reserved as it's not possible to
-// override or shadow a static method in a subclass. However `dart:mirrors`
-// does not provide a `isStatic` property on declarations so we can't check for
-// static methods in `findMemberNames`. Instead we need to hard-code static
-// methods of `GeneratedMessage` and its superclasses here and manually remove
-// these in `findMemberNames`.
-const _staticMethods = {
-  // These were added in Dart 2.14:
-  'hash',
-  'hashAll',
-  'hashAllUnordered',
-};

--- a/protoc_plugin/test/reserved_names_test.dart
+++ b/protoc_plugin/test/reserved_names_test.dart
@@ -26,9 +26,7 @@ void main() {
   test('GeneratedMessage reserved names are up to date', () {
     var actual = Set<String>.from(GeneratedMessage_reservedNames);
     var expected =
-        findMemberNames('package:protobuf/protobuf.dart', #GeneratedMessage)
-          // TODO: see https://github.com/google/protobuf.dart/issues/527
-          ..removeAll(_oneOffNames);
+        findMemberNames('package:protobuf/protobuf.dart', #GeneratedMessage);
 
     expect(actual.toList()..sort(), equals(expected.toList()..sort()));
   });
@@ -36,18 +34,14 @@ void main() {
   test('ProtobufEnum reserved names are up to date', () {
     var actual = Set<String>.from(ProtobufEnum_reservedNames);
     var expected =
-        findMemberNames('package:protobuf/protobuf.dart', #ProtobufEnum)
-          // TODO: see https://github.com/google/protobuf.dart/issues/527
-          ..removeAll(_oneOffNames);
+        findMemberNames('package:protobuf/protobuf.dart', #ProtobufEnum);
 
     expect(actual.toList()..sort(), equals(expected.toList()..sort()));
   });
 
   test("ReadonlyMessageMixin doesn't add any reserved names", () {
-    var mixinNames =
-        findMemberNames('package:protobuf/protobuf.dart', #ReadonlyMessageMixin)
-          // TODO: see https://github.com/google/protobuf.dart/issues/527
-          ..removeAll(_oneOffNames);
+    var mixinNames = findMemberNames(
+        'package:protobuf/protobuf.dart', #ReadonlyMessageMixin);
     var reservedNames = Set<String>.from(GeneratedMessage_reservedNames);
     for (var name in mixinNames) {
       if (name == 'ReadonlyMessageMixin' || name == 'unknownFields') continue;
@@ -63,9 +57,7 @@ void main() {
 
     var expected = findMemberNames(meta.importFrom, #PbMapMixin)
       ..addAll(findMemberNames('dart:collection', #MapMixin))
-      ..removeAll(GeneratedMessage_reservedNames)
-      // TODO: see https://github.com/google/protobuf.dart/issues/527
-      ..removeAll(_oneOffNames);
+      ..removeAll(GeneratedMessage_reservedNames);
 
     expect(
         actual.toList()..sort(), containsAllInOrder(expected.toList()..sort()));
@@ -76,17 +68,8 @@ void main() {
     var actual = Set<String>.from(meta.findReservedNames());
 
     var expected = findMemberNames(meta.importFrom, #PbEventMixin)
-      ..removeAll(GeneratedMessage_reservedNames)
-      // TODO: see https://github.com/google/protobuf.dart/issues/527
-      ..removeAll(_oneOffNames);
+      ..removeAll(GeneratedMessage_reservedNames);
 
     expect(actual.toList()..sort(), equals(expected.toList()..sort()));
   });
 }
-
-// See https://github.com/google/protobuf.dart/issues/527
-const _oneOffNames = {
-  'hash',
-  'hashAll',
-  'hashAllUnordered',
-};


### PR DESCRIPTION
This refactors the fix for #527 and improves on it. We now filter out static
methods in `findMemberNames`. Static methods cannot be overridden or shadowed
in subclasses so we don't consider them as reserved.

Static methods `GeneratedMessage.$_defaultFor` and `ProtobufEnum.initByValue`
are removed from reserved names lists. These were probably added because we
didn't properly remove static methods in `findMemberNames` before.

Closes #527