### PR TITLE
protoc_plugin: Improve "is map field" check

### DIFF
--- a/protoc_plugin/lib/src/protobuf_field.dart
+++ b/protoc_plugin/lib/src/protobuf_field.dart
@@ -118,7 +118,7 @@ class ProtobufField {
   bool get isMapField {
     if (!isRepeated || !baseType.isMessage) return false;
     final generator = baseType.generator as MessageGenerator;
-    return generator._descriptor.options.hasMapEntry();
+    return generator._descriptor.options.mapEntry;
   }
 
   // `true` if this field should have a `hazzer` generated.


### PR DESCRIPTION
`MessageOptions.map_entry` is an `optional bool` field. Currently to check whether a field is a map we check whether `map_entry` is present, but we don't check its value. This only works if the field is never set, or set to `true` (i.e. it's never set to `false`).

The right way to check it is

    descriptor.options.hasMapEntry() && descriptor.options.mapEntry

because the default value of the field is `false`, this can be simplified as

    descriptor.options.mapEntry