### PR TITLE
Fix `null` handling in proto3 JSON deserializer

### DIFF
--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -150,6 +150,8 @@ extension _FindFirst<E> on Iterable<E> {
   }
 }
 
+/// Merge a JSON object representing a message in proto3 JSON format ([json])
+/// to [fieldSet].
 void _mergeFromProto3Json(
     Object? json,
     _FieldSet fieldSet,
@@ -162,10 +164,7 @@ void _mergeFromProto3Json(
       ignoreUnknownFields, supportNamesWithUnderscores, permissiveEnums);
 
   void recursionHelper(Object? json, _FieldSet fieldSet) {
-    Object? convertProto3JsonValue(Object? value, FieldInfo fieldInfo) {
-      if (value == null) {
-        return fieldInfo.makeDefault!();
-      }
+    Object? convertProto3JsonValue(Object value, FieldInfo fieldInfo) {
       var fieldType = fieldInfo.type;
       switch (PbFieldType._baseType(fieldType)) {
         case PbFieldType._BOOL_BIT:
@@ -337,6 +336,9 @@ void _mergeFromProto3Json(
         final byName = meta.byName;
 
         json.forEach((key, Object? value) {
+          if (value == null) {
+            return;
+          }
           if (key is! String) {
             throw context.parseException('Key was not a String', key);
           }
@@ -375,10 +377,7 @@ void _mergeFromProto3Json(
               throw context.parseException('Expected a map', value);
             }
           } else if (_isRepeated(fieldInfo.type)) {
-            if (value == null) {
-              // `null` is accepted as the empty list [].
-              fieldSet._ensureRepeatedField(meta, fieldInfo);
-            } else if (value is List) {
+            if (value is List) {
               var values = fieldSet._ensureRepeatedField(meta, fieldInfo);
               for (var i = 0; i < value.length; i++) {
                 final entry = value[i];

--- a/protoc_plugin/test/proto3_json_test.dart
+++ b/protoc_plugin/test/proto3_json_test.dart
@@ -402,7 +402,7 @@ void main() {
     test('Nulls', () {
       final decoded = TestAllTypes()
         ..mergeFromProto3Json({'defaultString': null});
-      expect(decoded, TestAllTypes()..defaultString = 'hello');
+      expect(decoded, TestAllTypes());
     });
     test('decode TestAllTypes', () {
       final decoded = TestAllTypes()..mergeFromProto3Json(testAllTypesJson);
@@ -1181,16 +1181,7 @@ void main() {
               'stringField': null,
               'bytesField': null,
             }),
-          TestWellKnownTypes()
-            ..doubleField = DoubleValue()
-            ..floatField = FloatValue()
-            ..int64Field = Int64Value()
-            ..uint64Field = UInt64Value()
-            ..int32Field = Int32Value()
-            ..uint32Field = UInt32Value()
-            ..boolField = BoolValue()
-            ..stringField = StringValue()
-            ..bytesField = BytesValue(),
+          TestWellKnownTypes(),
           reason: 'having fields of wrapper types set to null will return an '
               'empty wrapper (with unset .value field)');
     });


### PR DESCRIPTION
[proto3 JSON spec][1] says this about `null` values:

> If a value is missing in the JSON-encoded data or if its value is
> null, it will be interpreted as the appropriate default value when
> parsed into a protocol buffer

proto3 spec does not talk about presence, but in an internal spec we have this about proto3 JSON null values:

> When parsing, a “null” value is accepted for all field types. It will
> be treated as if the field has the default value (the field itself
> would not be set, but its getter will return the default value for
> proto3).

So we shouldn't be initializing the fields with `null` values. The "interpreted as default value" part in the public spec is already handled by the getters.

With this #760 is no longer an issue as we don't generate empty message for the field value when we have a message-field.

We will still accept proto3 JSON message encodings with missing `required` fields, but that's by design. We don't check for `required` fields until `GeneratedMessage.check` is called.

Closes #760

cl/480829988 tests this internally and reports no breakage.

[1]: https://developers.google.com/protocol-buffers/docs/proto3#json