### PR TITLE
Fix compile-protos.sh interpreter

### DIFF
--- a/protobuf/benchmarks/compile-protos.sh
+++ b/protobuf/benchmarks/compile-protos.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.


### PR DESCRIPTION
This script is not sh and it fails to run under some OSes:

     $ ./compile-protos.sh
     ./compile-protos.sh: 8: Syntax error: "(" unexpected

Using bash as the interpreter fixes the problem.