### PR TITLE
Treat empty and uninitialized Maps the same in equality checks

### DIFF
--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -636,6 +636,11 @@ class _FieldSet {
     // We don't want reading a field to change equality comparisons.
     if (val is List && val.isEmpty) return true;
 
+    // An empty map field is the same as uninitialized.
+    // This is because accessing a map field automatically creates it.
+    // We don't want reading a field to change equality comparisons.
+    if (val is Map && val.isEmpty) return true;
+
     // For now, initialized and uninitialized fields are different.
     // TODO(skybrian) consider other cases; should we compare with the
     // default value or not?
@@ -691,6 +696,10 @@ class _FieldSet {
   static int _hashField(int hash, FieldInfo fi, value) {
     if (value is List && value.isEmpty) {
       return hash; // It's either repeated or an empty byte array.
+    }
+
+    if (value is Map && value.isEmpty) {
+      return hash;
     }
 
     hash = _HashUtils._combine(hash, fi.tagNumber);

--- a/protoc_plugin/test/map_field_test.dart
+++ b/protoc_plugin/test/map_field_test.dart
@@ -301,7 +301,7 @@ void main() {
     expect(value is Map<int, List<int>>, true);
   });
 
-  test('named optional arguments in cosntructor', () {
+  test('named optional arguments in constructor', () {
     final testMap = TestMap(
       int32ToInt32Field: {1: 11, 2: 22, 3: 33},
       int32ToStringField: {1: '11', 2: '22', 3: '33'},
@@ -345,5 +345,15 @@ void main() {
     expect(m.stringToInt32Field['abc'], 0);
     expect(m.stringToInt32Field[''], 11);
     expect(m.stringToInt32Field['def'], 42);
+  });
+
+  test('Map field reads should not affect equality or hash of message', () {
+    final m1 = TestMap.create();
+    final m2 = TestMap.create();
+    expect(m1, equals(m2));
+    expect(m1.hashCode, equals(m2.hashCode));
+    m1.int32ToStringField; // read a map field
+    expect(m1, equals(m2));
+    expect(m1.hashCode, equals(m2.hashCode));
   });
 }


### PR DESCRIPTION
Treat an empty Map the same as an uninitialized Map when performing equality
checks. This ensures that reading a map field does not alter the hashCode or
equality comparisons of the message itself.

-- 

Rebased version #591 with a regression test.