### PR TITLE
Benchmarks: add proto3 ser/deser benchs, move common code to common.dart

### DIFF
--- a/protobuf/benchmarks/benchmark_js.dart
+++ b/protobuf/benchmarks/benchmark_js.dart
@@ -17,14 +17,10 @@ final files = [
   'benchmarks/datasets/google_message2/dataset.google_message2.pb'
 ];
 
-void main(List<String> arguments) {
+void main() {
   final datasets = files
       .map((file) => Dataset.fromBinary(readAsBytesSync(file)))
       .toList(growable: false);
 
-  FromBinaryBenchmark(datasets).report();
-  ToBinaryBenchmark(datasets).report();
-  ToJsonBenchmark(datasets).report();
-  FromJsonBenchmark(datasets).report();
-  HashCodeBenchmark(datasets).report();
+  run(datasets);
 }

--- a/protobuf/benchmarks/benchmark_vm.dart
+++ b/protobuf/benchmarks/benchmark_vm.dart
@@ -12,7 +12,7 @@ import 'dart:io';
 
 import 'common.dart';
 
-void main(List<String> arguments) {
+void main() {
   final datasetPattern = RegExp(r'dataset\.[._\w]*\.pb$');
   final datasets = Directory(Platform.script.resolve('..').toFilePath())
       .listSync(recursive: true)
@@ -20,9 +20,5 @@ void main(List<String> arguments) {
       .map((file) => Dataset.fromBinary((file as File).readAsBytesSync()))
       .toList(growable: false);
 
-  FromBinaryBenchmark(datasets).report();
-  ToBinaryBenchmark(datasets).report();
-  ToJsonBenchmark(datasets).report();
-  FromJsonBenchmark(datasets).report();
-  HashCodeBenchmark(datasets).report();
+  run(datasets);
 }

--- a/protobuf/benchmarks/common.dart
+++ b/protobuf/benchmarks/common.dart
@@ -145,10 +145,9 @@ class ToBinaryBenchmark extends _ProtobufBenchmark {
 
   @override
   void run() {
-    for (var i = 0; i < datasets.length; i++) {
-      final ds = datasets[i];
-      for (var j = 0; j < ds.unpacked.length; j++) {
-        ds.unpacked[j].writeToBuffer();
+    for (final ds in datasets) {
+      for (final unpacked in ds.unpacked) {
+        unpacked.writeToBuffer();
       }
     }
   }
@@ -160,11 +159,10 @@ class FromJsonBenchmark extends _ProtobufBenchmark {
 
   @override
   void run() {
-    for (var i = 0; i < datasets.length; i++) {
-      final ds = datasets[i];
+    for (final ds in datasets) {
       final f = ds.factories.fromJson;
-      for (var j = 0; j < ds.asJson.length; j++) {
-        f(ds.asJson[j]);
+      for (final jsonStr in ds.asJson) {
+        f(jsonStr);
       }
     }
   }
@@ -176,10 +174,9 @@ class ToJsonBenchmark extends _ProtobufBenchmark {
 
   @override
   void run() {
-    for (var i = 0; i < datasets.length; i++) {
-      final ds = datasets[i];
-      for (var j = 0; j < ds.unpacked.length; j++) {
-        ds.unpacked[j].writeToJson();
+    for (final ds in datasets) {
+      for (final unpacked in ds.unpacked) {
+        unpacked.writeToJson();
       }
     }
   }
@@ -191,11 +188,10 @@ class FromProto3JsonBenchmark extends _ProtobufBenchmark {
 
   @override
   void run() {
-    for (var i = 0; i < datasets.length; i++) {
-      final ds = datasets[i];
+    for (final ds in datasets) {
       final f = ds.factories.fromProto3Json;
-      for (var j = 0; j < ds.asProto3Json.length; j++) {
-        f(ds.asProto3Json[j]);
+      for (final jsonStr in ds.asProto3Json) {
+        f(jsonStr);
       }
     }
   }
@@ -207,10 +203,9 @@ class ToProto3JsonBenchmark extends _ProtobufBenchmark {
 
   @override
   void run() {
-    for (var i = 0; i < datasets.length; i++) {
-      final ds = datasets[i];
-      for (var j = 0; j < ds.unpacked.length; j++) {
-        jsonEncode(ds.unpacked[j].toProto3Json());
+    for (final ds in datasets) {
+      for (final unpacked in ds.unpacked) {
+        jsonEncode(unpacked.toProto3Json());
       }
     }
   }


### PR DESCRIPTION
- Add benchmarks for proto3 JSON string and object generation and parsing

- Use for-in loops instead of indices in benchmark code

- Move benchmark entry point to `common.dart`, reuse in JS and VM benchmark
  programs