### PR TITLE
Eliminate more type casts when targeting JS

### DIFF
--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -39,26 +39,26 @@ class _ExtensionFieldSet {
   ///
   /// If it doesn't exist, creates the list and saves the extension.
   /// Suitable for public API and decoders.
-  List<T?> _ensureRepeatedField<T>(Extension<T?> fi) {
+  List<T> _ensureRepeatedField<T>(Extension<T> fi) {
     assert(!_isReadOnly);
     assert(fi.isRepeated);
     assert(fi.extendee == '' || fi.extendee == _parent._messageName);
 
     var list = _values[fi.tagNumber];
-    if (list != null) return list as List<T>;
+    if (list != null) return list;
 
-    return _addInfoAndCreateList(fi) as List<T?>;
+    return _addInfoAndCreateList(fi);
   }
 
-  List<T?> _getList<T>(Extension<T?> fi) {
+  List<T> _getList<T>(Extension<T> fi) {
     var value = _values[fi.tagNumber];
-    if (value != null) return value as List<T>;
+    if (value != null) return value;
     _checkNotInUnknown(fi);
     if (_isReadOnly) return List<T>.unmodifiable(const []);
-    return _addInfoAndCreateList(fi) as List<T?>;
+    return _addInfoAndCreateList<T>(fi);
   }
 
-  List _addInfoAndCreateList(Extension fi) {
+  List<T> _addInfoAndCreateList<T>(Extension<T> fi) {
     _validateInfo(fi);
     var newList = fi._createRepeatedField(_parent._message!);
     _addInfoUnchecked(fi);
@@ -184,7 +184,8 @@ class _ExtensionFieldSet {
       } else if (field.isGroupOrMessage) {
         final entry = _values[field.tagNumber];
         if (entry != null) {
-          (entry as GeneratedMessage).freeze();
+          GeneratedMessage msg = entry;
+          msg.freeze();
         }
       }
     }

--- a/protobuf/lib/src/protobuf/field_info.dart
+++ b/protobuf/lib/src/protobuf/field_info.dart
@@ -198,7 +198,7 @@ class FieldInfo<T> {
       GeneratedMessage message = value;
       message._fieldSet._appendInvalidFields(problems, '$prefix$name.');
     } else {
-      final list = value as List<GeneratedMessage>;
+      List<GeneratedMessage> list = value;
       if (list.isEmpty) return;
 
       // For message types that (recursively) contain no required fields,
@@ -219,7 +219,7 @@ class FieldInfo<T> {
   ///
   /// Delegates actual list creation to the message, so that it can
   /// be overridden by a mixin.
-  List<T?> _createRepeatedField(GeneratedMessage m) {
+  List<T> _createRepeatedField(GeneratedMessage m) {
     assert(isRepeated);
     return m.createRepeatedField<T>(tagNumber, this);
   }
@@ -232,7 +232,7 @@ class FieldInfo<T> {
 
   /// Convenience method to thread this FieldInfo's reified type parameter to
   /// _FieldSet._ensureRepeatedField.
-  List<T?> _ensureRepeatedField(BuilderInfo meta, _FieldSet fs) {
+  List<T> _ensureRepeatedField(BuilderInfo meta, _FieldSet fs) {
     return fs._ensureRepeatedField<T>(meta, this);
   }
 

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -157,10 +157,12 @@ class _FieldSet {
       } else if (field.isGroupOrMessage) {
         final entry = _values[field.index!];
         if (entry != null) {
-          (entry as GeneratedMessage).freeze();
+          GeneratedMessage msg = entry;
+          msg.freeze();
         }
       }
     }
+
     if (_hasExtensions) {
       _ensureExtensions()._markReadOnly();
     }
@@ -308,14 +310,14 @@ class _FieldSet {
   /// Creates and stores the repeated field if it doesn't exist.
   /// If it's an extension and the list doesn't exist, validates and stores it.
   /// Suitable for decoders.
-  List<T?> _ensureRepeatedField<T>(BuilderInfo meta, FieldInfo<T> fi) {
+  List<T> _ensureRepeatedField<T>(BuilderInfo meta, FieldInfo<T> fi) {
     assert(!_isReadOnly);
     assert(fi.isRepeated);
     if (fi.index == null) {
       return _ensureExtensions()._ensureRepeatedField(fi as Extension<T>);
     }
     var value = _getFieldOrNull(fi);
-    if (value != null) return value as List<T>;
+    if (value != null) return value;
 
     var newValue = fi._createRepeatedField(_message!);
     _setNonExtensionFieldUnchecked(meta, fi, newValue);
@@ -328,7 +330,7 @@ class _FieldSet {
     assert(fi.index != null); // Map fields are not allowed to be extensions.
 
     var value = _getFieldOrNull(fi);
-    if (value != null) return value as PbMap<K, V>;
+    if (value != null) return value;
 
     var newValue = fi._createMapField(_message!);
     _setNonExtensionFieldUnchecked(meta, fi, newValue);
@@ -359,7 +361,7 @@ class _FieldSet {
   /// The implementation of a generated getter.
   T _$get<T>(int index, T? defaultValue) {
     var value = _values[index];
-    if (value != null) return value as T;
+    if (value != null) return value;
     if (defaultValue != null) return defaultValue;
     return _getDefault(_nonExtensionInfoByIndex(index)) as T;
   }
@@ -387,7 +389,7 @@ class _FieldSet {
   /// The implementation of a generated getter for repeated fields.
   List<T> _$getList<T>(int index) {
     var value = _values[index];
-    if (value != null) return value as List<T>;
+    if (value != null) return value;
 
     final fi = _nonExtensionInfoByIndex(index) as FieldInfo<T>;
     assert(fi.isRepeated);
@@ -761,9 +763,9 @@ class _FieldSet {
       final PbMap<dynamic, dynamic> map =
           f._ensureMapField(meta, this) as dynamic;
       if (mustClone) {
-        PbMap fieldValueMap = fieldValue;
+        PbMap<dynamic, GeneratedMessage> fieldValueMap = fieldValue;
         for (final entry in fieldValueMap.entries) {
-          map[entry.key] = (entry.value as GeneratedMessage).deepCopy();
+          map[entry.key] = entry.value.deepCopy();
         }
       } else {
         map.addAll(fieldValue);


### PR DESCRIPTION
Explicit type casts (`as`) syntax is expensive when targeting.

In #685 we replaced some of the explicit casts with implicit casts.

This PR does the same in a few more places.

AOT and JS binaries get a few bytes smaller and runtimes are almost the same. JS benchmarks get a few percent faster.