### PR TITLE
Remove an old TODO, minor refactoring

### DIFF
--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -27,8 +27,8 @@ class BuilderInfo {
   /// Mapping from [FieldInfo.name]s to [FieldInfo]s.
   final Map<String, FieldInfo> byName = <String, FieldInfo>{};
 
-  /// Mapping from [FieldInfo.tagNumber]s to the corresponding `oneof` indices
-  /// (if any).
+  /// Mapping from `oneof` field [FieldInfo.tagNumber]s to the their indices in
+  /// [_FieldSet._oneofCases].
   final Map<int, int> oneofs = <int, int>{};
 
   /// Whether the message has extension fields.

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -301,12 +301,12 @@ class BuilderInfo {
         : qualifiedMessageName.substring(lastDot + 1);
   }
 
-  List<FieldInfo> _computeSortedByTag() {
-    // TODO(skybrian): perhaps the code generator should insert the FieldInfos
-    // in tag number order, to avoid sorting them?
-    return List<FieldInfo>.from(fieldInfo.values, growable: false)
-      ..sort((FieldInfo a, FieldInfo b) => a.tagNumber.compareTo(b.tagNumber));
-  }
+  List<FieldInfo> _computeSortedByTag() =>
+      // Code generator inserts fields in tag order, but it's possible for
+      // user-written code to insert unordered.
+      List<FieldInfo>.from(fieldInfo.values, growable: false)
+        ..sort(
+            (FieldInfo a, FieldInfo b) => a.tagNumber.compareTo(b.tagNumber));
 
   GeneratedMessage _makeEmptyMessage(
       int tagNumber, ExtensionRegistry? extensionRegistry) {

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -12,7 +12,7 @@ class _ExtensionFieldSet {
 
   _ExtensionFieldSet(this._parent);
 
-  Extension? _getInfoOrNull(int? tagNumber) => _info[tagNumber];
+  Extension? _getInfoOrNull(int tagNumber) => _info[tagNumber];
 
   dynamic _getFieldOrDefault(Extension fi) {
     if (fi.isRepeated) return _getList(fi);

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -279,12 +279,12 @@ abstract class GeneratedMessage {
     /// This is a slight regression on the Dart VM.
     /// TODO(skybrian) we could skip the reviver if we're running
     /// on the Dart VM for a slight speedup.
-    final jsonMap =
-        jsonDecode(data, reviver: _emptyReviver) as Map<String, dynamic>;
+    final Map<String, dynamic> jsonMap =
+        jsonDecode(data, reviver: _emptyReviver);
     _mergeFromJsonMap(_fieldSet, jsonMap, extensionRegistry);
   }
 
-  static dynamic _emptyReviver(k, v) => v;
+  static Object? _emptyReviver(Object? k, Object? v) => v;
 
   /// Merges field values from a JSON object represented as a Dart map.
   ///

--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -297,8 +297,6 @@ void _mergeFromProto3Json(
               throw context.parseException(
                   'Wrong boolean key, should be one of ("true", "false")', key);
           }
-          // ignore: dead_code
-          throw StateError('(Should have been) unreachable statement');
         case PbFieldType._STRING_BIT:
           return key;
         case PbFieldType._UINT64_BIT:


### PR DESCRIPTION
- Remove an old TODO, clarify the code

- Avoid an explicit cast in `GeneratedMessage.mergeFromJson`

- Update reviver argument type in `jsonDecode` calls to avoid any
  potential runtime type checks

- Remove a dead code

- Refactor `oneof` handling in `_FieldSet._clearField`