### PR TITLE
Make subBuilder args of BuilderInfo message methods required

### DIFF
--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -199,7 +199,7 @@ class BuilderInfo {
   }
 
   void aOM<T extends GeneratedMessage>(int tagNumber, String name,
-      {T Function()? subBuilder, String? protoName}) {
+      {required T Function() subBuilder, String? protoName}) {
     add<T>(
         tagNumber,
         name,
@@ -212,7 +212,7 @@ class BuilderInfo {
   }
 
   void aQM<T extends GeneratedMessage>(int tagNumber, String name,
-      {T Function()? subBuilder, String? protoName}) {
+      {required T Function() subBuilder, String? protoName}) {
     add<T>(
         tagNumber,
         name,


### PR DESCRIPTION
We always pass those args, and not passing them would be a bug as we can't deserialize a message without the `subBuilder` field.