### PR TITLE
Remove unused `GeneratedMessage` constructors

### DIFF
--- a/protobuf/lib/meta.dart
+++ b/protobuf/lib/meta.dart
@@ -26,8 +26,6 @@ const GeneratedMessage_reservedNames = <String>[
   'eventPlugin',
   'extensionsAreInitialized',
   'freeze',
-  'fromBuffer',
-  'fromJson',
   'getDefaultForField',
   'getExtension',
   'getField',

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -29,19 +29,6 @@ abstract class GeneratedMessage {
     if (eventPlugin != null) eventPlugin!.attach(this);
   }
 
-  GeneratedMessage.fromBuffer(
-      List<int> input, ExtensionRegistry extensionRegistry) {
-    __fieldSet = _FieldSet(this, info_, eventPlugin);
-    if (eventPlugin != null) eventPlugin!.attach(this);
-    mergeFromBuffer(input, extensionRegistry);
-  }
-
-  GeneratedMessage.fromJson(String input, ExtensionRegistry extensionRegistry) {
-    __fieldSet = _FieldSet(this, info_, eventPlugin);
-    if (eventPlugin != null) eventPlugin!.attach(this);
-    mergeFromJson(input, extensionRegistry);
-  }
-
   // Overridden by subclasses.
   BuilderInfo get info_;
 


### PR DESCRIPTION
`fromBuffer` and `fromJson` constructors can only be called in
`GeneratedMessage` subclasses, and we stopped calling them in #253
(merged as 481380e). They're now unused and unusable so it's safe to
remove them.