### PR TITLE
Update lints

### DIFF
--- a/protobuf/analysis_options.yaml
+++ b/protobuf/analysis_options.yaml
@@ -4,6 +4,6 @@ linter:
   rules:
     - comment_references
     - directives_ordering
+    - omit_local_variable_types
     - prefer_relative_imports
     - prefer_single_quotes
-    - prefer_spread_collections

--- a/protoc_plugin/analysis_options.yaml
+++ b/protoc_plugin/analysis_options.yaml
@@ -8,8 +8,8 @@ linter:
   rules:
     - camel_case_types
     - comment_references
-    - control_flow_in_finally
     - directives_ordering
+    - omit_local_variable_types
     - prefer_relative_imports
     - prefer_single_quotes
     - throw_in_finally

--- a/protoc_plugin/test/extension_test.dart
+++ b/protoc_plugin/test/extension_test.dart
@@ -3,7 +3,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:typed_data';
 import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 
@@ -554,7 +553,7 @@ void main() {
     final m = TestAllExtensions()
       ..setExtension(
           Extend_unittest.outer, Outer()..inner = (Inner()..value = 'hello'));
-    final Uint8List b = m.writeToBuffer();
+    final b = m.writeToBuffer();
     final c = TestAllExtensions.fromBuffer(b);
     final d = r.reparseMessage(c);
     expect(m.hashCode, d.hashCode);

--- a/protoc_plugin/test/freeze_test.dart
+++ b/protoc_plugin/test/freeze_test.dart
@@ -9,7 +9,7 @@ import '../out/protos/nested_message.pb.dart';
 
 void main() {
   test('testFreezingNestedFields', () {
-    Top top = Top(
+    var top = Top(
       nestedMessageList: [Nested(a: 1)],
       nestedMessageMap: {1: Nested(a: 2)},
       nestedMessage: Nested(a: 3),

--- a/protoc_plugin/test/json_test.dart
+++ b/protoc_plugin/test/json_test.dart
@@ -131,29 +131,28 @@ void main() {
   group('testConvertDouble', () {
     test('WithDecimal', () {
       final json = '{"12":1.2}';
-      TestAllTypes proto = TestAllTypes()..optionalDouble = 1.2;
+      var proto = TestAllTypes()..optionalDouble = 1.2;
       expect(TestAllTypes.fromJson(json), proto);
       expect(proto.writeToJson(), json);
     });
 
     test('WholeNumber', () {
       final json = '{"12":5}';
-      TestAllTypes proto = TestAllTypes()..optionalDouble = 5.0;
+      var proto = TestAllTypes()..optionalDouble = 5.0;
       expect(TestAllTypes.fromJson(json), proto);
       expect(proto.writeToJson(), json);
     });
 
     test('Infinity', () {
       final json = '{"12":"Infinity"}';
-      TestAllTypes proto = TestAllTypes()..optionalDouble = double.infinity;
+      var proto = TestAllTypes()..optionalDouble = double.infinity;
       expect(TestAllTypes.fromJson(json), proto);
       expect(proto.writeToJson(), json);
     });
 
     test('NegativeInfinity', () {
       final json = '{"12":"-Infinity"}';
-      TestAllTypes proto = TestAllTypes()
-        ..optionalDouble = double.negativeInfinity;
+      var proto = TestAllTypes()..optionalDouble = double.negativeInfinity;
       expect(TestAllTypes.fromJson(json), proto);
       expect(proto.writeToJson(), json);
     });

--- a/protoc_plugin/test/message_generator_test.dart
+++ b/protoc_plugin/test/message_generator_test.dart
@@ -77,9 +77,8 @@ void main() {
     var options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
 
-    FileGenerator fg = FileGenerator(fd, options);
-    MessageGenerator mg =
-        MessageGenerator.topLevel(md, fg, {}, null, <String>{}, 0);
+    var fg = FileGenerator(fd, options);
+    var mg = MessageGenerator.topLevel(md, fg, {}, null, <String>{}, 0);
 
     var ctx = GenerationContext(options);
     mg.register(ctx);
@@ -102,9 +101,8 @@ void main() {
   test('testMetadataIndices', () {
     var options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
-    FileGenerator fg = FileGenerator(fd, options);
-    MessageGenerator mg =
-        MessageGenerator.topLevel(md, fg, {}, null, <String>{}, 0);
+    var fg = FileGenerator(fd, options);
+    var mg = MessageGenerator.topLevel(md, fg, {}, null, <String>{}, 0);
 
     var ctx = GenerationContext(options);
     mg.register(ctx);

--- a/protoc_plugin/test/proto3_json_test.dart
+++ b/protoc_plugin/test/proto3_json_test.dart
@@ -1248,29 +1248,28 @@ void main() {
   group('Convert Double', () {
     test('With Decimal', () {
       final json = {'optionalDouble': 1.2};
-      TestAllTypes proto = TestAllTypes()..optionalDouble = 1.2;
+      var proto = TestAllTypes()..optionalDouble = 1.2;
       expect(TestAllTypes()..mergeFromProto3Json(json), proto);
       expect(proto.toProto3Json(), json);
     });
 
     test('Whole Number', () {
       final json = {'optionalDouble': 5};
-      TestAllTypes proto = TestAllTypes()..optionalDouble = 5.0;
+      var proto = TestAllTypes()..optionalDouble = 5.0;
       expect(TestAllTypes()..mergeFromProto3Json(json), proto);
       expect(proto.toProto3Json(), json);
     });
 
     test('Infinity', () {
       final json = {'optionalDouble': 'Infinity'};
-      TestAllTypes proto = TestAllTypes()..optionalDouble = double.infinity;
+      var proto = TestAllTypes()..optionalDouble = double.infinity;
       expect(TestAllTypes()..mergeFromProto3Json(json), proto);
       expect(proto.toProto3Json(), json);
     });
 
     test('Negative Infinity', () {
       final json = {'optionalDouble': '-Infinity'};
-      TestAllTypes proto = TestAllTypes()
-        ..optionalDouble = double.negativeInfinity;
+      var proto = TestAllTypes()..optionalDouble = double.negativeInfinity;
       expect(TestAllTypes()..mergeFromProto3Json(json), proto);
       expect(proto.toProto3Json(), json);
     });


### PR DESCRIPTION
This updates the lints used in the library and plugin to make it easier
to keep the code in sync with the internal version.

The only change is we now enable `omit_local_variable_types`.

This lint was enabled before in 52544ea (and then disabled in 45e054a),
so most of the code, other than a few tests, already follow this lint.
So no changes needed except a few lines in tests.

Lints `control_flow_in_finally` and `prefer_spread_collections` are
removed as they're already in recommended lints and enabled.

---

@mit-mit @devoncarew @natebosch @lrhn 