### PR TITLE
Remove redundant reserved names

### DIFF
--- a/protobuf/lib/meta.dart
+++ b/protobuf/lib/meta.dart
@@ -80,12 +80,6 @@ const GeneratedMessage_reservedNames = <String>[
   r'$_setString',
   r'$_setUnsignedInt32',
   r'$_whichOneof',
-
-  // Names below are no longer reserved and should be removed in the next major
-  // release
-  'fromBuffer',
-  'fromJson',
-  r'$_defaultFor',
 ];
 
 // List of names which cannot be used in a subclass of ProtobufEnum.
@@ -96,9 +90,5 @@ const ProtobufEnum_reservedNames = <String>[
   'hashCode',
   'noSuchMethod',
   'runtimeType',
-  'toString',
-
-  // Names below are no longer reserved and should be removed in the next major
-  // release
-  'initByValue',
+  'toString'
 ];

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 * Identifiers `fromBuffer`, `fromJson`, `$_defaultFor`, `initByValue` are no
   longer reserved. Proto fields with those Dart names will no longer have a
-  suffix added. [#xxx]
+  suffix added. ([#679])
+
+[#679]: https://github.com/google/protobuf.dart/pull/679
 
 ## 20.0.1
 

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 21.0.0
+
+* Identifiers `fromBuffer`, `fromJson`, `$_defaultFor`, `initByValue` are no
+  longer reserved. Proto fields with those Dart names will no longer have a
+  suffix added. [#xxx]
+
 ## 20.0.1
 
 * Fix proto3 repeated field encoding without the `packed` option ([#345],

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 20.0.1
+version: 21.0.0-dev
 description: Protoc compiler plugin to generate Dart code
 repository: https://github.com/google/protobuf.dart/tree/master/protoc_plugin
 

--- a/protoc_plugin/test/generated_message_test.dart
+++ b/protoc_plugin/test/generated_message_test.dart
@@ -468,8 +468,6 @@ void main() {
     message.noSuchMethod_2 = 1;
     message.runtimeType_3 = 1;
     message.toString_4 = 1;
-    message.fromBuffer_10 = 1;
-    message.fromJson_11 = 1;
     message.hasRequiredFields_12 = 1;
     message.isInitialized_13 = 1;
     message.clear_14 = 1;
@@ -507,8 +505,6 @@ void main() {
     message.noSuchMethod_2.clear();
     message.runtimeType_3.clear();
     message.toString_4.clear();
-    message.fromBuffer_10.clear();
-    message.fromJson_11.clear();
     message.hasRequiredFields_12.clear();
     message.isInitialized_13.clear();
     message.clear_14.clear();
@@ -550,8 +546,6 @@ void main() {
     message.noSuchMethod_2 = 1;
     message.runtimeType_3 = 1;
     message.toString_4 = 1;
-    message.fromBuffer_10 = 1;
-    message.fromJson_11 = 1;
     message.hasRequiredFields_12 = 1;
     message.isInitialized_13 = 1;
     message.clear_14 = 1;

--- a/protoc_plugin/test/protos/reserved_names.proto
+++ b/protoc_plugin/test/protos/reserved_names.proto
@@ -14,8 +14,6 @@ message ReservedNamesOptional {
   optional int32 to_string = 4;
 
   // Conflicts with GeneratedMessage.
-  optional int32 from_buffer = 10;
-  optional int32 from_json = 11;
   optional int32 has_required_fields = 12;
   optional int32 is_initialized = 13;
   optional int32 clear = 14;
@@ -60,8 +58,6 @@ message ReservedNamesRepeated {
   repeated int32 to_string = 4;
 
   // Conflicts with GeneratedMessage.
-  repeated int32 from_buffer = 10;
-  repeated int32 from_json = 11;
   repeated int32 has_required_fields = 12;
   repeated int32 is_initialized = 13;
   repeated int32 clear = 14;
@@ -106,8 +102,6 @@ message ReservedNamesRequired {
   required int32 to_string = 4;
 
   // Conflicts with GeneratedMessage.
-  required int32 from_buffer = 10;
-  required int32 from_json = 11;
   required int32 has_required_fields = 12;
   required int32 is_initialized = 13;
   required int32 clear = 14;

--- a/protoc_plugin/test/reserved_names_test.dart
+++ b/protoc_plugin/test/reserved_names_test.dart
@@ -22,26 +22,11 @@ import 'package:test/test.dart';
 
 import 'mirror_util.dart' show findMemberNames;
 
-// These names are no longer reserved but we keep them in
-// `GeneratedMessage_reservedNames` to keep generated code backwards
-// compatible. Remove in next major release.
-const List<String> oldGeneratedMessageReservedNames = [
-  'fromBuffer',
-  'fromJson',
-  r'$_defaultFor',
-];
-
-// These names are no longer reserved but we keep them in
-// `ProtobufEnum_reservedNames` to keep generated code backwards compatible.
-// Remove in next major release.
-const List<String> oldProtobufEnumReservedNames = ['initByValue'];
-
 void main() {
   test('GeneratedMessage reserved names are up to date', () {
     var actual = Set<String>.from(GeneratedMessage_reservedNames);
     var expected =
-        findMemberNames('package:protobuf/protobuf.dart', #GeneratedMessage)
-          ..addAll(oldGeneratedMessageReservedNames);
+        findMemberNames('package:protobuf/protobuf.dart', #GeneratedMessage);
 
     expect(actual.toList()..sort(), equals(expected.toList()..sort()));
   });
@@ -49,8 +34,7 @@ void main() {
   test('ProtobufEnum reserved names are up to date', () {
     var actual = Set<String>.from(ProtobufEnum_reservedNames);
     var expected =
-        findMemberNames('package:protobuf/protobuf.dart', #ProtobufEnum)
-          ..addAll(oldProtobufEnumReservedNames);
+        findMemberNames('package:protobuf/protobuf.dart', #ProtobufEnum);
 
     expect(actual.toList()..sort(), equals(expected.toList()..sort()));
   });


### PR DESCRIPTION
This reverts commit c35d787726173380348e744085d02d34d56d3ec1.

These reserved names are no longer reserved (see 146b186, b96dc21), but
we kept them to avoid breaking backwards compatibility.

Removing them now for the next major version bump.

Closes #637