### PR TITLE
Fix presence of bytes fields

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -9,6 +9,7 @@
   consistent with `getField` called on repeated fields. ([#373], [#707])
 * Unused and optional `PbMap` constructor argument (`BuilderInfo? info`)
   removed.
+* Fix presence of `bytes` fields ([#690])
 
 [#183]: https://github.com/google/protobuf.dart/issues/183
 [#644]: https://github.com/google/protobuf.dart/pull/644
@@ -18,6 +19,7 @@
 [#626]: https://github.com/google/protobuf.dart/pull/626
 [#373]: https://github.com/google/protobuf.dart/issues/373
 [#707]: https://github.com/google/protobuf.dart/pull/707
+[#690]: https://github.com/google/protobuf.dart/issues/690
 
 ## 2.1.0
 

--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -9,7 +9,7 @@
   consistent with `getField` called on repeated fields. ([#373], [#707])
 * Unused and optional `PbMap` constructor argument (`BuilderInfo? info`)
   removed.
-* Fix presence of `bytes` fields ([#690])
+* Fix presence of `bytes` fields ([#690], [#715])
 
 [#183]: https://github.com/google/protobuf.dart/issues/183
 [#644]: https://github.com/google/protobuf.dart/pull/644
@@ -20,6 +20,7 @@
 [#373]: https://github.com/google/protobuf.dart/issues/373
 [#707]: https://github.com/google/protobuf.dart/pull/707
 [#690]: https://github.com/google/protobuf.dart/issues/690
+[#715]: https://github.com/google/protobuf.dart/pull/715
 
 ## 2.1.0
 

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -484,7 +484,6 @@ class _FieldSet {
   bool _$has(int index) {
     var value = _values[index];
     if (value == null) return false;
-    if (value is List) return value.isNotEmpty;
     return true;
   }
 

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -481,11 +481,7 @@ class _FieldSet {
   }
 
   /// The implementation of a generated 'has' method.
-  bool _$has(int index) {
-    var value = _values[index];
-    if (value == null) return false;
-    return true;
-  }
+  bool _$has(int index) => _values[index] != null;
 
   /// The implementation of a generated setter.
   ///

--- a/protoc_plugin/test/proto3_optional_test.dart
+++ b/protoc_plugin/test/proto3_optional_test.dart
@@ -2,17 +2,32 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:core' hide Duration;
-
 import 'package:test/test.dart';
 
 import '../out/protos/proto3_optional.pb.dart';
 
 void main() {
   test('optional fields have presence', () {
-    var f = Foo();
-    expect(f.hasOptionalSubmessage(), isFalse);
+    final f = Foo();
+    expect(f.hasOptionalInt32(), false);
+    expect(f.hasOptionalEnum(), false);
+    expect(f.hasOptionalSubmessage(), false);
+    expect(f.hasOptionalBytes(), false);
+    expect(f.hasOptionalString(), false);
+
+    f.optionalInt32 = 0;
+    expect(f.hasOptionalInt32(), true);
+
+    f.optionalEnum = Enum.A;
+    expect(f.hasOptionalEnum(), true);
+
     f.optionalSubmessage = Submessage();
-    expect(f.hasOptionalSubmessage(), isTrue);
+    expect(f.hasOptionalSubmessage(), true);
+
+    f.optionalString = '';
+    expect(f.hasOptionalString(), true);
+
+    f.optionalBytes = <int>[];
+    expect(f.hasOptionalBytes(), true);
   });
 }

--- a/protoc_plugin/test/protos/proto3_optional.proto
+++ b/protoc_plugin/test/protos/proto3_optional.proto
@@ -6,14 +6,21 @@ syntax = "proto3";
 
 package third_party.dart.protoc_plugin.test.protos;
 
-message Foo {
-  optional int32 optional_field = 1;
-  int32 non_optional_field = 2;
-  optional Submessage optional_submessage = 3;
-  Submessage non_optional_submessage = 4;
+enum Enum {
+  A = 0;
+  B = 1;
+  C = 2;
+}
 
+message Foo {
+  optional int32 optional_int32 = 1;
+  optional Enum optional_enum = 2;
+  optional Submessage optional_submessage = 3;
+  optional bytes optional_bytes = 4;
+  optional string optional_string = 5;
+  repeated int32 repeated_int32 = 6;
 }
 
 message Submessage {
- int32 a = 1;
+  int32 a = 1;
 }


### PR DESCRIPTION
`_FieldSet._$has` previously returned `true` if a list field is empty.

Because `bytes` fields are represented as `List<int>`, this caused
incorrect presence when we set a bytes field to `[]`.

Remove the special case for lists in `_$has` to fix presence checks for
`bytes` fields.

The special case for lists in `_$has` is not necessary for repeated
fields as we don't generate hazzers for repeated fields.

Fixes #690