### PR TITLE
Revert changes to reserved names to maintain backwards compat

### DIFF
--- a/protobuf/lib/meta.dart
+++ b/protobuf/lib/meta.dart
@@ -80,6 +80,12 @@ const GeneratedMessage_reservedNames = <String>[
   r'$_setString',
   r'$_setUnsignedInt32',
   r'$_whichOneof',
+
+  // Names below are no longer reserved and should be removed in the next major
+  // release
+  'fromBuffer',
+  'fromJson',
+  r'$_defaultFor',
 ];
 
 // List of names which cannot be used in a subclass of ProtobufEnum.
@@ -90,5 +96,9 @@ const ProtobufEnum_reservedNames = <String>[
   'hashCode',
   'noSuchMethod',
   'runtimeType',
-  'toString'
+  'toString',
+
+  // Names below are no longer reserved and should be removed in the next major
+  // release
+  'initByValue',
 ];

--- a/protoc_plugin/test/generated_message_test.dart
+++ b/protoc_plugin/test/generated_message_test.dart
@@ -468,6 +468,8 @@ void main() {
     message.noSuchMethod_2 = 1;
     message.runtimeType_3 = 1;
     message.toString_4 = 1;
+    message.fromBuffer_10 = 1;
+    message.fromJson_11 = 1;
     message.hasRequiredFields_12 = 1;
     message.isInitialized_13 = 1;
     message.clear_14 = 1;
@@ -505,6 +507,8 @@ void main() {
     message.noSuchMethod_2.clear();
     message.runtimeType_3.clear();
     message.toString_4.clear();
+    message.fromBuffer_10.clear();
+    message.fromJson_11.clear();
     message.hasRequiredFields_12.clear();
     message.isInitialized_13.clear();
     message.clear_14.clear();
@@ -546,6 +550,8 @@ void main() {
     message.noSuchMethod_2 = 1;
     message.runtimeType_3 = 1;
     message.toString_4 = 1;
+    message.fromBuffer_10 = 1;
+    message.fromJson_11 = 1;
     message.hasRequiredFields_12 = 1;
     message.isInitialized_13 = 1;
     message.clear_14 = 1;

--- a/protoc_plugin/test/reserved_names_test.dart
+++ b/protoc_plugin/test/reserved_names_test.dart
@@ -22,11 +22,26 @@ import 'package:test/test.dart';
 
 import 'mirror_util.dart' show findMemberNames;
 
+// These names are no longer reserved but we keep them in
+// `GeneratedMessage_reservedNames` to keep generated code backwards
+// compatible. Remove in next major release.
+const List<String> oldGeneratedMessageReservedNames = [
+  'fromBuffer',
+  'fromJson',
+  r'$_defaultFor',
+];
+
+// These names are no longer reserved but we keep them in
+// `ProtobufEnum_reservedNames` to keep generated code backwards compatible.
+// Remove in next major release.
+const List<String> oldProtobufEnumReservedNames = ['initByValue'];
+
 void main() {
   test('GeneratedMessage reserved names are up to date', () {
     var actual = Set<String>.from(GeneratedMessage_reservedNames);
     var expected =
-        findMemberNames('package:protobuf/protobuf.dart', #GeneratedMessage);
+        findMemberNames('package:protobuf/protobuf.dart', #GeneratedMessage)
+          ..addAll(oldGeneratedMessageReservedNames);
 
     expect(actual.toList()..sort(), equals(expected.toList()..sort()));
   });
@@ -34,7 +49,8 @@ void main() {
   test('ProtobufEnum reserved names are up to date', () {
     var actual = Set<String>.from(ProtobufEnum_reservedNames);
     var expected =
-        findMemberNames('package:protobuf/protobuf.dart', #ProtobufEnum);
+        findMemberNames('package:protobuf/protobuf.dart', #ProtobufEnum)
+          ..addAll(oldProtobufEnumReservedNames);
 
     expect(actual.toList()..sort(), equals(expected.toList()..sort()));
   });


### PR DESCRIPTION
146b186 and b96dc21 removed some of the reserved names. Removing a
reserved name is a breaking change as a reserved field name would
previously be added a suffix. To avoid keep things backwards compatible
this adds those reserved names back, to be removed in the next major
release.

---

I will open an issue to make sure we remove these in the next major release.