### PR TITLE
pretty-print the ignore_for_file lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ packages
 pubspec.lock
 benchmarks/out
 doc/
-protoc/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ packages
 pubspec.lock
 benchmarks/out
 doc/
+protoc/

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -426,8 +426,9 @@ class FileGenerator extends ProtobufContainer {
     if (enumCount > 0) {
       // Make sure any other symbols in dart:core don't cause name conflicts
       // with enums that have the same name.
-      out.println('// ignore_for_file: UNDEFINED_SHOWN_NAME');
+      out.println('// ignore_for_file: undefined_shown_name');
       out.println(_coreImport);
+      out.println();
       out.println(_protobufImport);
       out.println();
     }
@@ -609,14 +610,30 @@ class FileGenerator extends ProtobufContainer {
     }).toList()
       ..sort();
 
+    // Group the ignores into lines not longer than 80 chars.
+    var ignorelines = <String>[];
+
+    if (ignores.isNotEmpty) {
+      ignorelines.add('// ignore_for_file: ${ignores.first}');
+
+      for (var ignore in ignores.skip(1)) {
+        if (ignorelines.last.length + ignore.length + ', '.length > 80) {
+          ignorelines.add('// ignore_for_file: $ignore');
+        } else {
+          ignorelines.add('${ignorelines.removeLast()}, $ignore');
+        }
+      }
+    }
+
     out.println('''
 ///
 //  Generated code. Do not modify.
 //  source: ${descriptor.name}
 //
 // @dart = 2.12
-// ignore_for_file: ${ignores.join(',')}
 ''');
+    ignorelines.forEach(out.println);
+    out.println('');
   }
 
   /// Writes an import of a .dart file corresponding to a .proto file.
@@ -647,9 +664,9 @@ class FileGenerator extends ProtobufContainer {
 
 const _ignores = {
   'annotate_overrides',
-  'directives_ordering',
   'camel_case_types',
   'constant_identifier_names',
+  'directives_ordering',
   'library_prefixes',
   'non_constant_identifier_names',
   'prefer_final_fields',

--- a/protoc_plugin/lib/src/generated/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/generated/dart_options.pb.dart
@@ -3,7 +3,13 @@
 //  source: dart_options.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 
@@ -44,6 +50,7 @@ class DartMixin extends $pb.GeneratedMessage {
   factory DartMixin.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -54,7 +61,9 @@ class DartMixin extends $pb.GeneratedMessage {
   DartMixin copyWith(void Function(DartMixin) updates) =>
       super.copyWith((message) => updates(message as DartMixin))
           as DartMixin; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DartMixin create() => DartMixin._();
   DartMixin createEmptyInstance() => create();
@@ -128,6 +137,7 @@ class Imports extends $pb.GeneratedMessage {
   factory Imports.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -138,7 +148,9 @@ class Imports extends $pb.GeneratedMessage {
   Imports copyWith(void Function(Imports) updates) =>
       super.copyWith((message) => updates(message as Imports))
           as Imports; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Imports create() => Imports._();
   Imports createEmptyInstance() => create();

--- a/protoc_plugin/lib/src/generated/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pb.dart
@@ -3,7 +3,13 @@
 //  source: descriptor.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 
@@ -40,6 +46,7 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
   factory FileDescriptorSet.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -50,7 +57,9 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
   FileDescriptorSet copyWith(void Function(FileDescriptorSet) updates) =>
       super.copyWith((message) => updates(message as FileDescriptorSet))
           as FileDescriptorSet; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static FileDescriptorSet create() => FileDescriptorSet._();
   FileDescriptorSet createEmptyInstance() => create();
@@ -156,6 +165,7 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
   factory FileDescriptorProto.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -166,7 +176,9 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
   FileDescriptorProto copyWith(void Function(FileDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as FileDescriptorProto))
           as FileDescriptorProto; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static FileDescriptorProto create() => FileDescriptorProto._();
   FileDescriptorProto createEmptyInstance() => create();
@@ -300,6 +312,7 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
   factory DescriptorProto_ExtensionRange.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -313,7 +326,9 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
       super.copyWith(
               (message) => updates(message as DescriptorProto_ExtensionRange))
           as DescriptorProto_ExtensionRange; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ExtensionRange create() =>
       DescriptorProto_ExtensionRange._();
@@ -396,6 +411,7 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
   factory DescriptorProto_ReservedRange.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -409,7 +425,9 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
       super.copyWith(
               (message) => updates(message as DescriptorProto_ReservedRange))
           as DescriptorProto_ReservedRange; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ReservedRange create() =>
       DescriptorProto_ReservedRange._();
@@ -530,6 +548,7 @@ class DescriptorProto extends $pb.GeneratedMessage {
   factory DescriptorProto.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -540,7 +559,9 @@ class DescriptorProto extends $pb.GeneratedMessage {
   DescriptorProto copyWith(void Function(DescriptorProto) updates) =>
       super.copyWith((message) => updates(message as DescriptorProto))
           as DescriptorProto; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DescriptorProto create() => DescriptorProto._();
   DescriptorProto createEmptyInstance() => create();
@@ -629,6 +650,7 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
   factory ExtensionRangeOptions.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -641,7 +663,9 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
           void Function(ExtensionRangeOptions) updates) =>
       super.copyWith((message) => updates(message as ExtensionRangeOptions))
           as ExtensionRangeOptions; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ExtensionRangeOptions create() => ExtensionRangeOptions._();
   ExtensionRangeOptions createEmptyInstance() => create();
@@ -741,6 +765,7 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
   factory FieldDescriptorProto.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -752,7 +777,9 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
   FieldDescriptorProto copyWith(void Function(FieldDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as FieldDescriptorProto))
           as FieldDescriptorProto; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static FieldDescriptorProto create() => FieldDescriptorProto._();
   FieldDescriptorProto createEmptyInstance() => create();
@@ -928,6 +955,7 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
   factory OneofDescriptorProto.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -939,7 +967,9 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
   OneofDescriptorProto copyWith(void Function(OneofDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as OneofDescriptorProto))
           as OneofDescriptorProto; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static OneofDescriptorProto create() => OneofDescriptorProto._();
   OneofDescriptorProto createEmptyInstance() => create();
@@ -1010,6 +1040,7 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
   factory EnumDescriptorProto_EnumReservedRange.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -1023,7 +1054,9 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
       super.copyWith((message) =>
               updates(message as EnumDescriptorProto_EnumReservedRange))
           as EnumDescriptorProto_EnumReservedRange; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static EnumDescriptorProto_EnumReservedRange create() =>
       EnumDescriptorProto_EnumReservedRange._();
@@ -1110,6 +1143,7 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
   factory EnumDescriptorProto.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -1120,7 +1154,9 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
   EnumDescriptorProto copyWith(void Function(EnumDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as EnumDescriptorProto))
           as EnumDescriptorProto; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static EnumDescriptorProto create() => EnumDescriptorProto._();
   EnumDescriptorProto createEmptyInstance() => create();
@@ -1204,6 +1240,7 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
   factory EnumValueDescriptorProto.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -1216,7 +1253,9 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
           void Function(EnumValueDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as EnumValueDescriptorProto))
           as EnumValueDescriptorProto; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static EnumValueDescriptorProto create() => EnumValueDescriptorProto._();
   EnumValueDescriptorProto createEmptyInstance() => create();
@@ -1303,6 +1342,7 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
   factory ServiceDescriptorProto.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -1315,7 +1355,9 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
           void Function(ServiceDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as ServiceDescriptorProto))
           as ServiceDescriptorProto; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ServiceDescriptorProto create() => ServiceDescriptorProto._();
   ServiceDescriptorProto createEmptyInstance() => create();
@@ -1406,6 +1448,7 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
   factory MethodDescriptorProto.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -1418,7 +1461,9 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
           void Function(MethodDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as MethodDescriptorProto))
           as MethodDescriptorProto; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MethodDescriptorProto create() => MethodDescriptorProto._();
   MethodDescriptorProto createEmptyInstance() => create();
@@ -1637,6 +1682,7 @@ class FileOptions extends $pb.GeneratedMessage {
   factory FileOptions.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -1647,7 +1693,9 @@ class FileOptions extends $pb.GeneratedMessage {
   FileOptions copyWith(void Function(FileOptions) updates) =>
       super.copyWith((message) => updates(message as FileOptions))
           as FileOptions; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static FileOptions create() => FileOptions._();
   FileOptions createEmptyInstance() => create();
@@ -1952,6 +2000,7 @@ class MessageOptions extends $pb.GeneratedMessage {
   factory MessageOptions.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -1962,7 +2011,9 @@ class MessageOptions extends $pb.GeneratedMessage {
   MessageOptions copyWith(void Function(MessageOptions) updates) =>
       super.copyWith((message) => updates(message as MessageOptions))
           as MessageOptions; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MessageOptions create() => MessageOptions._();
   MessageOptions createEmptyInstance() => create();
@@ -2090,6 +2141,7 @@ class FieldOptions extends $pb.GeneratedMessage {
   factory FieldOptions.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -2100,7 +2152,9 @@ class FieldOptions extends $pb.GeneratedMessage {
   FieldOptions copyWith(void Function(FieldOptions) updates) =>
       super.copyWith((message) => updates(message as FieldOptions))
           as FieldOptions; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static FieldOptions create() => FieldOptions._();
   FieldOptions createEmptyInstance() => create();
@@ -2214,6 +2268,7 @@ class OneofOptions extends $pb.GeneratedMessage {
   factory OneofOptions.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -2224,7 +2279,9 @@ class OneofOptions extends $pb.GeneratedMessage {
   OneofOptions copyWith(void Function(OneofOptions) updates) =>
       super.copyWith((message) => updates(message as OneofOptions))
           as OneofOptions; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static OneofOptions create() => OneofOptions._();
   OneofOptions createEmptyInstance() => create();
@@ -2276,6 +2333,7 @@ class EnumOptions extends $pb.GeneratedMessage {
   factory EnumOptions.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -2286,7 +2344,9 @@ class EnumOptions extends $pb.GeneratedMessage {
   EnumOptions copyWith(void Function(EnumOptions) updates) =>
       super.copyWith((message) => updates(message as EnumOptions))
           as EnumOptions; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static EnumOptions create() => EnumOptions._();
   EnumOptions createEmptyInstance() => create();
@@ -2356,6 +2416,7 @@ class EnumValueOptions extends $pb.GeneratedMessage {
   factory EnumValueOptions.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -2366,7 +2427,9 @@ class EnumValueOptions extends $pb.GeneratedMessage {
   EnumValueOptions copyWith(void Function(EnumValueOptions) updates) =>
       super.copyWith((message) => updates(message as EnumValueOptions))
           as EnumValueOptions; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static EnumValueOptions create() => EnumValueOptions._();
   EnumValueOptions createEmptyInstance() => create();
@@ -2425,6 +2488,7 @@ class ServiceOptions extends $pb.GeneratedMessage {
   factory ServiceOptions.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -2435,7 +2499,9 @@ class ServiceOptions extends $pb.GeneratedMessage {
   ServiceOptions copyWith(void Function(ServiceOptions) updates) =>
       super.copyWith((message) => updates(message as ServiceOptions))
           as ServiceOptions; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ServiceOptions create() => ServiceOptions._();
   ServiceOptions createEmptyInstance() => create();
@@ -2503,6 +2569,7 @@ class MethodOptions extends $pb.GeneratedMessage {
   factory MethodOptions.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -2513,7 +2580,9 @@ class MethodOptions extends $pb.GeneratedMessage {
   MethodOptions copyWith(void Function(MethodOptions) updates) =>
       super.copyWith((message) => updates(message as MethodOptions))
           as MethodOptions; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MethodOptions create() => MethodOptions._();
   MethodOptions createEmptyInstance() => create();
@@ -2582,6 +2651,7 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
   factory UninterpretedOption_NamePart.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -2595,7 +2665,9 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
       super.copyWith(
               (message) => updates(message as UninterpretedOption_NamePart))
           as UninterpretedOption_NamePart; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption_NamePart create() =>
       UninterpretedOption_NamePart._();
@@ -2692,6 +2764,7 @@ class UninterpretedOption extends $pb.GeneratedMessage {
   factory UninterpretedOption.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -2702,7 +2775,9 @@ class UninterpretedOption extends $pb.GeneratedMessage {
   UninterpretedOption copyWith(void Function(UninterpretedOption) updates) =>
       super.copyWith((message) => updates(message as UninterpretedOption))
           as UninterpretedOption; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption create() => UninterpretedOption._();
   UninterpretedOption createEmptyInstance() => create();
@@ -2836,6 +2911,7 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
   factory SourceCodeInfo_Location.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -2848,7 +2924,9 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
           void Function(SourceCodeInfo_Location) updates) =>
       super.copyWith((message) => updates(message as SourceCodeInfo_Location))
           as SourceCodeInfo_Location; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo_Location create() => SourceCodeInfo_Location._();
   SourceCodeInfo_Location createEmptyInstance() => create();
@@ -2920,6 +2998,7 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
   factory SourceCodeInfo.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -2930,7 +3009,9 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
   SourceCodeInfo copyWith(void Function(SourceCodeInfo) updates) =>
       super.copyWith((message) => updates(message as SourceCodeInfo))
           as SourceCodeInfo; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo create() => SourceCodeInfo._();
   SourceCodeInfo createEmptyInstance() => create();
@@ -2988,6 +3069,7 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
   factory GeneratedCodeInfo_Annotation.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -3001,7 +3083,9 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
       super.copyWith(
               (message) => updates(message as GeneratedCodeInfo_Annotation))
           as GeneratedCodeInfo_Annotation; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo_Annotation create() =>
       GeneratedCodeInfo_Annotation._();
@@ -3080,6 +3164,7 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
   factory GeneratedCodeInfo.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -3090,7 +3175,9 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
   GeneratedCodeInfo copyWith(void Function(GeneratedCodeInfo) updates) =>
       super.copyWith((message) => updates(message as GeneratedCodeInfo))
           as GeneratedCodeInfo; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo create() => GeneratedCodeInfo._();
   GeneratedCodeInfo createEmptyInstance() => create();

--- a/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
@@ -3,10 +3,17 @@
 //  source: descriptor.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
-// ignore_for_file: UNDEFINED_SHOWN_NAME
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
+
+// ignore_for_file: undefined_shown_name
 import 'dart:core' as $core;
+
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class FieldDescriptorProto_Type extends $pb.ProtobufEnum {

--- a/protoc_plugin/lib/src/generated/plugin.pb.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pb.dart
@@ -3,7 +3,13 @@
 //  source: plugin.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 
@@ -57,6 +63,7 @@ class Version extends $pb.GeneratedMessage {
   factory Version.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -67,7 +74,9 @@ class Version extends $pb.GeneratedMessage {
   Version copyWith(void Function(Version) updates) =>
       super.copyWith((message) => updates(message as Version))
           as Version; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Version create() => Version._();
   Version createEmptyInstance() => create();
@@ -168,6 +177,7 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
   factory CodeGeneratorRequest.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -179,7 +189,9 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
   CodeGeneratorRequest copyWith(void Function(CodeGeneratorRequest) updates) =>
       super.copyWith((message) => updates(message as CodeGeneratorRequest))
           as CodeGeneratorRequest; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorRequest create() => CodeGeneratorRequest._();
   CodeGeneratorRequest createEmptyInstance() => create();
@@ -264,6 +276,7 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
   factory CodeGeneratorResponse_File.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -277,7 +290,9 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
       super.copyWith(
               (message) => updates(message as CodeGeneratorResponse_File))
           as CodeGeneratorResponse_File; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse_File create() => CodeGeneratorResponse_File._();
   CodeGeneratorResponse_File createEmptyInstance() => create();
@@ -378,6 +393,7 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
   factory CodeGeneratorResponse.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
       'Will be removed in next major version')
@@ -390,7 +406,9 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
           void Function(CodeGeneratorResponse) updates) =>
       super.copyWith((message) => updates(message as CodeGeneratorResponse))
           as CodeGeneratorResponse; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse create() => CodeGeneratorResponse._();
   CodeGeneratorResponse createEmptyInstance() => create();

--- a/protoc_plugin/lib/src/generated/plugin.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pbenum.dart
@@ -3,10 +3,17 @@
 //  source: plugin.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
-// ignore_for_file: UNDEFINED_SHOWN_NAME
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
+
+// ignore_for_file: undefined_shown_name
 import 'dart:core' as $core;
+
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class CodeGeneratorResponse_Feature extends $pb.ProtobufEnum {

--- a/protoc_plugin/lib/src/message_generator.dart
+++ b/protoc_plugin/lib/src/message_generator.dart
@@ -370,6 +370,8 @@ class MessageGenerator extends ProtobufContainer {
       out.println('factory $classname.fromJson($coreImportPrefix.String i,'
           ' [$protobufImportPrefix.ExtensionRegistry r = $protobufImportPrefix.ExtensionRegistry.EMPTY])'
           ' => create()..mergeFromJson(i, r);');
+
+      out.println('');
       out.println('''@$coreImportPrefix.Deprecated(
 'Using this can add significant overhead to your binary. '
 'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -385,9 +387,11 @@ class MessageGenerator extends ProtobufContainer {
           ' as $classname;'
           ' // ignore: deprecated_member_use');
 
+      out.println('');
       out.println('$protobufImportPrefix.BuilderInfo get info_ => _i;');
 
       // Factory functions which can be used as default value closures.
+      out.println('');
       out.println("@$coreImportPrefix.pragma('dart2js:noInline')");
       out.println('static $classname create() => $classname._();');
       out.println('$classname createEmptyInstance() => create();');

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -3,7 +3,13 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 
@@ -18,6 +24,7 @@ class Empty extends $pb.GeneratedMessage {
   factory Empty() => create();
   factory Empty.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory Empty.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -28,7 +35,9 @@ class Empty extends $pb.GeneratedMessage {
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
   Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)) as Empty; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Empty create() => Empty._();
   Empty createEmptyInstance() => create();

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -3,7 +3,13 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:async' as $async;
 

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -3,7 +3,13 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -3,7 +3,13 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -3,7 +3,13 @@
 //  source: test.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 
@@ -24,6 +30,7 @@ class M extends $pb.GeneratedMessage {
   factory M() => create();
   factory M.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory M.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -34,7 +41,9 @@ class M extends $pb.GeneratedMessage {
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
   M copyWith(void Function(M) updates) => super.copyWith((message) => updates(message as M)) as M; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static M create() => M._();
   M createEmptyInstance() => create();

--- a/protoc_plugin/test/goldens/imports.pbjson
+++ b/protoc_plugin/test/goldens/imports.pbjson
@@ -3,5 +3,11 @@
 //  source: test.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -3,7 +3,13 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 
@@ -20,6 +26,7 @@ class Int64 extends $pb.GeneratedMessage {
   factory Int64() => create();
   factory Int64.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory Int64.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -30,7 +37,9 @@ class Int64 extends $pb.GeneratedMessage {
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
   Int64 copyWith(void Function(Int64) updates) => super.copyWith((message) => updates(message as Int64)) as Int64; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Int64 create() => Int64._();
   Int64 createEmptyInstance() => create();

--- a/protoc_plugin/test/goldens/messageGenerator
+++ b/protoc_plugin/test/goldens/messageGenerator
@@ -10,6 +10,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   factory PhoneNumber() => create();
   factory PhoneNumber.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory PhoneNumber.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -20,7 +21,9 @@ class PhoneNumber extends $pb.GeneratedMessage {
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
   PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber)) as PhoneNumber; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PhoneNumber create() => PhoneNumber._();
   PhoneNumber createEmptyInstance() => create();

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2263
-  end: 2269
+  begin: 2266
+  end: 2272
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2311
-  end: 2317
+  begin: 2314
+  end: 2320
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2390
-  end: 2399
+  begin: 2393
+  end: 2402
 }
 annotation: {
   path: 4
@@ -45,8 +45,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2442
-  end: 2453
+  begin: 2445
+  end: 2456
 }
 annotation: {
   path: 4
@@ -54,8 +54,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2523
-  end: 2527
+  begin: 2526
+  end: 2530
 }
 annotation: {
   path: 4
@@ -63,8 +63,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2568
-  end: 2572
+  begin: 2571
+  end: 2575
 }
 annotation: {
   path: 4
@@ -72,8 +72,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2651
-  end: 2658
+  begin: 2654
+  end: 2661
 }
 annotation: {
   path: 4
@@ -81,8 +81,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2701
-  end: 2710
+  begin: 2704
+  end: 2713
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2771
-  end: 2775
+  begin: 2774
+  end: 2778
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2822
-  end: 2826
+  begin: 2825
+  end: 2829
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2899
-  end: 2906
+  begin: 2902
+  end: 2909
 }
 annotation: {
   path: 4
@@ -117,17 +117,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2949
-  end: 2958
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 3068
-  end: 3083
+  begin: 2952
+  end: 2961
 }
 annotation: {
   path: 4
@@ -135,8 +126,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3174
-  end: 3189
+  begin: 3071
+  end: 3086
 }
 annotation: {
   path: 4
@@ -144,8 +135,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3311
-  end: 3329
+  begin: 3177
+  end: 3192
 }
 annotation: {
   path: 4
@@ -153,6 +144,15 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3421
-  end: 3441
+  begin: 3314
+  end: 3332
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 3424
+  end: 3444
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -3,7 +3,13 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 
@@ -20,6 +26,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   factory PhoneNumber() => create();
   factory PhoneNumber.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory PhoneNumber.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -30,7 +37,9 @@ class PhoneNumber extends $pb.GeneratedMessage {
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
   PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber)) as PhoneNumber; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PhoneNumber create() => PhoneNumber._();
   PhoneNumber createEmptyInstance() => create();

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 439
-  end: 450
+  begin: 547
+  end: 558
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 1011
-  end: 1022
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2455
-  end: 2461
+  begin: 1119
+  end: 1130
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2503
-  end: 2509
+  begin: 2566
+  end: 2572
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2582
-  end: 2591
+  begin: 2614
+  end: 2620
 }
 annotation: {
   path: 4
@@ -45,17 +36,17 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2634
-  end: 2645
+  begin: 2693
+  end: 2702
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: test
-  begin: 2703
-  end: 2707
+  begin: 2745
+  end: 2756
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2749
-  end: 2753
+  begin: 2814
+  end: 2818
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2828
-  end: 2835
+  begin: 2860
+  end: 2864
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2878
-  end: 2887
+  begin: 2939
+  end: 2946
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2989
+  end: 2998
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2948
-  end: 2952
+  begin: 3059
+  end: 3063
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2999
-  end: 3003
+  begin: 3110
+  end: 3114
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3076
-  end: 3083
+  begin: 3187
+  end: 3194
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3126
-  end: 3135
+  begin: 3237
+  end: 3246
 }

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -3,7 +3,14 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -3,7 +3,13 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;
@@ -19,6 +25,7 @@ class Empty extends $pb.GeneratedMessage {
   factory Empty() => create();
   factory Empty.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory Empty.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -29,7 +36,9 @@ class Empty extends $pb.GeneratedMessage {
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
   Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)) as Empty; // ignore: deprecated_member_use
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Empty create() => Empty._();
   Empty createEmptyInstance() => create();

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -3,7 +3,14 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:async' as $async;
 

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -3,7 +3,14 @@
 //  source: testpkg.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -3,7 +3,13 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -3,10 +3,17 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
-// ignore_for_file: UNDEFINED_SHOWN_NAME
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
+
+// ignore_for_file: undefined_shown_name
 import 'dart:core' as $core;
+
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class PhoneType extends $pb.ProtobufEnum {

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 479
-  end: 488
+  begin: 588
+  end: 597
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 541
-  end: 547
+  begin: 650
+  end: 656
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 669
-  end: 673
+  begin: 778
+  end: 782
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 793
-  end: 797
+  begin: 902
+  end: 906
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 918
-  end: 926
+  begin: 1027
+  end: 1035
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -3,7 +3,14 @@
 //  source: test
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;


### PR DESCRIPTION
- pretty-print the `// ignore_for_file: xxx` lines (ensure they don't exceed 80 chars)
- add a few blank lines in the generated method bodies to make them easier to read

Most of the changes in this PR are in the golden test files.

cc @osa1 