### PR TITLE
Remove unused `UnknownFieldSetField` methods

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -11,7 +11,7 @@
   ([d94d3f0])
 * Fix presence of `bytes` fields ([#690], [#715])
 * `UnknownFieldSetField` methods `hasRequiredFields`, `isInitialized` and
-  getter `length` removed.
+  getter `length` removed. ([#721])
 
 [#183]: https://github.com/google/protobuf.dart/issues/183
 [#644]: https://github.com/google/protobuf.dart/pull/644
@@ -24,6 +24,7 @@
 [d94d3f0]: https://github.com/google/protobuf.dart/commit/d94d3f0
 [#690]: https://github.com/google/protobuf.dart/issues/690
 [#715]: https://github.com/google/protobuf.dart/pull/715
+[#721]: https://github.com/google/protobuf.dart/pull/721
 
 ## 2.1.0
 

--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Remove unused and optional `PbMap` constructor argument `BuilderInfo? info`.
   ([d94d3f0])
 * Fix presence of `bytes` fields ([#690], [#715])
+* `UnknownFieldSetField` methods `hasRequiredFields`, `isInitialized` and
+  getter `length` removed.
 
 [#183]: https://github.com/google/protobuf.dart/issues/183
 [#644]: https://github.com/google/protobuf.dart/pull/644

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -307,10 +307,4 @@ class UnknownFieldSetField {
   void addVarint(Int64 value) {
     varints.add(value);
   }
-
-  bool hasRequiredFields() => false;
-
-  bool isInitialized() => true;
-
-  int get length => values.length;
 }


### PR DESCRIPTION
These are not used and I don't want to maintain them as I refactor the
types.

cl/465290506