### PR TITLE
Avoid redundant shallow copy when getting read-only map fields

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -13,6 +13,9 @@
   getter `length` removed. ([#721])
 * Update library documentation to hide internals, add documentation for public
   types. ([#681])
+* Avoid copying when reading map fields of read-only messages. ([#741])
+* Fix `PbMap._isReadonly` field initialization in `PbMap.unmodifiable`.
+  ([#741])
 
 [#183]: https://github.com/google/protobuf.dart/issues/183
 [#644]: https://github.com/google/protobuf.dart/pull/644
@@ -25,6 +28,7 @@
 [d94d3f0]: https://github.com/google/protobuf.dart/commit/d94d3f0
 [#721]: https://github.com/google/protobuf.dart/pull/721
 [#681]: https://github.com/google/protobuf.dart/pull/681
+[#741]: https://github.com/google/protobuf.dart/pull/741
 
 ## 2.1.0
 

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -410,8 +410,7 @@ class _FieldSet {
     assert(fi.isMapField);
 
     if (_isReadOnly) {
-      return PbMap<K, V>.unmodifiable(
-          PbMap<K, V>(fi.keyFieldType, fi.valueFieldType));
+      return PbMap<K, V>(fi.keyFieldType, fi.valueFieldType);
     }
 
     var map = fi._createMapField(_message!);

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -31,7 +31,7 @@ class PbMap<K, V> extends MapBase<K, V> {
       : keyFieldType = other.keyFieldType,
         valueFieldType = other.valueFieldType,
         _wrappedMap = Map.unmodifiable(other._wrappedMap),
-        _isReadonly = other._isReadonly;
+        _isReadonly = true;
 
   @override
   V? operator [](Object? key) => _wrappedMap[key];


### PR DESCRIPTION
`_FieldSet._$getMap` unnecessarily shallow-copies the map field when the
message is read-only.

If a message is read-only then all of its fields are read-only, so the
map fields are read-only. We don't need to copy them.

Copying map fields on every access can be expensive depending on the map
size, so this will potentially be a significant performance win.

(Also, if we had to copy, we would have to deep-copy, rather than
shallow-copy, so the code would be buggy if we needed to copy the field)

Also fix `_isReadonly` field initialization in `PbMap.unmodifiable`.

We actually do not use `PbMap.unmodifiable` and we don't have any users
of it, but I think that method will be useful when fixing #705, so I'm
not removing it for now.