### PR TITLE
Refactor null handling in `_FieldSet` implementation

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -22,8 +22,10 @@ void _writeToCodedBufferWriter(_FieldSet fs, CodedBufferWriter out) {
       out.writeField(tagNumber, fi.type, extensions._getFieldOrNull(fi));
     }
   }
-  if (fs._hasUnknownFields) {
-    fs._unknownFields!.writeToCodedBufferWriter(out);
+
+  final unknownFields = fs._unknownFields;
+  if (unknownFields != null) {
+    unknownFields.writeToCodedBufferWriter(out);
   }
 }
 

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -15,10 +15,11 @@ void _writeToCodedBufferWriter(_FieldSet fs, CodedBufferWriter out) {
     out.writeField(fi.tagNumber, fi.type, value);
   }
 
-  if (fs._hasExtensions) {
-    for (var tagNumber in _sorted(fs._extensions!._tagNumbers)) {
-      var fi = fs._extensions!._getInfoOrNull(tagNumber)!;
-      out.writeField(tagNumber, fi.type, fs._extensions!._getFieldOrNull(fi));
+  final extensions = fs._extensions;
+  if (extensions != null) {
+    for (var tagNumber in _sorted(extensions._tagNumbers)) {
+      var fi = extensions._getInfoOrNull(tagNumber)!;
+      out.writeField(tagNumber, fi.type, extensions._getFieldOrNull(fi));
     }
   }
   if (fs._hasUnknownFields) {

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -191,8 +191,8 @@ class _ExtensionFieldSet {
   }
 
   void _checkNotInUnknown(Extension extension) {
-    if (_parent._hasUnknownFields &&
-        _parent._unknownFields!.hasField(extension.tagNumber)) {
+    final unknownFields = _parent._unknownFields;
+    if (unknownFields != null && unknownFields.hasField(extension.tagNumber)) {
       throw StateError(
           'Trying to get $extension that is present as an unknown field. '
           'Parse the message with this extension in the extension registry or '

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -76,7 +76,10 @@ class _ExtensionFieldSet {
   void _clearField(Extension fi) {
     _ensureWritable();
     _validateInfo(fi);
-    if (_parent._hasObservers) _parent._eventPlugin!.beforeClearField(fi);
+    final eventPlugin = _parent._eventPlugin;
+    if (eventPlugin != null && eventPlugin.hasObservers) {
+      eventPlugin.beforeClearField(fi);
+    }
     _values.remove(fi.tagNumber);
   }
 
@@ -131,8 +134,9 @@ class _ExtensionFieldSet {
   }
 
   void _setFieldUnchecked(Extension fi, value) {
-    if (_parent._hasObservers) {
-      _parent._eventPlugin!.beforeSetField(fi, value);
+    final eventPlugin = _parent._eventPlugin;
+    if (eventPlugin != null && eventPlugin.hasObservers) {
+      eventPlugin.beforeSetField(fi, value);
     }
     // If there was already an unknown field with the same tag number,
     // overwrite it.

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -101,8 +101,6 @@ class _FieldSet {
   /// Returns true if we should send events to the plugin.
   bool get _hasObservers => _eventPlugin != null && _eventPlugin!.hasObservers;
 
-  bool get _hasUnknownFields => _unknownFields != null;
-
   _ExtensionFieldSet _ensureExtensions() =>
       _extensions ??= _ExtensionFieldSet(this);
 
@@ -158,14 +156,8 @@ class _FieldSet {
       }
     }
 
-    final extensions = _extensions;
-    if (extensions != null) {
-      extensions._markReadOnly();
-    }
-
-    if (_hasUnknownFields) {
-      _ensureUnknownFields()._markReadOnly();
-    }
+    _extensions?._markReadOnly();
+    _unknownFields?._markReadOnly();
   }
 
   void _ensureWritable() {
@@ -706,8 +698,10 @@ class _FieldSet {
             _extensions!._values[tagNumber],
             '[${_extensions!._info[tagNumber]!.name}]'));
     }
-    if (_hasUnknownFields) {
-      out.write(_unknownFields.toString());
+
+    final unknownFields = _unknownFields;
+    if (unknownFields != null) {
+      out.write(unknownFields.toString());
     } else {
       out.write(UnknownFieldSet().toString());
     }
@@ -728,6 +722,7 @@ class _FieldSet {
       var value = other._values[fi.index!];
       if (value != null) _mergeField(fi, value, isExtension: false);
     }
+
     final otherExtensions = other._extensions;
     if (otherExtensions != null) {
       for (var tagNumber in otherExtensions._tagNumbers) {
@@ -737,8 +732,9 @@ class _FieldSet {
       }
     }
 
-    if (other._hasUnknownFields) {
-      _ensureUnknownFields().mergeFromUnknownFieldSet(other._unknownFields!);
+    final otherUnknownFields = other._unknownFields;
+    if (otherUnknownFields != null) {
+      _ensureUnknownFields().mergeFromUnknownFieldSet(otherUnknownFields);
     }
   }
 
@@ -892,8 +888,9 @@ class _FieldSet {
       _ensureExtensions()._shallowCopyValues(originalExtensions);
     }
 
-    if (original._hasUnknownFields) {
-      _ensureUnknownFields()._fields.addAll(original._unknownFields!._fields);
+    final originalUnknownFields = original._unknownFields;
+    if (originalUnknownFields != null) {
+      _ensureUnknownFields()._fields.addAll(originalUnknownFields._fields);
     }
 
     _oneofCases?.addAll(original._oneofCases!);

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -98,9 +98,6 @@ class _FieldSet {
   /// The FieldInfo for each non-extension field in tag order.
   Iterable<FieldInfo> get _infosSortedByTag => _meta.sortedByTag;
 
-  /// Returns true if we should send events to the plugin.
-  bool get _hasObservers => _eventPlugin != null && _eventPlugin!.hasObservers;
-
   _ExtensionFieldSet _ensureExtensions() =>
       _extensions ??= _ExtensionFieldSet(this);
 
@@ -226,7 +223,9 @@ class _FieldSet {
     var fi = _nonExtensionInfo(meta, tagNumber);
     if (fi != null) {
       // clear a non-extension field
-      if (_hasObservers) _eventPlugin!.beforeClearField(fi);
+      final eventPlugin = _eventPlugin;
+      if (eventPlugin != null && eventPlugin.hasObservers)
+        eventPlugin.beforeClearField(fi);
       _values[fi.index!] = null;
 
       if (meta.oneofs.containsKey(fi.tagNumber)) {
@@ -339,8 +338,9 @@ class _FieldSet {
     // beginning of this method but happens just before the value is set.
     // Otherwise the observers will be notified about 'clearField' and
     // 'setField' events in an incorrect order.
-    if (_hasObservers) {
-      _eventPlugin!.beforeSetField(fi, value);
+    final eventPlugin = _eventPlugin;
+    if (eventPlugin != null && eventPlugin.hasObservers) {
+      eventPlugin.beforeSetField(fi, value);
     }
     _values[fi.index!] = value;
   }
@@ -479,8 +479,9 @@ class _FieldSet {
     if (value == null) {
       _$check(index, value); // throw exception for null value
     }
-    if (_hasObservers) {
-      _eventPlugin!.beforeSetField(_nonExtensionInfoByIndex(index), value);
+    final eventPlugin = _eventPlugin;
+    if (eventPlugin != null && eventPlugin.hasObservers) {
+      eventPlugin.beforeSetField(_nonExtensionInfoByIndex(index), value);
     }
     final meta = _meta;
     var tag = meta.byIndex[index].tagNumber;
@@ -508,16 +509,17 @@ class _FieldSet {
 
     final extensions = _extensions;
 
-    if (_hasObservers) {
+    final eventPlugin = _eventPlugin;
+    if (eventPlugin != null && eventPlugin.hasObservers) {
       for (var fi in _infos) {
         if (_values[fi.index!] != null) {
-          _eventPlugin!.beforeClearField(fi);
+          eventPlugin.beforeClearField(fi);
         }
       }
       if (extensions != null) {
         for (var key in extensions._tagNumbers) {
           var fi = extensions._getInfoOrNull(key)!;
-          _eventPlugin!.beforeClearField(fi);
+          eventPlugin.beforeClearField(fi);
         }
       }
     }

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -224,8 +224,9 @@ class _FieldSet {
     if (fi != null) {
       // clear a non-extension field
       final eventPlugin = _eventPlugin;
-      if (eventPlugin != null && eventPlugin.hasObservers)
+      if (eventPlugin != null && eventPlugin.hasObservers) {
         eventPlugin.beforeClearField(fi);
+      }
       _values[fi.index!] = null;
 
       if (meta.oneofs.containsKey(fi.tagNumber)) {

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -308,9 +308,7 @@ abstract class GeneratedMessage {
 
   /// Clears an extension field and also removes the extension.
   void clearExtension(Extension extension) {
-    if (_fieldSet._hasExtensions) {
-      _fieldSet._extensions!._clearFieldAndInfo(extension);
-    }
+    _fieldSet._extensions?._clearFieldAndInfo(extension);
   }
 
   /// Clears the contents of a given field.
@@ -368,8 +366,7 @@ abstract class GeneratedMessage {
 
   /// Returns `true` if a value of [extension] is present.
   bool hasExtension(Extension extension) =>
-      _fieldSet._hasExtensions &&
-      _fieldSet._extensions!._getFieldOrNull(extension) != null;
+      _fieldSet._extensions?._getFieldOrNull(extension) != null;
 
   /// Whether this message has a field associated with [tagNumber].
   bool hasField(int tagNumber) => _fieldSet._hasField(tagNumber);

--- a/protobuf/lib/src/protobuf/json.dart
+++ b/protobuf/lib/src/protobuf/json.dart
@@ -78,13 +78,14 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
     }
     result['${fi.tagNumber}'] = convertToMap(value, fi.type);
   }
-  if (fs._hasExtensions) {
-    for (var tagNumber in _sorted(fs._extensions!._tagNumbers)) {
-      var value = fs._extensions!._values[tagNumber];
+  final extensions = fs._extensions;
+  if (extensions != null) {
+    for (var tagNumber in _sorted(extensions._tagNumbers)) {
+      var value = extensions._values[tagNumber];
       if (value is List && value.isEmpty) {
         continue; // It's repeated or an empty byte array.
       }
-      var fi = fs._extensions!._getInfoOrNull(tagNumber)!;
+      var fi = extensions._getInfoOrNull(tagNumber)!;
       result['$tagNumber'] = convertToMap(value, fi.type);
     }
   }


### PR DESCRIPTION
This PR refactors null handling in `_FieldSet` to avoid redundant null checks
(`!`) in the source code.

Generated JS is almost identical in the benchmark programs as dart2js does the
same transformation we do in this PR. For example, extension handling in
`_FieldSet.hashCode` is compiled to this JS in master branch:

```javascript
t1 = _this._extensions;
if (t1 != null) {
  t2 = t1._values;
  sortedByTagNumbers = A._sorted(new A.LinkedHashMapKeyIterable(t2, t2.$ti._eval$1("LinkedHashMapKeyIterable<1>")), type$.int);
  for (t3 = sortedByTagNumbers.length, t1 = t1._info, _i = 0; _i < sortedByTagNumbers.length; sortedByTagNumbers.length === t3 || (0, A.throwConcurrentModificationError)(sortedByTagNumbers), ++_i) {
    fi = t1.$index(0, sortedByTagNumbers[_i]);
    hash = A._FieldSet__hashField(hash, fi, t2.$index(0, fi.get$tagNumber()));
  }
}
```

With this PR:

```javascript
extensions = _this._extensions;
if (extensions != null) {
  t1 = extensions._values;
  sortedByTagNumbers = A._sorted(new A.LinkedHashMapKeyIterable(t1, t1.$ti._eval$1("LinkedHashMapKeyIterable<1>")), type$.int);
  for (t2 = sortedByTagNumbers.length, t3 = extensions._info, _i = 0; _i < sortedByTagNumbers.length; sortedByTagNumbers.length === t2 || (0, A.throwConcurrentModificationError)(sortedByTagNumbers), ++_i) {
    fi = t3.$index(0, sortedByTagNumbers[_i]);
    hash = A._FieldSet__hashField(hash, fi, t1.$index(0, fi.get$tagNumber()));
  }
}
```

This is the same as before, with `t1` renamed to `extensions`, and `t2` renamed
to `t1`.

This PR is still useful to avoid relying on compiler transformations, which
are often fragile and do not survive refactoring. Also, because each `!` can
potentially fail, having less of them is helpful when reading the code or
when refactoring.

Note that this pattern:

```dart
final eventPlugin = message._eventPlugin;
if (eventPlugin != null && eventPlugin.hasObservers) {
  ... use eventPlugin ...
}
```

Could be encapsulated in a `_FieldSet` method like:

```dart
void withEventPlugin(void Function(EventPlugin) f) {
  final eventPlugin = _eventPlugin;
  if (eventPlugin != null && eventPlugin.hasObservers) {
    f(eventPlugin);
  }
}
```

Which would simplify the use cases quite a bit as they all need the
`hasObservers` check.

However the performance implications are unclear to me, so I do not do this
refactoring in this PR.