### PR TITLE
New release: 20.1.0

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 2.0.2-dev
+## 20.1.0
+
+Starting with this release `protoc_plugin` and `protobuf` versions will be in
+sync. Please make sure to use the same versions of `protoc_plugin` and
+`protobuf`.
+
+This release is backwards compatible with `protobuf-2.0.1`. Major version was
+bumped to make it in sync with `protoc_plugin` version number.
 
 * Update READMEs of `protobuf` and `protoc_plugin`:
   * Use `dart pub` instead of `pub` in command examples ([a7e75cb])

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 2.0.2-dev
+version: 20.1.0
 description: >-
   Runtime library for protocol buffers support.
   Use https://pub.dev/packages/protoc_plugin to generate dart code for your '.proto' files.

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 20.1.0
+
+Starting with this release `protoc_plugin` and `protobuf` versions will be in
+sync. Please make sure to use the same versions of `protoc_plugin` and
+`protobuf`.
+
+Further changelog entries will only be added to `protobuf` changelog.
+
 ## 20.0.0
 
 * Stable release generating null-safe code.

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 20.0.1-dev
+version: 20.1.0
 description: Protoc compiler plugin to generate Dart code
 repository: https://github.com/google/protobuf.dart/tree/master/protoc_plugin
 


### PR DESCRIPTION
Update CHANGELOGs and bump version numbers for the new version.

CHANGELOGs describe the new release policy: plugin and library will have the
same version numbers and users should make sure to use the same versions of the
library and the plugin. This simplifies things for both maintainers and users.

This release is backwards compatible with the current releases of the plugin
and the library, but to sync the version numbers a major bump was required for
protobuf. For protoc_plugin we bump the minor version.

The merge commit will be tagged as `protobuf-20.1.0` and released on pub.dev.

---

Ping @sigurdm @devoncarew @kevmoo @natebosch @mraleph 