### PR TITLE
Avoid hitting size limit when parsing request in protoc plugin

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -29,6 +29,14 @@ class CodedBufferReader {
     _currentLimit = _sizeLimit;
   }
 
+  void _reportTruncatedMessage(int limit) {
+    if (limit > _sizeLimit && limit <= _buffer.length) {
+      throw InvalidProtocolBufferException.truncatedMessageDueToSizeLimit(
+          _buffer.length, _sizeLimit);
+    }
+    throw InvalidProtocolBufferException.truncatedMessage();
+  }
+
   void checkLastTagWas(int value) {
     if (_lastTag != value) {
       throw InvalidProtocolBufferException.invalidEndTag();
@@ -46,7 +54,7 @@ class CodedBufferReader {
     byteLimit += _bufferPos;
     var oldLimit = _currentLimit;
     if ((oldLimit != -1 && byteLimit > oldLimit) || byteLimit > _sizeLimit) {
-      throw InvalidProtocolBufferException.truncatedMessage();
+      _reportTruncatedMessage(byteLimit);
     }
     _currentLimit = byteLimit;
     callback();
@@ -99,7 +107,7 @@ class CodedBufferReader {
     var oldLimit = _currentLimit;
     _currentLimit = _bufferPos + length;
     if (_currentLimit > oldLimit) {
-      throw InvalidProtocolBufferException.truncatedMessage();
+      _reportTruncatedMessage(_currentLimit);
     }
     ++_recursionDepth;
     message.mergeFromCodedBufferReader(this, extensionRegistry);

--- a/protobuf/lib/src/protobuf/exceptions.dart
+++ b/protobuf/lib/src/protobuf/exceptions.dart
@@ -6,9 +6,9 @@ part of protobuf;
 
 const _truncatedMessageText = '''
 While parsing a protocol message, the input ended unexpectedly
-in the middle of a field. This could mean either than the
-input has been truncated or that an embedded message
-misreported its own length.
+in the middle of a field. This could either mean that the input
+has been truncated or that an embedded message misreported its
+own length.
 ''';
 
 /// Exception thrown by the binary deserializer when the encoding is malformed.

--- a/protobuf/lib/src/protobuf/exceptions.dart
+++ b/protobuf/lib/src/protobuf/exceptions.dart
@@ -4,6 +4,13 @@
 
 part of protobuf;
 
+const _truncatedMessageText = '''
+While parsing a protocol message, the input ended unexpectedly
+in the middle of a field.  This could mean either than the
+input has been truncated or that an embedded message
+misreported its own length.
+''';
+
 /// Exception thrown by the binary deserializer when the encoding is malformed.
 class InvalidProtocolBufferException implements Exception {
   final String message;
@@ -30,11 +37,16 @@ Protocol message had too many levels of nesting.  May be malicious.
 Use CodedBufferReader.setRecursionLimit() to increase the depth limit.
 ''');
 
-  InvalidProtocolBufferException.truncatedMessage() : this._('''
-While parsing a protocol message, the input ended unexpectedly
-in the middle of a field.  This could mean either than the
-input has been truncated or that an embedded message
-misreported its own length.
+  InvalidProtocolBufferException.truncatedMessage()
+      : this._(_truncatedMessageText);
+
+  InvalidProtocolBufferException.truncatedMessageDueToSizeLimit(
+      int originalSize, int truncatedSize)
+      : this._(_truncatedMessageText +
+            '''
+
+Note that the buffer containing the message has $originalSize bytes, but
+CodedBufferReader was allowed to parse only $truncatedSize bytes.
 ''');
 
   InvalidProtocolBufferException.wrongAnyMessage(

--- a/protobuf/lib/src/protobuf/exceptions.dart
+++ b/protobuf/lib/src/protobuf/exceptions.dart
@@ -6,7 +6,7 @@ part of protobuf;
 
 const _truncatedMessageText = '''
 While parsing a protocol message, the input ended unexpectedly
-in the middle of a field.  This could mean either than the
+in the middle of a field. This could mean either than the
 input has been truncated or that an embedded message
 misreported its own length.
 ''';
@@ -33,7 +33,7 @@ class InvalidProtocolBufferException implements Exception {
       : this._('CodedBufferReader encountered a malformed varint.');
 
   InvalidProtocolBufferException.recursionLimitExceeded() : this._('''
-Protocol message had too many levels of nesting.  May be malicious.
+Protocol message had too many levels of nesting. May be malicious.
 Use CodedBufferReader.setRecursionLimit() to increase the depth limit.
 ''');
 


### PR DESCRIPTION
By default `CodedBufferReader` only reads 64Mb of input, which can easily be exceeded for large protobuf definitions.

Additionally adjust reported error to make it easier to diagnose. 
