### PR TITLE
proto3 JSON: Serialize integer floats and doubles as integers

### DIFF
--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -67,6 +67,9 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
           if (value.isInfinite) {
             return value.isNegative ? negativeInfinity : infinity;
           }
+          if (fieldValue.toInt() == fieldValue) {
+            return fieldValue.toInt();
+          }
           return value;
         case PbFieldType._UINT64_BIT:
           return (fieldValue as Int64).toStringUnsigned();

--- a/protoc_plugin/test/proto3_json_test.dart
+++ b/protoc_plugin/test/proto3_json_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:core' hide Duration;
+import 'dart:convert' show jsonEncode;
 
 import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart';
@@ -1257,6 +1258,7 @@ void main() {
       var proto = TestAllTypes()..optionalDouble = 5.0;
       expect(TestAllTypes()..mergeFromProto3Json(json), proto);
       expect(proto.toProto3Json(), json);
+      expect(jsonEncode(proto.toProto3Json()), '{"optionalDouble":5}');
     });
 
     test('Infinity', () {

--- a/protoc_plugin/test/proto3_json_test.dart
+++ b/protoc_plugin/test/proto3_json_test.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:core' hide Duration;
 import 'dart:convert' show jsonEncode;
+import 'dart:core' hide Duration;
 
 import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart';


### PR DESCRIPTION
This is not required by the spec, but it seems to be more consistent
with how other libraries in other languages generate JSON.

Internally this change was made in cl/405998525.