### PR TITLE
Convert the field started with underscore and digit to a legal name

### DIFF
--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -420,7 +420,8 @@ FieldNames _unusedMemberNames(FieldDescriptorProto field, int? index,
       _memberNamesSuffix(field.number),
       generateVariants: generateNameVariants);
 
-  return FieldNames(field, index, sourcePosition, _defaultFieldName(name),
+  return FieldNames(field, index, sourcePosition,
+      avoidInitialUnderscore(_defaultFieldName(name)),
       hasMethodName: _defaultHasMethodName(name),
       clearMethodName: _defaultClearMethodName(name),
       ensureMethodName:

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -32,8 +32,8 @@ void main() {
 
   test('Can access a filed started with underscore and digit', () {
     var msg = pb.UnderscoreDigitName();
-    msg.x3d = "one";
-    expect(msg.getField(1), "one");
+    msg.x3d = 'one';
+    expect(msg.getField(1), 'one');
   });
 
   test('Can swap field names using dart_name option', () {

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -30,6 +30,12 @@ void main() {
     expect(msg.hasRenamedField(), false);
   });
 
+  test('Can access a filed started with underscore and digit', () {
+    var msg = pb.UnderscoreDigitName();
+    msg.x3d = "one";
+    expect(msg.getField(1), "one");
+  });
+
   test('Can swap field names using dart_name option', () {
     var msg = pb.SwapNames();
     msg.first = 'one';

--- a/protoc_plugin/test/protos/dart_name.proto
+++ b/protoc_plugin/test/protos/dart_name.proto
@@ -37,3 +37,7 @@ message Function {
 message Function_ {
   optional string fun1 = 1;
 }
+
+message UnderscoreDigitName {
+  optional string _3d = 1;
+}


### PR DESCRIPTION
In proto, it is allowed to name a field started with underscore and
digit like `_3d`. But it's illegal in Dart. Convert the field name when
generating code.

Port of cl/411592880