### PR TITLE
Avoid redundant copying when deserializing binary messages

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -114,13 +114,14 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         fs._setFieldUnchecked(meta, fi, input.readSfixed64());
         break;
       case PbFieldType._OPTIONAL_MESSAGE:
-        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
-        var oldValue = fs._getFieldOrNull(fi);
+        GeneratedMessage? oldValue = fs._getFieldOrNull(fi);
         if (oldValue != null) {
-          subMessage.mergeFromMessage(oldValue);
+          input.readMessage(oldValue, registry);
+        } else {
+          var subMessage = meta._makeEmptyMessage(tagNumber, registry);
+          input.readMessage(subMessage, registry);
+          fs._setFieldUnchecked(meta, fi, subMessage);
         }
-        input.readMessage(subMessage, registry);
-        fs._setFieldUnchecked(meta, fi, subMessage);
         break;
       case PbFieldType._REPEATED_BOOL:
         _readPackable(meta, fs, input, wireType, fi, input.readBool);


### PR DESCRIPTION
When deserializing a field of type `message` we create a new empty
message, deserialize the binary encoding into the empty message, then
set the field.

When the parent message already has a value set for the message-field,
we copy the fields of the message-field to the empty message that we use
to deserialize the binary encoding.

This PR avoids this copying by decoding the binary encoding into the
value of the message-field directly.

Benchmark results don't seem to be affected: we probably don't have any
benchmarks that deserializes a field with message type multiple times in
a single binary encoding.