### PR TITLE
Rename _reportTruncatedMessage -> _throwTruncatedMessageError

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -29,7 +29,7 @@ class CodedBufferReader {
     _currentLimit = _sizeLimit;
   }
 
-  void _reportTruncatedMessage(int limit) {
+  void _throwTruncatedMessageError(int limit) {
     if (limit > _sizeLimit && limit <= _buffer.length) {
       throw InvalidProtocolBufferException.truncatedMessageDueToSizeLimit(
           _buffer.length, _sizeLimit);
@@ -54,7 +54,7 @@ class CodedBufferReader {
     byteLimit += _bufferPos;
     var oldLimit = _currentLimit;
     if ((oldLimit != -1 && byteLimit > oldLimit) || byteLimit > _sizeLimit) {
-      _reportTruncatedMessage(byteLimit);
+      _throwTruncatedMessageError(byteLimit);
     }
     _currentLimit = byteLimit;
     callback();
@@ -107,7 +107,7 @@ class CodedBufferReader {
     var oldLimit = _currentLimit;
     _currentLimit = _bufferPos + length;
     if (_currentLimit > oldLimit) {
-      _reportTruncatedMessage(_currentLimit);
+      _throwTruncatedMessageError(_currentLimit);
     }
     ++_recursionDepth;
     message.mergeFromCodedBufferReader(this, extensionRegistry);


### PR DESCRIPTION
"report" reads like it may be logging. Rename it to "throw" to make it
clear that it's throwing an exception.

(PR comment in #734)

---

@mkustermann's PR review in #734