### PR TITLE
Added extra "lints/recommended.yaml" rules to "ignore_for_file"

### DIFF
--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -659,4 +659,6 @@ const _ignores = {
   'unnecessary_this',
   'unused_import',
   'unused_shown_name',
+  'no_leading_underscores_for_local_identifiers',
+  'depend_on_referenced_packages',
 };


### PR DESCRIPTION
In my project, I'm using the `package:lints/recommended.yaml` linter rules, and two of these recommended rules are being triggered by the generated `.pb.dart` files. Therefore I'd like to add the following two rules to the `ignore_for_file` list:

1. `no_leading_underscores_for_local_identifiers`
   - for covering the `final _result = create();`
   - alternatively `_result` could be changed into `$result` or something else?
2. `depend_on_referenced_packages`
   - I don't have any direct, only transitive dependencies on the following packages:
     - `fixnum`
     - `protobuf`

So for 1. I might change the prefix, but I'm not sure what the preferred solution would be.

For 2. I might add the dependencies explicitly in my own `pubspec.yaml` files, though I'm reluctant to do so. On the other hand, checking https://dart-lang.github.io/linter/lints/depend_on_referenced_packages.html I might just do that anyway.

So I'm mainly looking for feedback on this one right now.