### PR TITLE
Fix initializing required fields with proto3 JSON null values

### DIFF
--- a/protoc_plugin/Makefile
+++ b/protoc_plugin/Makefile
@@ -50,6 +50,7 @@ TEST_PROTO_LIST = \
 	nested_message \
 	non_nested_extension \
 	oneof \
+	required \
 	reserved_names \
 	reserved_names_extension \
 	reserved_names_message \

--- a/protoc_plugin/test/proto3_json_test.dart
+++ b/protoc_plugin/test/proto3_json_test.dart
@@ -17,12 +17,13 @@ import '../out/protos/google/protobuf/empty.pb.dart';
 import '../out/protos/google/protobuf/field_mask.pb.dart';
 import '../out/protos/google/protobuf/struct.pb.dart';
 import '../out/protos/google/protobuf/timestamp.pb.dart';
-import '../out/protos/google/protobuf/unittest.pb.dart';
+import '../out/protos/google/protobuf/unittest.pb.dart' hide TestRequired;
 import '../out/protos/google/protobuf/unittest_well_known_types.pb.dart';
 import '../out/protos/google/protobuf/wrappers.pb.dart';
 import '../out/protos/map_field.pb.dart';
 import '../out/protos/nested_any.pb.dart';
 import '../out/protos/oneof.pb.dart';
+import '../out/protos/required.pb.dart';
 import 'oneof_test.dart';
 import 'test_util.dart';
 
@@ -1290,6 +1291,23 @@ void main() {
       var proto = TestAllTypes()..optionalDouble = double.negativeInfinity;
       expect(TestAllTypes()..mergeFromProto3Json(json), proto);
       expect(proto.toProto3Json(), json);
+    });
+  });
+
+  test('Parsing null with required fields', () {
+    final message = TestRequired()..mergeFromProto3Json(null);
+    expect(message.toProto3Json(), {
+      'requiredInt': 0,
+      'requiredString': '',
+      'requiredFloat': 0,
+      'requiredEnum': 'DEFAULT',
+      'requiredNestedMessage': {
+        'requiredInt': 0,
+        'requiredString': '',
+        'requiredFloat': 0,
+        'requiredEnum': 'DEFAULT',
+        'requiredNestedMessage': {'requiredInt': 0}
+      }
     });
   });
 }

--- a/protoc_plugin/test/protos/required.proto
+++ b/protoc_plugin/test/protos/required.proto
@@ -1,0 +1,32 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+syntax = 'proto2';
+
+message TestRequired {
+  required int32 requiredInt = 1;
+  required string requiredString = 2;
+  required bytes requiredBytes = 3;
+  required float requiredFloat = 4;
+  required TestEnum requiredEnum = 5;
+  required NestedMessage requiredNestedMessage = 6;
+}
+
+enum TestEnum {
+  DEFAULT = 0;
+  A = 1;
+}
+
+message NestedMessage {
+  required int32 requiredInt = 1;
+  required string requiredString = 2;
+  required bytes requiredBytes = 3;
+  required float requiredFloat = 4;
+  required TestEnum requiredEnum = 5;
+  required NestedMessage2 requiredNestedMessage = 6;
+}
+
+message NestedMessage2 {
+  required int32 requiredInt = 1;
+}


### PR DESCRIPTION
[proto3 JSON spec][1] says this about `null` values:

> If a value is missing in the JSON-encoded data or if its value is
> null, it will be interpreted as the appropriate default value when
> parsed into a protocol buffer

Normally empty field set represents the default message, but for that representation to work with proto2 required fields, serializers need to check for required fields in the `BuilderInfo` and for fields that are not in the field set serialize the default value for the field.

Currently we don't do this, which results in generating messages with missing required fields. See #760 for a repro.

Checking missing required fields in serializers should fix the issue, but as a simpler fix, this PR deserializes proto3 JSON `null` values to field sets with required fields set to defaults. This way serializers do not need to be tweaked.

Fixes #760

[1]: https://developers.google.com/protocol-buffers/docs/proto3#json