### PR TITLE
[WIP] Avoid intermediate values when serializing proto3 JSON

### DIFF
--- a/protobuf/lib/protobuf.dart
+++ b/protobuf/lib/protobuf.dart
@@ -11,6 +11,7 @@ import 'dart:math' as math;
 import 'dart:typed_data' show TypedData, Uint8List, ByteData, Endian;
 
 import 'package:fixnum/fixnum.dart' show Int64;
+import 'package:jsontool/jsontool.dart';
 import 'package:meta/meta.dart' show UseResult;
 
 import 'src/protobuf/json_parsing_context.dart';
@@ -39,6 +40,7 @@ part 'src/protobuf/pb_list.dart';
 part 'src/protobuf/pb_map.dart';
 part 'src/protobuf/protobuf_enum.dart';
 part 'src/protobuf/proto3_json.dart';
+part 'src/protobuf/proto3_json_string.dart';
 part 'src/protobuf/readonly_message.dart';
 part 'src/protobuf/rpc_client.dart';
 part 'src/protobuf/unknown_field_set.dart';

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -223,6 +223,13 @@ abstract class GeneratedMessage {
           {TypeRegistry typeRegistry = const TypeRegistry.empty()}) =>
       _writeToProto3Json(_fieldSet, typeRegistry);
 
+  String toProto3JsonString(
+      {TypeRegistry typeRegistry = const TypeRegistry.empty()}) {
+    StringBuffer buf = StringBuffer();
+    _writeToProto3JsonSink(_fieldSet, typeRegistry, buf);
+    return buf.toString();
+  }
+
   /// Merges field values from [json], a JSON object using proto3 encoding.
   ///
   /// Well-known types and their special JSON encoding are supported.

--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -93,7 +93,8 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
     dynamic jsonValue;
     if (fieldInfo.isMapField) {
       jsonValue = (value as PbMap).map((key, entryValue) {
-        var mapEntryInfo = fieldInfo as MapFieldInfo;
+        var mapEntryInfo =
+            fieldInfo as MapFieldInfo; // TODO: move this outside of closure
         return MapEntry(convertToMapKey(key, mapEntryInfo.keyFieldType),
             valueToProto3Json(entryValue, mapEntryInfo.valueFieldType));
       });

--- a/protobuf/lib/src/protobuf/proto3_json_string.dart
+++ b/protobuf/lib/src/protobuf/proto3_json_string.dart
@@ -1,0 +1,141 @@
+part of protobuf;
+
+void _writeToProto3JsonSink<S extends StringSink>(
+    _FieldSet fs, TypeRegistry typeRegistry, S sink) {
+
+  // TODO: Either add `writeToProto3JsonSink` for well-known types, or fall
+  // back to slow proto3 JSON serialization
+  if (fs._meta.toProto3Json != null) {
+    throw 'well-known type detected';
+  }
+
+  final JsonWriter<String> jsonWriter = jsonStringWriter(sink, indent: null);
+  _writeToProto3JsonWriter(fs, typeRegistry, jsonWriter);
+}
+
+void _writeToProto3JsonWriter(
+    _FieldSet fs, TypeRegistry typeRegistry, JsonWriter<String> jsonWriter) {
+  jsonWriter.startObject(); // start message
+
+  for (FieldInfo fieldInfo in fs._infosSortedByTag) {
+    var value = fs._values[fieldInfo.index!];
+
+    if (value == null || (value is List && value.isEmpty)) {
+      continue; // It's missing, repeated, or an empty byte array.
+    }
+
+    jsonWriter.addKey(fieldInfo.name);
+
+    if (fieldInfo.isMapField) {
+      jsonWriter.startObject(); // start map field
+      final MapFieldInfo mapEntryInfo = fieldInfo as MapFieldInfo;
+      for (MapEntry entry in (value as PbMap).entries) {
+        final key = entry.key;
+        final value = entry.value;
+        _writeMapKey(key, mapEntryInfo.keyFieldType, jsonWriter);
+        _writeFieldValue(
+            value, mapEntryInfo.valueFieldType, jsonWriter, typeRegistry);
+      }
+      jsonWriter.endObject(); // end map field
+    } else if (fieldInfo.isRepeated) {
+      jsonWriter.startArray(); // start repeated field
+      for (final element in value as PbListBase) {
+        _writeFieldValue(element, fieldInfo.type, jsonWriter, typeRegistry);
+      }
+      jsonWriter.endArray(); // end repeated field
+    } else {
+      _writeFieldValue(value, fieldInfo.type, jsonWriter, typeRegistry);
+    }
+  }
+
+  jsonWriter.endObject(); // end message
+}
+
+void _writeMapKey(dynamic key, int keyType, JsonWriter<String> jsonWriter) {
+  var baseType = PbFieldType._baseType(keyType);
+
+  assert(!_isRepeated(keyType));
+
+  switch (baseType) {
+    case PbFieldType._BOOL_BIT:
+      jsonWriter.addBool(key as bool);
+      break;
+    case PbFieldType._STRING_BIT:
+      jsonWriter.addString(key as String);
+      break;
+    case PbFieldType._UINT64_BIT:
+      jsonWriter.addString((key as Int64).toStringUnsigned());
+      break;
+    case PbFieldType._INT32_BIT:
+    case PbFieldType._SINT32_BIT:
+    case PbFieldType._UINT32_BIT:
+    case PbFieldType._FIXED32_BIT:
+    case PbFieldType._SFIXED32_BIT:
+    case PbFieldType._INT64_BIT:
+    case PbFieldType._SINT64_BIT:
+    case PbFieldType._SFIXED64_BIT:
+    case PbFieldType._FIXED64_BIT:
+      jsonWriter.addString(key.toString());
+      break;
+    default:
+      throw StateError('Not a valid key type $keyType');
+  }
+}
+
+void _writeFieldValue(dynamic fieldValue, int fieldType,
+    JsonWriter<String> jsonWriter, TypeRegistry typeRegistry) {
+  if (fieldValue == null) {
+    jsonWriter.addNull();
+    return;
+  }
+
+  if (_isGroupOrMessage(fieldType)) {
+    _writeToProto3JsonWriter(
+        (fieldValue as GeneratedMessage)._fieldSet, typeRegistry, jsonWriter);
+  } else if (_isEnum(fieldType)) {
+    jsonWriter.addString((fieldValue as ProtobufEnum).name);
+  } else {
+    final baseType = PbFieldType._baseType(fieldType);
+    switch (baseType) {
+      case PbFieldType._BOOL_BIT:
+        jsonWriter.addBool(fieldValue);
+        break;
+      case PbFieldType._STRING_BIT:
+        jsonWriter.addString(fieldValue);
+        break;
+      case PbFieldType._INT32_BIT:
+      case PbFieldType._SINT32_BIT:
+      case PbFieldType._UINT32_BIT:
+      case PbFieldType._FIXED32_BIT:
+      case PbFieldType._SFIXED32_BIT:
+        jsonWriter.addNumber(fieldValue);
+        break;
+      case PbFieldType._INT64_BIT:
+      case PbFieldType._SINT64_BIT:
+      case PbFieldType._SFIXED64_BIT:
+      case PbFieldType._FIXED64_BIT:
+        jsonWriter.addString(fieldValue.toString());
+        break;
+      case PbFieldType._FLOAT_BIT:
+      case PbFieldType._DOUBLE_BIT:
+        double value = fieldValue;
+        if (value.isNaN) {
+          jsonWriter.addString(nan);
+        } else if (value.isInfinite) {
+          jsonWriter.addString(value.isNegative ? negativeInfinity : infinity);
+        } else {
+          jsonWriter.addNumber(value);
+        }
+        break;
+      case PbFieldType._UINT64_BIT:
+        jsonWriter.addString((fieldValue as Int64).toStringUnsigned());
+        break;
+      case PbFieldType._BYTES_BIT:
+        jsonWriter.addString(base64Encode(fieldValue));
+        break;
+      default:
+        throw StateError(
+            'Invariant violation: unexpected value type $fieldType');
+    }
+  }
+}

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -9,8 +9,9 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  fixnum: ^1.0.0
   collection: ^1.15.0
+  fixnum: ^1.0.0
+  jsontool: ^1.1.0
   meta: ^1.7.0
 
 dev_dependencies:


### PR DESCRIPTION
This uses jsontool library to avoid allocating intermediate values when
generating proto3 JSON strings.

Note that the code is not tested for correctness yet, and well-known
types are not supported.

AOT results:

Before:

    ToProto3JsonString(RunTime): 40474.54 us.
    ToProto3JsonString(RunTime): 40340.84 us.
    ToProto3JsonString(RunTime): 40403.9 us.

After:

    ToProto3JsonString(RunTime): 26978.906666666666 us.
    ToProto3JsonString(RunTime): 26891.893333333333 us.
    ToProto3JsonString(RunTime): 26945.04 us.

Diff: -33%

JS results:

Before:

    ToProto3JsonString(RunTime): 71551.72413793103 us.
    ToProto3JsonString(RunTime): 72103.44827586207 us.
    ToProto3JsonString(RunTime): 72035.71428571429 us.

After:

    ToProto3JsonString(RunTime): 45422.22222222222 us.
    ToProto3JsonString(RunTime): 45266.666666666664 us.
    ToProto3JsonString(RunTime): 46813.95348837209 us.

Diff: -36%

---

cc @rakudrama 