### PR TITLE
Set map fields in `_getDefault`, minor refactoring

### DIFF
--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -200,13 +200,10 @@ class _FieldSet {
   }
 
   dynamic _getDefault(FieldInfo fi) {
-    if (!fi.isRepeated) return fi.makeDefault!();
+    if (!fi.isRepeated && !fi.isMapField) return fi.makeDefault!();
     if (_isReadOnly) return fi.readonlyDefault;
 
-    // TODO(skybrian) we could avoid this by generating another
-    // method for repeated fields:
-    //   msg.mutableFoo().add(123);
-    var value = fi._createRepeatedField(_message!);
+    var value = fi.makeDefault!();
     _setNonExtensionFieldUnchecked(_meta, fi, value);
     return value;
   }
@@ -215,9 +212,6 @@ class _FieldSet {
     assert(fi.isRepeated);
     if (_isReadOnly) return fi.readonlyDefault;
 
-    // TODO(skybrian) we could avoid this by generating another
-    // method for repeated fields:
-    //   msg.mutableFoo().add(123);
     var value = fi._createRepeatedFieldWithType<T>(_message!);
     _setNonExtensionFieldUnchecked(_meta, fi, value);
     return value;

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -208,28 +208,6 @@ class _FieldSet {
     return value;
   }
 
-  List<T> _getDefaultList<T>(FieldInfo<T> fi) {
-    assert(fi.isRepeated);
-    if (_isReadOnly) return fi.readonlyDefault;
-
-    var value = fi._createRepeatedFieldWithType<T>(_message!);
-    _setNonExtensionFieldUnchecked(_meta, fi, value);
-    return value;
-  }
-
-  Map<K, V> _getDefaultMap<K, V>(MapFieldInfo<K, V> fi) {
-    assert(fi.isMapField);
-
-    if (_isReadOnly) {
-      return PbMap<K, V>.unmodifiable(
-          PbMap<K, V>(fi.keyFieldType, fi.valueFieldType));
-    }
-
-    var value = fi._createMapField(_message!);
-    _setNonExtensionFieldUnchecked(_meta, fi, value);
-    return value;
-  }
-
   dynamic _getFieldOrNullByTag(int tagNumber) {
     var fi = _getFieldInfoOrNull(tagNumber);
     if (fi == null) return null;
@@ -410,15 +388,35 @@ class _FieldSet {
   List<T> _$getList<T>(int index) {
     var value = _values[index];
     if (value != null) return value as List<T>;
-    return _getDefaultList<T>(_nonExtensionInfoByIndex(index) as FieldInfo<T>);
+
+    final fi = _nonExtensionInfoByIndex(index) as FieldInfo<T>;
+    assert(fi.isRepeated);
+
+    if (_isReadOnly) {
+      return fi.readonlyDefault;
+    }
+
+    var list = fi._createRepeatedFieldWithType<T>(_message!);
+    _setNonExtensionFieldUnchecked(_meta, fi, list);
+    return list;
   }
 
   /// The implementation of a generated getter for map fields.
   Map<K, V> _$getMap<K, V>(GeneratedMessage parentMessage, int index) {
     var value = _values[index];
     if (value != null) return value as Map<K, V>;
-    return _getDefaultMap<K, V>(
-        _nonExtensionInfoByIndex(index) as MapFieldInfo<K, V>);
+
+    final fi = _nonExtensionInfoByIndex(index) as MapFieldInfo<K, V>;
+    assert(fi.isMapField);
+
+    if (_isReadOnly) {
+      return PbMap<K, V>.unmodifiable(
+          PbMap<K, V>(fi.keyFieldType, fi.valueFieldType));
+    }
+
+    var map = fi._createMapField(_message!);
+    _setNonExtensionFieldUnchecked(_meta, fi, map);
+    return map;
   }
 
   /// The implementation of a generated getter for `bool` fields.

--- a/protoc_plugin/test/map_field_test.dart
+++ b/protoc_plugin/test/map_field_test.dart
@@ -341,4 +341,18 @@ void main() {
     expect(m1, equals(m2));
     expect(m1.hashCode, equals(m2.hashCode));
   });
+
+  test('getField and \$_getMap are in sync', () {
+    final msg1 = TestMap();
+    var map1 = msg1.getField(1) as Map<int, int>;
+    expect(msg1.hasField(1), true);
+    map1[1] = 2;
+    expect(msg1.int32ToInt32Field[1], 2);
+
+    final msg2 = TestMap();
+    var map2 = msg2.$_getMap(0) as Map<int, int>;
+    expect(msg2.hasField(1), true);
+    map2[1] = 2;
+    expect(msg2.int32ToInt32Field[1], 2);
+  });
 }


### PR DESCRIPTION
- `$_getMap` when called on an uninitialized map field initializes the field.
  Update `getField` to do the same.

  `getField` already initializes repeated fields, but it used to not initialize
  map fields.

  Fixes #373

  This is a sync of cl/442686654.

- Inline `_getDefaultList` into `_$getList` and `_getDefaultMap` into
  `_$getMap`. These inlined functions have only one use site, and inlining them
  makes the `_$getList` and `_$getMap` easier to compare for consistency.