### PR TITLE
Make FieldSet lists use the same representation when empty and otherwise

### DIFF
--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -83,9 +83,9 @@ class _FieldSet {
     return List.filled(length, null, growable: false);
   }
 
-  // Use a fixed length list and not a constant list to ensure that _values
-  // always has the same implementation type.
-  static final List _zeroList = [];
+  // Use `List.filled` and not a `[]` to ensure that `_values` always has the
+  // same implementation type.
+  static final List _zeroList = List.filled(0, null, growable: false);
 
   // Metadata about multiple fields
 


### PR DESCRIPTION
I think `List.filled` could return different `List`s when length is 0
and otherwise, but I checked SDK code and at least on JS that's not the
case.

With `[]` syntax the list will be modifiable, and representation can be
different than `List.filled(..., growable: false)`.

Updated `_zeroList` documentation for clarity.