### PR TITLE
Remove invalid check in `_FieldSet.writeFieldValue`

### DIFF
--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -726,11 +726,7 @@ class _FieldSet {
 
     void writeFieldValue(fieldValue, String name) {
       if (fieldValue == null) return;
-      if (fieldValue is ByteData) {
-        // TODO(skybrian): possibly unused. Delete?
-        final value = fieldValue.getUint64(0, Endian.little);
-        renderValue(name, value);
-      } else if (fieldValue is PbListBase) {
+      if (fieldValue is PbListBase) {
         for (var value in fieldValue) {
           renderValue(name, value);
         }

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -167,10 +167,6 @@ class UnknownFieldSet {
             ..write(value._toString('$indent  '))
             ..write('$indent}\n');
         } else {
-          if (value is ByteData) {
-            // TODO(antonm): fix for longs.
-            value = value.getUint64(0, Endian.little);
-          }
           stringBuffer.write('$indent$tag: $value\n');
         }
       }

--- a/protobuf/lib/src/protobuf/utils.dart
+++ b/protobuf/lib/src/protobuf/utils.dart
@@ -11,9 +11,6 @@ bool _deepEquals(lhs, rhs) {
   if (rhs is GeneratedMessage) return false;
   if ((lhs is List) && (rhs is List)) return _areListsEqual(lhs, rhs);
   if ((lhs is Map) && (rhs is Map)) return _areMapsEqual(lhs, rhs);
-  if ((lhs is ByteData) && (rhs is ByteData)) {
-    return _areByteDataEqual(lhs, rhs);
-  }
   return lhs == rhs;
 }
 
@@ -28,12 +25,6 @@ bool _areListsEqual(List lhs, List rhs) {
 bool _areMapsEqual(Map lhs, Map rhs) {
   if (lhs.length != rhs.length) return false;
   return lhs.keys.every((key) => _deepEquals(lhs[key], rhs[key]));
-}
-
-bool _areByteDataEqual(ByteData lhs, ByteData rhs) {
-  Uint8List asBytes(d) =>
-      Uint8List.view(d.buffer, d.offsetInBytes, d.lengthInBytes);
-  return _areListsEqual(asBytes(lhs), asBytes(rhs));
 }
 
 @Deprecated('This function was not intended to be public. '


### PR DESCRIPTION
A field value is one of these:

- PbListBase (for `repeated`, PbList after #626)
- PbMap
- int
- double
- bool
- String
- List<int> (for `bytes`)
- GeneratedMessage

`ByteData` is not a valid field value type, so remove the `ByteData`
cases when checking field value types.