### PR TITLE
Fix $_getMap return value when mutability when message is read-only

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -13,7 +13,6 @@
   getter `length` removed. ([#721])
 * Update library documentation to hide internals, add documentation for public
   types. ([#681])
-* Avoid copying when reading map fields of read-only messages. ([#741])
 * Fix `PbMap._isReadonly` field initialization in `PbMap.unmodifiable`.
   ([#741])
 * Fix decoding map fields when key or value (or both) fields of a map entry is

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -407,7 +407,8 @@ class _FieldSet {
     assert(fi.isMapField);
 
     if (_isReadOnly) {
-      return PbMap<K, V>(fi.keyFieldType, fi.valueFieldType);
+      return PbMap<K, V>.unmodifiable(
+          PbMap<K, V>(fi.keyFieldType, fi.valueFieldType));
     }
 
     var map = fi._createMapField(_message!);

--- a/protoc_plugin/test/map_field_test.dart
+++ b/protoc_plugin/test/map_field_test.dart
@@ -447,4 +447,11 @@ void main() {
       expect(message, TestMap()..int32ToEnumField[0] = TestMap_EnumValue.BAR);
     }
   });
+
+  test('Read-only message uninitialized map field value is read-only', () {
+    final msg = TestMap()..freeze();
+    expect(() {
+      msg.int32ToInt32Field[0] = 1;
+    }, throwsA(const TypeMatcher<UnsupportedError>()));
+  });
 }


### PR DESCRIPTION
This was broken in #741