### PR TITLE
Refactor protobuf bench runners, update README:

### DIFF
--- a/protobuf/benchmarks/README.md
+++ b/protobuf/benchmarks/README.md
@@ -9,12 +9,13 @@ JSON formats, and hash code generation for messages.
 ## Prerequisites
 
 Before running benchmarks you first need to compile all involved protos, which
-requires installing `protoc` and [dart-protoc-plugin](../../protoc_plugin).
+requires installing `protoc` and [protoc_plugin](../../protoc_plugin).
 
 ```console
 $ ./compile-protos.sh
-# This would produce temp folder with output of protoc.
 ```
+
+This produces temp folder with output of protoc.
 
 ## Running benchmarks on the VM
 

--- a/protobuf/benchmarks/README.md
+++ b/protobuf/benchmarks/README.md
@@ -8,25 +8,31 @@ JSON formats, and hash code generation for messages.
 
 ## Prerequisites
 
-Before running benchmarks you first need to compile all involved
-protos, which requires installing `protoc` and
-[dart-protoc-plugin](https://github.com/dart-lang/dart-protoc-plugin).
+Before running benchmarks you first need to compile all involved protos, which
+requires installing `protoc` and [dart-protoc-plugin](../../protoc_plugin).
 
 ```console
-$ cd benchmarks
 $ ./compile-protos.sh
-# This would produce benchmarks/temp folder with output of protoc.
+# This would produce temp folder with output of protoc.
 ```
 
 ## Running benchmarks on the VM
 
+In `benchmarks/` directory:
+
 ```
-$ dart benchmarks/benchmark_vm.dart
+$ dart benchmark_vm.dart
 ```
 
 ## Running benchmarks via JavaScript (D8)
 
+In `benchmarks/` directory:
+
 ```
-$ benchmarks/compile-js.sh
-$ d8 $DART_SDK/lib/_internal/js_runtime/lib/preambles/d8.js benchmarks/temp/benchmark.js
+$ ./compile-js.sh
+$ d8 $DART_SDK/lib/_internal/js_runtime/lib/preambles/d8.js temp/benchmark.js
 ```
+
+Note: if you are seeing a "Error reading file" error while running the JS
+benchmarks it means that you are in the wrong directory. Run the `d8` command
+shown above in `benchmarks/` directory.

--- a/protobuf/benchmarks/benchmark_js.dart
+++ b/protobuf/benchmarks/benchmark_js.dart
@@ -11,14 +11,8 @@ library benchmark_js;
 import 'common.dart';
 import 'd8.dart';
 
-final files = [
-  'benchmarks/datasets/google_message1/proto3/dataset.google_message1_proto3.pb',
-  'benchmarks/datasets/google_message1/proto2/dataset.google_message1_proto2.pb',
-  'benchmarks/datasets/google_message2/dataset.google_message2.pb'
-];
-
 void main(List<String> arguments) {
-  final datasets = files
+  final datasets = datasetFiles
       .map((file) => Dataset.fromBinary(readAsBytesSync(file)))
       .toList(growable: false);
 

--- a/protobuf/benchmarks/benchmark_vm.dart
+++ b/protobuf/benchmarks/benchmark_vm.dart
@@ -13,11 +13,8 @@ import 'dart:io';
 import 'common.dart';
 
 void main(List<String> arguments) {
-  final datasetPattern = RegExp(r'dataset\.[._\w]*\.pb$');
-  final datasets = Directory(Platform.script.resolve('..').toFilePath())
-      .listSync(recursive: true)
-      .where((file) => datasetPattern.hasMatch(file.path))
-      .map((file) => Dataset.fromBinary((file as File).readAsBytesSync()))
+  final datasets = datasetFiles
+      .map((file) => Dataset.fromBinary(File(file).readAsBytesSync()))
       .toList(growable: false);
 
   FromBinaryBenchmark(datasets).report();

--- a/protobuf/benchmarks/common.dart
+++ b/protobuf/benchmarks/common.dart
@@ -22,6 +22,12 @@ import 'temp/datasets/google_message2/benchmark_message2.pb.dart';
 import 'temp/datasets/google_message3/benchmark_message3.pb.dart';
 import 'temp/datasets/google_message4/benchmark_message4.pb.dart';
 
+final datasetFiles = [
+  'datasets/google_message1/proto3/dataset.google_message1_proto3.pb',
+  'datasets/google_message1/proto2/dataset.google_message1_proto2.pb',
+  'datasets/google_message2/dataset.google_message2.pb'
+];
+
 /// Represents a dataset, a list of protobufs payloads, used for benchmarking.
 /// All payloads are instances of the same message.
 /// Datasets are loaded from BenchmarkDataset proto (see benchmark.proto).


### PR DESCRIPTION
- Use the same set of files in all versions of the benchmark runners.

  Previously the native version was searching for dataset files, JS
  version had hard-coded file paths. It's unclear whether these both run
  the same set of files, so we now have dataset file paths in the common
  library and use the same file list in all versions.

- Update link to protoc_plugin in README

- Update commands in the README to allow running them in `benchmarks/`
  directory.

  Since the README is in `benchmarks/` it makes sense for it to show
  commands to be run in the same directory.

- Add a note in README about the "Error reading file" errors when
  running the JS benchmarks. d8's `readbuffer` doesn't show the path of
  the file it's trying to read, so clarify that in README.