### PR TITLE
Add/update copyright lines in protobuf/test

### DIFF
--- a/protobuf/test/json_test.dart
+++ b/protobuf/test/json_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 // Basic smoke tests for the GeneratedMessage JSON API.
 //
 // There are more JSON tests in the dart-protoc-plugin package.

--- a/protobuf/test/json_vm_test.dart
+++ b/protobuf/test/json_vm_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 // VM-specific smoke tests for the GeneratedMessage JSON API.
 //
 // These tests will be skipped on js, as the dart2js platform

--- a/protobuf/test/list_equality_test.dart
+++ b/protobuf/test/list_equality_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 // Test for ensuring that protobuf lists compare using value semantics.
 
 import 'package:test/test.dart';

--- a/protobuf/test/mock_util.dart
+++ b/protobuf/test/mock_util.dart
@@ -1,4 +1,4 @@
-// Copyright(c) 2015, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/protobuf/test/test_util.dart
+++ b/protobuf/test/test_util.dart
@@ -1,4 +1,4 @@
-// Copyright(c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 


### PR DESCRIPTION
list_equality_test.dart was added to g3 with the copyright lines, copy
it over to open source.

I also checked copyright lines in other files, added as necessary. Minor
formatting fix to make them follow the same format.