### PR TITLE
Add `UseResult` annotation to `rebuild`

### DIFF
--- a/protobuf/lib/protobuf.dart
+++ b/protobuf/lib/protobuf.dart
@@ -11,6 +11,7 @@ import 'dart:math' as math;
 import 'dart:typed_data' show TypedData, Uint8List, ByteData, Endian;
 
 import 'package:fixnum/fixnum.dart' show Int64;
+import 'package:meta/meta.dart' show UseResult;
 
 import 'src/protobuf/json_parsing_context.dart';
 import 'src/protobuf/permissive_compare.dart';

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -558,6 +558,8 @@ extension GeneratedMessageGenericExtensions<T extends GeneratedMessage> on T {
   ///
   /// Makes a writable shallow copy of this message, applies the [updates] to
   /// it, and marks the copy read-only before returning it.
+  @UseResult('[GeneratedMessageGenericExtensions.rebuild] '
+      'does not update the message, returns a new message')
   T rebuild(void Function(T) updates) {
     if (!isFrozen) {
       throw ArgumentError('Rebuilding only works on frozen messages.');

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   fixnum: ^1.0.0
   collection: ^1.15.0
+  meta: ^1.7.0
 
 dev_dependencies:
   test: ^1.16.0

--- a/protoc_plugin/test/oneof_test.dart
+++ b/protoc_plugin/test/oneof_test.dart
@@ -162,12 +162,14 @@ void main() {
     var foo = Foo();
     expectOneofNotSet(foo);
     // `ignore` below to work around https://github.com/dart-lang/sdk/issues/48879
-    var copy1 = foo.deepCopy().freeze().rebuild((_) {}) as Foo; // ignore: unused_result
+    var copy1 =
+        foo.deepCopy().freeze().rebuild((_) {}) as Foo; // ignore: unused_result
     expectOneofNotSet(copy1);
     foo.first = 'oneof';
     expectFirstSet(foo);
     // `ignore` below to work around https://github.com/dart-lang/sdk/issues/48879
-    var copy2 = foo.deepCopy().freeze().rebuild((_) {}) as Foo; // ignore: unused_result
+    var copy2 =
+        foo.deepCopy().freeze().rebuild((_) {}) as Foo; // ignore: unused_result
     expectFirstSet(copy2);
   });
 

--- a/protoc_plugin/test/oneof_test.dart
+++ b/protoc_plugin/test/oneof_test.dart
@@ -161,11 +161,13 @@ void main() {
   test('copyWith preserves oneof state', () {
     var foo = Foo();
     expectOneofNotSet(foo);
-    var copy1 = foo.deepCopy().freeze().rebuild((_) {}) as Foo;
+    // `ignore` below to work around https://github.com/dart-lang/sdk/issues/48879
+    var copy1 = foo.deepCopy().freeze().rebuild((_) {}) as Foo; // ignore: unused_result
     expectOneofNotSet(copy1);
     foo.first = 'oneof';
     expectFirstSet(foo);
-    var copy2 = foo.deepCopy().freeze().rebuild((_) {}) as Foo;
+    // `ignore` below to work around https://github.com/dart-lang/sdk/issues/48879
+    var copy2 = foo.deepCopy().freeze().rebuild((_) {}) as Foo; // ignore: unused_result
     expectFirstSet(copy2);
   });
 


### PR DESCRIPTION
This catches issues like #630 where we forgot to use return value of
`rebuild`. Since `rebuild` does not update in-place, not using the
return value is often a bug.

This adds `meta` as a dependency but it should not affect generated
code. We may also want to use `meta` in the future for things like:

- Annotating `GeneratedMessage` methods that are supposed to be used by
  the generated code with `@protected`.

- Annotating generated message classes with `@sealed`. This help with
  maintaining backwards compatibility when adding new members to
  generated messages or to `GeneratedMessage`.