### PR TITLE
Release protobuf-2.1.0, protoc_plugin-20.0.1

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.2-dev
+## 2.1.0
 
 * Update READMEs of `protobuf` and `protoc_plugin`:
   * Use `dart pub` instead of `pub` in command examples ([a7e75cb])
@@ -24,8 +24,6 @@
   ([#640])
 * `GeneratedMessage.rebuild` now generates a warning when the return value is
   not used. ([#631])
-* Fix proto3 repeated field encoding without the `packed` option ([#345],
-  [#635])
 * Fix hash code of messages with empty unknown field set ([#648])
 * Show field tags with `protobuf.omit_field_names`, enum value tags with
   `protobuf.omit_enum_names` in debug strings (`toString` methods) ([#649])
@@ -57,8 +55,6 @@
 [#640]: https://github.com/google/protobuf.dart/pull/640
 [#641]: https://github.com/google/protobuf.dart/pull/641
 [#631]: https://github.com/google/protobuf.dart/pull/631
-[#345]: https://github.com/google/protobuf.dart/issues/345
-[#635]: https://github.com/google/protobuf.dart/pull/635
 [#648]: https://github.com/google/protobuf.dart/pull/648
 [#649]: https://github.com/google/protobuf.dart/pull/649
 [#653]: https://github.com/google/protobuf.dart/pull/653

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 2.0.2-dev
+version: 2.1.0
 description: >-
   Runtime library for protocol buffers support.
   Use https://pub.dev/packages/protoc_plugin to generate dart code for your '.proto' files.

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 20.0.1
+
+* Fix proto3 repeated field encoding without the `packed` option ([#345],
+  [#635])
+
+[#345]: https://github.com/google/protobuf.dart/issues/345
+[#635]: https://github.com/google/protobuf.dart/pull/635
+
 ## 20.0.0
 
 * Stable release generating null-safe code.

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 20.0.1-dev
+version: 20.0.1
 description: Protoc compiler plugin to generate Dart code
 repository: https://github.com/google/protobuf.dart/tree/master/protoc_plugin
 


### PR DESCRIPTION
Minor version of protobuf bumped as we add new backwards-compatible features (`TimestampMixin.toDateTime` takes a new optional argument).

Patch version of protoc_plugin bumped.

The merge commit will be tagged as `protobuf-21.0` and `protoc_plugin-20.0.1` and released on pub.dev.

---

Ping @sigurdm @devoncarew @kevmoo @natebosch @mraleph 