### PR TITLE
Use shared consts for bool.fromEnvironment expressions

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -24,6 +24,10 @@
   `.pbenum.dart` files, same as `.pb.dart` files. ([9aad6aa])
 * Fix decoding map fields when key or value (or both) fields of a map entry is
   missing. ([#719], [#745])
+* Generated files now split `ignore_for_file` comments across multiple lines
+  when necessary.
+* Generated files now uses shared consts to eliminate repeated
+  `bool.fromEnvironment()` expressions.
 
 [#679]: https://github.com/google/protobuf.dart/pull/679
 [#703]: https://github.com/google/protobuf.dart/pull/703

--- a/protoc_plugin/Makefile
+++ b/protoc_plugin/Makefile
@@ -103,6 +103,10 @@ protos: $(PLUGIN_PATH) $(TEST_PROTO_LIBS)
 run-tests: protos
 	dart run test
 
+update-goldens: protos
+	rm -rf test/goldens
+	dart run test
+
 clean:
 	rm -rf benchmark/lib/generated
 	rm -rf $(OUTPUT_DIR)

--- a/protoc_plugin/analysis_options.yaml
+++ b/protoc_plugin/analysis_options.yaml
@@ -1,15 +1,20 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
 
 linter:
   rules:
+    - always_declare_return_types
+    - avoid_bool_literals_in_conditional_expressions
     - camel_case_types
     - comment_references
     - directives_ordering
     - omit_local_variable_types
     - prefer_relative_imports
     - prefer_single_quotes
+    - sort_pub_dependencies
     - throw_in_finally
+    - type_annotate_public_apis
+    - unawaited_futures

--- a/protoc_plugin/lib/const_generator.dart
+++ b/protoc_plugin/lib/const_generator.dart
@@ -7,7 +7,7 @@ import 'string_escape.dart';
 
 /// Writes JSON data as a Dart constant expression.
 /// Accepts null, bool, num, String, and maps and lists.
-void writeJsonConst(IndentingWriter out, val) {
+void writeJsonConst(IndentingWriter out, Object? val) {
   if (val is Map) {
     if (val.values.any(_nonEmptyListOrMap)) {
       out.addBlock(

--- a/protoc_plugin/lib/indenting_writer.dart
+++ b/protoc_plugin/lib/indenting_writer.dart
@@ -27,6 +27,9 @@ class IndentingWriter {
   int _previousOffset = 0;
   final String? _sourceFile;
 
+  // Named text sections to write at the end of the file.
+  Map<String, String> suffixes = {};
+
   IndentingWriter({String? filename}) : _sourceFile = filename;
 
   /// Appends a string indented to the current level.
@@ -101,8 +104,23 @@ class IndentingWriter {
     }
   }
 
+  void addSuffix(String suffixName, String text) {
+    suffixes[suffixName] = text;
+  }
+
   @override
-  String toString() => _buffer.toString();
+  String toString() {
+    if (suffixes.isNotEmpty) {
+      // TODO: We may want to introduce the notion of closing the file stream.
+      println('');
+      for (var key in suffixes.keys.toList()..sort()) {
+        println(suffixes[key]!);
+      }
+      suffixes.clear();
+    }
+
+    return _buffer.toString();
+  }
 
   /// Writes part of a line of text.
   /// Adds indentation if we're at the start of a line.

--- a/protoc_plugin/lib/src/code_generator.dart
+++ b/protoc_plugin/lib/src/code_generator.dart
@@ -107,7 +107,7 @@ class CodeGenerator {
 
       var response = CodeGeneratorResponse();
 
-      // Parse the options in the request. Return the errors is any.
+      // Parse the options in the request. Return the errors if any.
       var options = parseGenerationOptions(request, response, optionParsers);
       if (options == null) {
         _streamOut.add(response.writeToBuffer());

--- a/protoc_plugin/lib/src/enum_generator.dart
+++ b/protoc_plugin/lib/src/enum_generator.dart
@@ -116,8 +116,10 @@ class EnumGenerator extends ProtobufContainer {
       for (var i = 0; i < _canonicalValues.length; i++) {
         var val = _canonicalValues[i];
         final name = dartNames[val.name]!;
-        final conditionalValName = configurationDependent(
-            'protobuf.omit_enum_names', quoted(val.name));
+        final omitEnumNames = ConditionalConstDefinition('omit_enum_names');
+        out.addSuffix(
+            omitEnumNames.constFieldName, omitEnumNames.constDefinition);
+        final conditionalValName = omitEnumNames.createTernary(val.name);
         out.printlnAnnotated(
             'static const $classname $name = '
             '$classname._(${val.number}, $conditionalValName);',

--- a/protoc_plugin/lib/src/extension_generator.dart
+++ b/protoc_plugin/lib/src/extension_generator.dart
@@ -90,12 +90,18 @@ class ExtensionGenerator {
     if (!_resolved) throw StateError('resolve not called');
 
     var name = _extensionName;
-    final conditionalName = configurationDependent(
-        'protobuf.omit_field_names', quoted(_extensionName));
     var type = _field.baseType;
     var dartType = type.getDartType(fileGen!);
-    final conditionalExtendedName = configurationDependent(
-        'protobuf.omit_message_names', quoted(_extendedFullName));
+
+    final omitFieldNames = ConditionalConstDefinition('omit_field_names');
+    out.addSuffix(
+        omitFieldNames.constFieldName, omitFieldNames.constDefinition);
+    final conditionalName = omitFieldNames.createTernary(_extensionName);
+    final omitMessageNames = ConditionalConstDefinition('omit_message_names');
+    out.addSuffix(
+        omitMessageNames.constFieldName, omitMessageNames.constDefinition);
+    final conditionalExtendedName =
+        omitMessageNames.createTernary(_extendedFullName);
 
     String invocation;
     var positionals = <String>[];

--- a/protoc_plugin/lib/src/generated/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/generated/dart_options.pb.dart
@@ -17,29 +17,12 @@ import 'package:protobuf/protobuf.dart' as $pb;
 
 class DartMixin extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DartMixin',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'dart_options'),
+      _omitMessageNames ? '' : 'DartMixin',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'dart_options'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'importFrom')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'parent')
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOS(2, _omitFieldNames ? '' : 'importFrom')
+    ..aOS(3, _omitFieldNames ? '' : 'parent')
     ..hasRequiredFields = false;
 
   DartMixin._() : super();
@@ -112,20 +95,10 @@ class DartMixin extends $pb.GeneratedMessage {
 
 class Imports extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Imports',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'dart_options'),
+      _omitMessageNames ? '' : 'Imports',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'dart_options'),
       createEmptyInstance: create)
-    ..pc<DartMixin>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'mixins',
-        $pb.PbFieldType.PM,
+    ..pc<DartMixin>(1, _omitFieldNames ? '' : 'mixins', $pb.PbFieldType.PM,
         subBuilder: DartMixin.create)
     ..hasRequiredFields = false;
 
@@ -166,77 +139,45 @@ class Imports extends $pb.GeneratedMessage {
 
 class Dart_options {
   static final imports = $pb.Extension<Imports>(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'google.protobuf.FileOptions',
-      const $core.bool.fromEnvironment('protobuf.omit_field_names')
-          ? ''
-          : 'imports',
+      _omitMessageNames ? '' : 'google.protobuf.FileOptions',
+      _omitFieldNames ? '' : 'imports',
       28125061,
       $pb.PbFieldType.OM,
       defaultOrMaker: Imports.getDefault,
       subBuilder: Imports.create);
   static final defaultMixin = $pb.Extension<$core.String>(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'google.protobuf.FileOptions',
-      const $core.bool.fromEnvironment('protobuf.omit_field_names')
-          ? ''
-          : 'defaultMixin',
+      _omitMessageNames ? '' : 'google.protobuf.FileOptions',
+      _omitFieldNames ? '' : 'defaultMixin',
       96128839,
       $pb.PbFieldType.OS);
   static final mixin = $pb.Extension<$core.String>(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'google.protobuf.MessageOptions',
-      const $core.bool.fromEnvironment('protobuf.omit_field_names')
-          ? ''
-          : 'mixin',
+      _omitMessageNames ? '' : 'google.protobuf.MessageOptions',
+      _omitFieldNames ? '' : 'mixin',
       96128839,
       $pb.PbFieldType.OS);
   static final overrideGetter = $pb.Extension<$core.bool>(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'google.protobuf.FieldOptions',
-      const $core.bool.fromEnvironment('protobuf.omit_field_names')
-          ? ''
-          : 'overrideGetter',
+      _omitMessageNames ? '' : 'google.protobuf.FieldOptions',
+      _omitFieldNames ? '' : 'overrideGetter',
       28205290,
       $pb.PbFieldType.OB);
   static final overrideSetter = $pb.Extension<$core.bool>(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'google.protobuf.FieldOptions',
-      const $core.bool.fromEnvironment('protobuf.omit_field_names')
-          ? ''
-          : 'overrideSetter',
+      _omitMessageNames ? '' : 'google.protobuf.FieldOptions',
+      _omitFieldNames ? '' : 'overrideSetter',
       28937366,
       $pb.PbFieldType.OB);
   static final overrideHasMethod = $pb.Extension<$core.bool>(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'google.protobuf.FieldOptions',
-      const $core.bool.fromEnvironment('protobuf.omit_field_names')
-          ? ''
-          : 'overrideHasMethod',
+      _omitMessageNames ? '' : 'google.protobuf.FieldOptions',
+      _omitFieldNames ? '' : 'overrideHasMethod',
       28937461,
       $pb.PbFieldType.OB);
   static final overrideClearMethod = $pb.Extension<$core.bool>(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'google.protobuf.FieldOptions',
-      const $core.bool.fromEnvironment('protobuf.omit_field_names')
-          ? ''
-          : 'overrideClearMethod',
+      _omitMessageNames ? '' : 'google.protobuf.FieldOptions',
+      _omitFieldNames ? '' : 'overrideClearMethod',
       28907907,
       $pb.PbFieldType.OB);
   static final dartName = $pb.Extension<$core.String>(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'google.protobuf.FieldOptions',
-      const $core.bool.fromEnvironment('protobuf.omit_field_names')
-          ? ''
-          : 'dartName',
+      _omitMessageNames ? '' : 'google.protobuf.FieldOptions',
+      _omitFieldNames ? '' : 'dartName',
       28700919,
       $pb.PbFieldType.OS);
   static void registerAllExtensions($pb.ExtensionRegistry registry) {
@@ -250,3 +191,7 @@ class Dart_options {
     registry.add(dartName);
   }
 }
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/lib/src/generated/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pb.dart
@@ -22,20 +22,12 @@ export 'descriptor.pbenum.dart';
 
 class FileDescriptorSet extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'FileDescriptorSet',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'FileDescriptorSet',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<FileDescriptorProto>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'file',
-        $pb.PbFieldType.PM,
+        1, _omitFieldNames ? '' : 'file', $pb.PbFieldType.PM,
         subBuilder: FileDescriptorProto.create);
 
   FileDescriptorSet._() : super();
@@ -76,86 +68,34 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
 
 class FileDescriptorProto extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'FileDescriptorProto',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'FileDescriptorProto',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'package')
-    ..pPS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'dependency')
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOS(2, _omitFieldNames ? '' : 'package')
+    ..pPS(3, _omitFieldNames ? '' : 'dependency')
     ..pc<DescriptorProto>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'messageType',
-        $pb.PbFieldType.PM,
+        4, _omitFieldNames ? '' : 'messageType', $pb.PbFieldType.PM,
         subBuilder: DescriptorProto.create)
     ..pc<EnumDescriptorProto>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'enumType',
-        $pb.PbFieldType.PM,
+        5, _omitFieldNames ? '' : 'enumType', $pb.PbFieldType.PM,
         subBuilder: EnumDescriptorProto.create)
     ..pc<ServiceDescriptorProto>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'service',
-        $pb.PbFieldType.PM,
+        6, _omitFieldNames ? '' : 'service', $pb.PbFieldType.PM,
         subBuilder: ServiceDescriptorProto.create)
     ..pc<FieldDescriptorProto>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'extension',
-        $pb.PbFieldType.PM,
+        7, _omitFieldNames ? '' : 'extension', $pb.PbFieldType.PM,
         subBuilder: FieldDescriptorProto.create)
-    ..aOM<FileOptions>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'options',
+    ..aOM<FileOptions>(8, _omitFieldNames ? '' : 'options',
         subBuilder: FileOptions.create)
-    ..aOM<SourceCodeInfo>(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'sourceCodeInfo',
+    ..aOM<SourceCodeInfo>(9, _omitFieldNames ? '' : 'sourceCodeInfo',
         subBuilder: SourceCodeInfo.create)
     ..p<$core.int>(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'publicDependency',
-        $pb.PbFieldType.P3)
+        10, _omitFieldNames ? '' : 'publicDependency', $pb.PbFieldType.P3)
     ..p<$core.int>(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'weakDependency',
-        $pb.PbFieldType.P3)
-    ..aOS(
-        12,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'syntax');
+        11, _omitFieldNames ? '' : 'weakDependency', $pb.PbFieldType.P3)
+    ..aOS(12, _omitFieldNames ? '' : 'syntax');
 
   FileDescriptorProto._() : super();
   factory FileDescriptorProto() => create();
@@ -277,31 +217,13 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
 
 class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DescriptorProto.ExtensionRange',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'DescriptorProto.ExtensionRange',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'start',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'end',
-        $pb.PbFieldType.O3)
-    ..aOM<ExtensionRangeOptions>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'options',
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'start', $pb.PbFieldType.O3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'end', $pb.PbFieldType.O3)
+    ..aOM<ExtensionRangeOptions>(3, _omitFieldNames ? '' : 'options',
         subBuilder: ExtensionRangeOptions.create);
 
   DescriptorProto_ExtensionRange._() : super();
@@ -381,26 +303,12 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
 
 class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DescriptorProto.ReservedRange',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'DescriptorProto.ReservedRange',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'start',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'end',
-        $pb.PbFieldType.O3)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'start', $pb.PbFieldType.O3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'end', $pb.PbFieldType.O3)
     ..hasRequiredFields = false;
 
   DescriptorProto_ReservedRange._() : super();
@@ -466,79 +374,35 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
 
 class DescriptorProto extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DescriptorProto',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'DescriptorProto',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
+    ..aOS(1, _omitFieldNames ? '' : 'name')
     ..pc<FieldDescriptorProto>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'field',
-        $pb.PbFieldType.PM,
+        2, _omitFieldNames ? '' : 'field', $pb.PbFieldType.PM,
         subBuilder: FieldDescriptorProto.create)
     ..pc<DescriptorProto>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'nestedType',
-        $pb.PbFieldType.PM,
+        3, _omitFieldNames ? '' : 'nestedType', $pb.PbFieldType.PM,
         subBuilder: DescriptorProto.create)
     ..pc<EnumDescriptorProto>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'enumType',
-        $pb.PbFieldType.PM,
+        4, _omitFieldNames ? '' : 'enumType', $pb.PbFieldType.PM,
         subBuilder: EnumDescriptorProto.create)
     ..pc<DescriptorProto_ExtensionRange>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'extensionRange',
-        $pb.PbFieldType.PM,
+        5, _omitFieldNames ? '' : 'extensionRange', $pb.PbFieldType.PM,
         subBuilder: DescriptorProto_ExtensionRange.create)
     ..pc<FieldDescriptorProto>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'extension',
-        $pb.PbFieldType.PM,
+        6, _omitFieldNames ? '' : 'extension', $pb.PbFieldType.PM,
         subBuilder: FieldDescriptorProto.create)
-    ..aOM<MessageOptions>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'options',
+    ..aOM<MessageOptions>(7, _omitFieldNames ? '' : 'options',
         subBuilder: MessageOptions.create)
     ..pc<OneofDescriptorProto>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'oneofDecl',
-        $pb.PbFieldType.PM,
+        8, _omitFieldNames ? '' : 'oneofDecl', $pb.PbFieldType.PM,
         subBuilder: OneofDescriptorProto.create)
     ..pc<DescriptorProto_ReservedRange>(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'reservedRange',
-        $pb.PbFieldType.PM,
+        9, _omitFieldNames ? '' : 'reservedRange', $pb.PbFieldType.PM,
         subBuilder: DescriptorProto_ReservedRange.create)
-    ..pPS(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'reservedName');
+    ..pPS(10, _omitFieldNames ? '' : 'reservedName');
 
   DescriptorProto._() : super();
   factory DescriptorProto() => create();
@@ -625,20 +489,12 @@ class DescriptorProto extends $pb.GeneratedMessage {
 
 class ExtensionRangeOptions extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ExtensionRangeOptions',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'ExtensionRangeOptions',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<UninterpretedOption>(
-        999,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'uninterpretedOption',
-        $pb.PbFieldType.PM,
+        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -682,80 +538,30 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
 
 class FieldDescriptorProto extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'FieldDescriptorProto',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'FieldDescriptorProto',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'extendee')
-    ..a<$core.int>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'number',
-        $pb.PbFieldType.O3)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOS(2, _omitFieldNames ? '' : 'extendee')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'number', $pb.PbFieldType.O3)
     ..e<FieldDescriptorProto_Label>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'label',
-        $pb.PbFieldType.OE,
+        4, _omitFieldNames ? '' : 'label', $pb.PbFieldType.OE,
         defaultOrMaker: FieldDescriptorProto_Label.LABEL_OPTIONAL,
         valueOf: FieldDescriptorProto_Label.valueOf,
         enumValues: FieldDescriptorProto_Label.values)
     ..e<FieldDescriptorProto_Type>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'type',
-        $pb.PbFieldType.OE,
+        5, _omitFieldNames ? '' : 'type', $pb.PbFieldType.OE,
         defaultOrMaker: FieldDescriptorProto_Type.TYPE_DOUBLE,
         valueOf: FieldDescriptorProto_Type.valueOf,
         enumValues: FieldDescriptorProto_Type.values)
-    ..aOS(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'typeName')
-    ..aOS(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'defaultValue')
-    ..aOM<FieldOptions>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'options',
+    ..aOS(6, _omitFieldNames ? '' : 'typeName')
+    ..aOS(7, _omitFieldNames ? '' : 'defaultValue')
+    ..aOM<FieldOptions>(8, _omitFieldNames ? '' : 'options',
         subBuilder: FieldOptions.create)
-    ..a<$core.int>(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'oneofIndex',
-        $pb.PbFieldType.O3)
-    ..aOS(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'jsonName')
-    ..aOB(
-        17,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'proto3Optional');
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'oneofIndex', $pb.PbFieldType.O3)
+    ..aOS(10, _omitFieldNames ? '' : 'jsonName')
+    ..aOB(17, _omitFieldNames ? '' : 'proto3Optional');
 
   FieldDescriptorProto._() : super();
   factory FieldDescriptorProto() => create();
@@ -927,24 +733,12 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
 
 class OneofDescriptorProto extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'OneofDescriptorProto',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'OneofDescriptorProto',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..aOM<OneofOptions>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'options',
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOM<OneofOptions>(2, _omitFieldNames ? '' : 'options',
         subBuilder: OneofOptions.create);
 
   OneofDescriptorProto._() : super();
@@ -1009,26 +803,12 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
 
 class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'EnumDescriptorProto.EnumReservedRange',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'EnumDescriptorProto.EnumReservedRange',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'start',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'end',
-        $pb.PbFieldType.O3)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'start', $pb.PbFieldType.O3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'end', $pb.PbFieldType.O3)
     ..hasRequiredFields = false;
 
   EnumDescriptorProto_EnumReservedRange._() : super();
@@ -1096,44 +876,20 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
 
 class EnumDescriptorProto extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'EnumDescriptorProto',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'EnumDescriptorProto',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
+    ..aOS(1, _omitFieldNames ? '' : 'name')
     ..pc<EnumValueDescriptorProto>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value',
-        $pb.PbFieldType.PM,
+        2, _omitFieldNames ? '' : 'value', $pb.PbFieldType.PM,
         subBuilder: EnumValueDescriptorProto.create)
-    ..aOM<EnumOptions>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'options',
+    ..aOM<EnumOptions>(3, _omitFieldNames ? '' : 'options',
         subBuilder: EnumOptions.create)
     ..pc<EnumDescriptorProto_EnumReservedRange>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'reservedRange',
-        $pb.PbFieldType.PM,
+        4, _omitFieldNames ? '' : 'reservedRange', $pb.PbFieldType.PM,
         subBuilder: EnumDescriptorProto_EnumReservedRange.create)
-    ..pPS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'reservedName');
+    ..pPS(5, _omitFieldNames ? '' : 'reservedName');
 
   EnumDescriptorProto._() : super();
   factory EnumDescriptorProto() => create();
@@ -1206,30 +962,13 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
 
 class EnumValueDescriptorProto extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'EnumValueDescriptorProto',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'EnumValueDescriptorProto',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'number',
-        $pb.PbFieldType.O3)
-    ..aOM<EnumValueOptions>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'options',
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'number', $pb.PbFieldType.O3)
+    ..aOM<EnumValueOptions>(3, _omitFieldNames ? '' : 'options',
         subBuilder: EnumValueOptions.create);
 
   EnumValueDescriptorProto._() : super();
@@ -1307,31 +1046,15 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
 
 class ServiceDescriptorProto extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ServiceDescriptorProto',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'ServiceDescriptorProto',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
+    ..aOS(1, _omitFieldNames ? '' : 'name')
     ..pc<MethodDescriptorProto>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'method',
-        $pb.PbFieldType.PM,
+        2, _omitFieldNames ? '' : 'method', $pb.PbFieldType.PM,
         subBuilder: MethodDescriptorProto.create)
-    ..aOM<ServiceOptions>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'options',
+    ..aOM<ServiceOptions>(3, _omitFieldNames ? '' : 'options',
         subBuilder: ServiceOptions.create);
 
   ServiceDescriptorProto._() : super();
@@ -1400,45 +1123,17 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
 
 class MethodDescriptorProto extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MethodDescriptorProto',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'MethodDescriptorProto',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'inputType')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'outputType')
-    ..aOM<MethodOptions>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'options',
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOS(2, _omitFieldNames ? '' : 'inputType')
+    ..aOS(3, _omitFieldNames ? '' : 'outputType')
+    ..aOM<MethodOptions>(4, _omitFieldNames ? '' : 'options',
         subBuilder: MethodOptions.create)
-    ..aOB(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'clientStreaming')
-    ..aOB(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'serverStreaming');
+    ..aOB(5, _omitFieldNames ? '' : 'clientStreaming')
+    ..aOB(6, _omitFieldNames ? '' : 'serverStreaming');
 
   MethodDescriptorProto._() : super();
   factory MethodDescriptorProto() => create();
@@ -1551,126 +1246,38 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
 
 class FileOptions extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'FileOptions',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'FileOptions',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'javaPackage')
-    ..aOS(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'javaOuterClassname')
+    ..aOS(1, _omitFieldNames ? '' : 'javaPackage')
+    ..aOS(8, _omitFieldNames ? '' : 'javaOuterClassname')
     ..e<FileOptions_OptimizeMode>(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'optimizeFor',
-        $pb.PbFieldType.OE,
+        9, _omitFieldNames ? '' : 'optimizeFor', $pb.PbFieldType.OE,
         defaultOrMaker: FileOptions_OptimizeMode.SPEED,
         valueOf: FileOptions_OptimizeMode.valueOf,
         enumValues: FileOptions_OptimizeMode.values)
-    ..aOB(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'javaMultipleFiles')
-    ..aOS(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'goPackage')
-    ..aOB(
-        16,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ccGenericServices')
-    ..aOB(
-        17,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'javaGenericServices')
-    ..aOB(
-        18,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'pyGenericServices')
-    ..aOB(
-        20,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'javaGenerateEqualsAndHash')
-    ..aOB(
-        23,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deprecated')
-    ..aOB(
-        27,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'javaStringCheckUtf8')
+    ..aOB(10, _omitFieldNames ? '' : 'javaMultipleFiles')
+    ..aOS(11, _omitFieldNames ? '' : 'goPackage')
+    ..aOB(16, _omitFieldNames ? '' : 'ccGenericServices')
+    ..aOB(17, _omitFieldNames ? '' : 'javaGenericServices')
+    ..aOB(18, _omitFieldNames ? '' : 'pyGenericServices')
+    ..aOB(20, _omitFieldNames ? '' : 'javaGenerateEqualsAndHash')
+    ..aOB(23, _omitFieldNames ? '' : 'deprecated')
+    ..aOB(27, _omitFieldNames ? '' : 'javaStringCheckUtf8')
     ..a<$core.bool>(
-        31,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ccEnableArenas',
-        $pb.PbFieldType.OB,
+        31, _omitFieldNames ? '' : 'ccEnableArenas', $pb.PbFieldType.OB,
         defaultOrMaker: true)
-    ..aOS(
-        36,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'objcClassPrefix')
-    ..aOS(
-        37,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'csharpNamespace')
-    ..aOS(
-        39,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'swiftPrefix')
-    ..aOS(
-        40,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'phpClassPrefix')
-    ..aOS(
-        41,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'phpNamespace')
-    ..aOB(
-        42,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'phpGenericServices')
-    ..aOS(
-        44,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'phpMetadataNamespace')
-    ..aOS(
-        45,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'rubyPackage')
+    ..aOS(36, _omitFieldNames ? '' : 'objcClassPrefix')
+    ..aOS(37, _omitFieldNames ? '' : 'csharpNamespace')
+    ..aOS(39, _omitFieldNames ? '' : 'swiftPrefix')
+    ..aOS(40, _omitFieldNames ? '' : 'phpClassPrefix')
+    ..aOS(41, _omitFieldNames ? '' : 'phpNamespace')
+    ..aOB(42, _omitFieldNames ? '' : 'phpGenericServices')
+    ..aOS(44, _omitFieldNames ? '' : 'phpMetadataNamespace')
+    ..aOS(45, _omitFieldNames ? '' : 'rubyPackage')
     ..pc<UninterpretedOption>(
-        999,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'uninterpretedOption',
-        $pb.PbFieldType.PM,
+        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -1955,40 +1562,16 @@ class FileOptions extends $pb.GeneratedMessage {
 
 class MessageOptions extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MessageOptions',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'MessageOptions',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOB(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'messageSetWireFormat')
-    ..aOB(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'noStandardDescriptorAccessor')
-    ..aOB(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deprecated')
-    ..aOB(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'mapEntry')
+    ..aOB(1, _omitFieldNames ? '' : 'messageSetWireFormat')
+    ..aOB(2, _omitFieldNames ? '' : 'noStandardDescriptorAccessor')
+    ..aOB(3, _omitFieldNames ? '' : 'deprecated')
+    ..aOB(7, _omitFieldNames ? '' : 'mapEntry')
     ..pc<UninterpretedOption>(
-        999,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'uninterpretedOption',
-        $pb.PbFieldType.PM,
+        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2078,58 +1661,26 @@ class MessageOptions extends $pb.GeneratedMessage {
 
 class FieldOptions extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'FieldOptions',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'FieldOptions',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..e<FieldOptions_CType>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ctype',
-        $pb.PbFieldType.OE,
+        1, _omitFieldNames ? '' : 'ctype', $pb.PbFieldType.OE,
         defaultOrMaker: FieldOptions_CType.STRING,
         valueOf: FieldOptions_CType.valueOf,
         enumValues: FieldOptions_CType.values)
-    ..aOB(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'packed')
-    ..aOB(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deprecated')
-    ..aOB(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'lazy')
+    ..aOB(2, _omitFieldNames ? '' : 'packed')
+    ..aOB(3, _omitFieldNames ? '' : 'deprecated')
+    ..aOB(5, _omitFieldNames ? '' : 'lazy')
     ..e<FieldOptions_JSType>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'jstype',
-        $pb.PbFieldType.OE,
+        6, _omitFieldNames ? '' : 'jstype', $pb.PbFieldType.OE,
         defaultOrMaker: FieldOptions_JSType.JS_NORMAL,
         valueOf: FieldOptions_JSType.valueOf,
         enumValues: FieldOptions_JSType.values)
-    ..aOB(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'weak')
+    ..aOB(10, _omitFieldNames ? '' : 'weak')
     ..pc<UninterpretedOption>(
-        999,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'uninterpretedOption',
-        $pb.PbFieldType.PM,
+        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2243,20 +1794,12 @@ class FieldOptions extends $pb.GeneratedMessage {
 
 class OneofOptions extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'OneofOptions',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'OneofOptions',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<UninterpretedOption>(
-        999,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'uninterpretedOption',
-        $pb.PbFieldType.PM,
+        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2298,30 +1841,14 @@ class OneofOptions extends $pb.GeneratedMessage {
 
 class EnumOptions extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'EnumOptions',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'EnumOptions',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOB(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'allowAlias')
-    ..aOB(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deprecated')
+    ..aOB(2, _omitFieldNames ? '' : 'allowAlias')
+    ..aOB(3, _omitFieldNames ? '' : 'deprecated')
     ..pc<UninterpretedOption>(
-        999,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'uninterpretedOption',
-        $pb.PbFieldType.PM,
+        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2386,25 +1913,13 @@ class EnumOptions extends $pb.GeneratedMessage {
 
 class EnumValueOptions extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'EnumValueOptions',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'EnumValueOptions',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOB(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deprecated')
+    ..aOB(1, _omitFieldNames ? '' : 'deprecated')
     ..pc<UninterpretedOption>(
-        999,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'uninterpretedOption',
-        $pb.PbFieldType.PM,
+        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2458,25 +1973,13 @@ class EnumValueOptions extends $pb.GeneratedMessage {
 
 class ServiceOptions extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ServiceOptions',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'ServiceOptions',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOB(
-        33,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deprecated')
+    ..aOB(33, _omitFieldNames ? '' : 'deprecated')
     ..pc<UninterpretedOption>(
-        999,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'uninterpretedOption',
-        $pb.PbFieldType.PM,
+        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2530,34 +2033,18 @@ class ServiceOptions extends $pb.GeneratedMessage {
 
 class MethodOptions extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MethodOptions',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'MethodOptions',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOB(
-        33,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deprecated')
+    ..aOB(33, _omitFieldNames ? '' : 'deprecated')
     ..e<MethodOptions_IdempotencyLevel>(
-        34,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'idempotencyLevel',
-        $pb.PbFieldType.OE,
+        34, _omitFieldNames ? '' : 'idempotencyLevel', $pb.PbFieldType.OE,
         defaultOrMaker: MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN,
         valueOf: MethodOptions_IdempotencyLevel.valueOf,
         enumValues: MethodOptions_IdempotencyLevel.values)
     ..pc<UninterpretedOption>(
-        999,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'uninterpretedOption',
-        $pb.PbFieldType.PM,
+        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2623,25 +2110,13 @@ class MethodOptions extends $pb.GeneratedMessage {
 
 class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'UninterpretedOption.NamePart',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'UninterpretedOption.NamePart',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aQS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'namePart')
+    ..aQS(1, _omitFieldNames ? '' : 'namePart')
     ..a<$core.bool>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'isExtension',
-        $pb.PbFieldType.QB);
+        2, _omitFieldNames ? '' : 'isExtension', $pb.PbFieldType.QB);
 
   UninterpretedOption_NamePart._() : super();
   factory UninterpretedOption_NamePart() => create();
@@ -2706,55 +2181,23 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
 
 class UninterpretedOption extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'UninterpretedOption',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'UninterpretedOption',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<UninterpretedOption_NamePart>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name',
-        $pb.PbFieldType.PM,
+        2, _omitFieldNames ? '' : 'name', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption_NamePart.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'identifierValue')
+    ..aOS(3, _omitFieldNames ? '' : 'identifierValue')
     ..a<$fixnum.Int64>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'positiveIntValue',
-        $pb.PbFieldType.OU6,
+        4, _omitFieldNames ? '' : 'positiveIntValue', $pb.PbFieldType.OU6,
         defaultOrMaker: $fixnum.Int64.ZERO)
-    ..aInt64(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'negativeIntValue')
+    ..aInt64(5, _omitFieldNames ? '' : 'negativeIntValue')
     ..a<$core.double>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'doubleValue',
-        $pb.PbFieldType.OD)
+        6, _omitFieldNames ? '' : 'doubleValue', $pb.PbFieldType.OD)
     ..a<$core.List<$core.int>>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'stringValue',
-        $pb.PbFieldType.OY)
-    ..aOS(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'aggregateValue');
+        7, _omitFieldNames ? '' : 'stringValue', $pb.PbFieldType.OY)
+    ..aOS(8, _omitFieldNames ? '' : 'aggregateValue');
 
   UninterpretedOption._() : super();
   factory UninterpretedOption() => create();
@@ -2866,41 +2309,15 @@ class UninterpretedOption extends $pb.GeneratedMessage {
 
 class SourceCodeInfo_Location extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'SourceCodeInfo.Location',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'SourceCodeInfo.Location',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..p<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'path',
-        $pb.PbFieldType.K3)
-    ..p<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'span',
-        $pb.PbFieldType.K3)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leadingComments')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'trailingComments')
-    ..pPS(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leadingDetachedComments')
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'path', $pb.PbFieldType.K3)
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'span', $pb.PbFieldType.K3)
+    ..aOS(3, _omitFieldNames ? '' : 'leadingComments')
+    ..aOS(4, _omitFieldNames ? '' : 'trailingComments')
+    ..pPS(6, _omitFieldNames ? '' : 'leadingDetachedComments')
     ..hasRequiredFields = false;
 
   SourceCodeInfo_Location._() : super();
@@ -2973,20 +2390,12 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
 
 class SourceCodeInfo extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'SourceCodeInfo',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'SourceCodeInfo',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<SourceCodeInfo_Location>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'location',
-        $pb.PbFieldType.PM,
+        1, _omitFieldNames ? '' : 'location', $pb.PbFieldType.PM,
         subBuilder: SourceCodeInfo_Location.create)
     ..hasRequiredFields = false;
 
@@ -3028,37 +2437,14 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
 
 class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'GeneratedCodeInfo.Annotation',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'GeneratedCodeInfo.Annotation',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..p<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'path',
-        $pb.PbFieldType.K3)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'sourceFile')
-    ..a<$core.int>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'begin',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'end',
-        $pb.PbFieldType.O3)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'path', $pb.PbFieldType.K3)
+    ..aOS(2, _omitFieldNames ? '' : 'sourceFile')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'begin', $pb.PbFieldType.O3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'end', $pb.PbFieldType.O3)
     ..hasRequiredFields = false;
 
   GeneratedCodeInfo_Annotation._() : super();
@@ -3139,20 +2525,12 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
 
 class GeneratedCodeInfo extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'GeneratedCodeInfo',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'GeneratedCodeInfo',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<GeneratedCodeInfo_Annotation>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'annotation',
-        $pb.PbFieldType.PM,
+        1, _omitFieldNames ? '' : 'annotation', $pb.PbFieldType.PM,
         subBuilder: GeneratedCodeInfo_Annotation.create)
     ..hasRequiredFields = false;
 
@@ -3191,3 +2569,7 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.List<GeneratedCodeInfo_Annotation> get annotation => $_getList(0);
 }
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
@@ -8,123 +8,50 @@
 // ignore_for_file: constant_identifier_names, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: undefined_shown_name, unnecessary_const, unnecessary_import
+// ignore_for_file: unnecessary_this, unused_import, unused_shown_name
 
-// ignore_for_file: undefined_shown_name
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class FieldDescriptorProto_Type extends $pb.ProtobufEnum {
   static const FieldDescriptorProto_Type TYPE_DOUBLE =
-      FieldDescriptorProto_Type._(
-          1,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_DOUBLE');
+      FieldDescriptorProto_Type._(1, _omitEnumNames ? '' : 'TYPE_DOUBLE');
   static const FieldDescriptorProto_Type TYPE_FLOAT =
-      FieldDescriptorProto_Type._(
-          2,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_FLOAT');
+      FieldDescriptorProto_Type._(2, _omitEnumNames ? '' : 'TYPE_FLOAT');
   static const FieldDescriptorProto_Type TYPE_INT64 =
-      FieldDescriptorProto_Type._(
-          3,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_INT64');
+      FieldDescriptorProto_Type._(3, _omitEnumNames ? '' : 'TYPE_INT64');
   static const FieldDescriptorProto_Type TYPE_UINT64 =
-      FieldDescriptorProto_Type._(
-          4,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_UINT64');
+      FieldDescriptorProto_Type._(4, _omitEnumNames ? '' : 'TYPE_UINT64');
   static const FieldDescriptorProto_Type TYPE_INT32 =
-      FieldDescriptorProto_Type._(
-          5,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_INT32');
+      FieldDescriptorProto_Type._(5, _omitEnumNames ? '' : 'TYPE_INT32');
   static const FieldDescriptorProto_Type TYPE_FIXED64 =
-      FieldDescriptorProto_Type._(
-          6,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_FIXED64');
+      FieldDescriptorProto_Type._(6, _omitEnumNames ? '' : 'TYPE_FIXED64');
   static const FieldDescriptorProto_Type TYPE_FIXED32 =
-      FieldDescriptorProto_Type._(
-          7,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_FIXED32');
+      FieldDescriptorProto_Type._(7, _omitEnumNames ? '' : 'TYPE_FIXED32');
   static const FieldDescriptorProto_Type TYPE_BOOL =
-      FieldDescriptorProto_Type._(
-          8,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_BOOL');
+      FieldDescriptorProto_Type._(8, _omitEnumNames ? '' : 'TYPE_BOOL');
   static const FieldDescriptorProto_Type TYPE_STRING =
-      FieldDescriptorProto_Type._(
-          9,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_STRING');
+      FieldDescriptorProto_Type._(9, _omitEnumNames ? '' : 'TYPE_STRING');
   static const FieldDescriptorProto_Type TYPE_GROUP =
-      FieldDescriptorProto_Type._(
-          10,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_GROUP');
+      FieldDescriptorProto_Type._(10, _omitEnumNames ? '' : 'TYPE_GROUP');
   static const FieldDescriptorProto_Type TYPE_MESSAGE =
-      FieldDescriptorProto_Type._(
-          11,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_MESSAGE');
+      FieldDescriptorProto_Type._(11, _omitEnumNames ? '' : 'TYPE_MESSAGE');
   static const FieldDescriptorProto_Type TYPE_BYTES =
-      FieldDescriptorProto_Type._(
-          12,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_BYTES');
+      FieldDescriptorProto_Type._(12, _omitEnumNames ? '' : 'TYPE_BYTES');
   static const FieldDescriptorProto_Type TYPE_UINT32 =
-      FieldDescriptorProto_Type._(
-          13,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_UINT32');
+      FieldDescriptorProto_Type._(13, _omitEnumNames ? '' : 'TYPE_UINT32');
   static const FieldDescriptorProto_Type TYPE_ENUM =
-      FieldDescriptorProto_Type._(
-          14,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_ENUM');
+      FieldDescriptorProto_Type._(14, _omitEnumNames ? '' : 'TYPE_ENUM');
   static const FieldDescriptorProto_Type TYPE_SFIXED32 =
-      FieldDescriptorProto_Type._(
-          15,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_SFIXED32');
+      FieldDescriptorProto_Type._(15, _omitEnumNames ? '' : 'TYPE_SFIXED32');
   static const FieldDescriptorProto_Type TYPE_SFIXED64 =
-      FieldDescriptorProto_Type._(
-          16,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_SFIXED64');
+      FieldDescriptorProto_Type._(16, _omitEnumNames ? '' : 'TYPE_SFIXED64');
   static const FieldDescriptorProto_Type TYPE_SINT32 =
-      FieldDescriptorProto_Type._(
-          17,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_SINT32');
+      FieldDescriptorProto_Type._(17, _omitEnumNames ? '' : 'TYPE_SINT32');
   static const FieldDescriptorProto_Type TYPE_SINT64 =
-      FieldDescriptorProto_Type._(
-          18,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'TYPE_SINT64');
+      FieldDescriptorProto_Type._(18, _omitEnumNames ? '' : 'TYPE_SINT64');
 
   static const $core.List<FieldDescriptorProto_Type> values =
       <FieldDescriptorProto_Type>[
@@ -157,23 +84,11 @@ class FieldDescriptorProto_Type extends $pb.ProtobufEnum {
 
 class FieldDescriptorProto_Label extends $pb.ProtobufEnum {
   static const FieldDescriptorProto_Label LABEL_OPTIONAL =
-      FieldDescriptorProto_Label._(
-          1,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'LABEL_OPTIONAL');
+      FieldDescriptorProto_Label._(1, _omitEnumNames ? '' : 'LABEL_OPTIONAL');
   static const FieldDescriptorProto_Label LABEL_REQUIRED =
-      FieldDescriptorProto_Label._(
-          2,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'LABEL_REQUIRED');
+      FieldDescriptorProto_Label._(2, _omitEnumNames ? '' : 'LABEL_REQUIRED');
   static const FieldDescriptorProto_Label LABEL_REPEATED =
-      FieldDescriptorProto_Label._(
-          3,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'LABEL_REPEATED');
+      FieldDescriptorProto_Label._(3, _omitEnumNames ? '' : 'LABEL_REPEATED');
 
   static const $core.List<FieldDescriptorProto_Label> values =
       <FieldDescriptorProto_Label>[
@@ -191,22 +106,12 @@ class FieldDescriptorProto_Label extends $pb.ProtobufEnum {
 }
 
 class FileOptions_OptimizeMode extends $pb.ProtobufEnum {
-  static const FileOptions_OptimizeMode SPEED = FileOptions_OptimizeMode._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'SPEED');
-  static const FileOptions_OptimizeMode CODE_SIZE = FileOptions_OptimizeMode._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'CODE_SIZE');
+  static const FileOptions_OptimizeMode SPEED =
+      FileOptions_OptimizeMode._(1, _omitEnumNames ? '' : 'SPEED');
+  static const FileOptions_OptimizeMode CODE_SIZE =
+      FileOptions_OptimizeMode._(2, _omitEnumNames ? '' : 'CODE_SIZE');
   static const FileOptions_OptimizeMode LITE_RUNTIME =
-      FileOptions_OptimizeMode._(
-          3,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'LITE_RUNTIME');
+      FileOptions_OptimizeMode._(3, _omitEnumNames ? '' : 'LITE_RUNTIME');
 
   static const $core.List<FileOptions_OptimizeMode> values =
       <FileOptions_OptimizeMode>[
@@ -223,21 +128,12 @@ class FileOptions_OptimizeMode extends $pb.ProtobufEnum {
 }
 
 class FieldOptions_CType extends $pb.ProtobufEnum {
-  static const FieldOptions_CType STRING = FieldOptions_CType._(
-      0,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'STRING');
-  static const FieldOptions_CType CORD = FieldOptions_CType._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'CORD');
-  static const FieldOptions_CType STRING_PIECE = FieldOptions_CType._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'STRING_PIECE');
+  static const FieldOptions_CType STRING =
+      FieldOptions_CType._(0, _omitEnumNames ? '' : 'STRING');
+  static const FieldOptions_CType CORD =
+      FieldOptions_CType._(1, _omitEnumNames ? '' : 'CORD');
+  static const FieldOptions_CType STRING_PIECE =
+      FieldOptions_CType._(2, _omitEnumNames ? '' : 'STRING_PIECE');
 
   static const $core.List<FieldOptions_CType> values = <FieldOptions_CType>[
     STRING,
@@ -253,21 +149,12 @@ class FieldOptions_CType extends $pb.ProtobufEnum {
 }
 
 class FieldOptions_JSType extends $pb.ProtobufEnum {
-  static const FieldOptions_JSType JS_NORMAL = FieldOptions_JSType._(
-      0,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'JS_NORMAL');
-  static const FieldOptions_JSType JS_STRING = FieldOptions_JSType._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'JS_STRING');
-  static const FieldOptions_JSType JS_NUMBER = FieldOptions_JSType._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'JS_NUMBER');
+  static const FieldOptions_JSType JS_NORMAL =
+      FieldOptions_JSType._(0, _omitEnumNames ? '' : 'JS_NORMAL');
+  static const FieldOptions_JSType JS_STRING =
+      FieldOptions_JSType._(1, _omitEnumNames ? '' : 'JS_STRING');
+  static const FieldOptions_JSType JS_NUMBER =
+      FieldOptions_JSType._(2, _omitEnumNames ? '' : 'JS_NUMBER');
 
   static const $core.List<FieldOptions_JSType> values = <FieldOptions_JSType>[
     JS_NORMAL,
@@ -285,22 +172,12 @@ class FieldOptions_JSType extends $pb.ProtobufEnum {
 class MethodOptions_IdempotencyLevel extends $pb.ProtobufEnum {
   static const MethodOptions_IdempotencyLevel IDEMPOTENCY_UNKNOWN =
       MethodOptions_IdempotencyLevel._(
-          0,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'IDEMPOTENCY_UNKNOWN');
+          0, _omitEnumNames ? '' : 'IDEMPOTENCY_UNKNOWN');
   static const MethodOptions_IdempotencyLevel NO_SIDE_EFFECTS =
       MethodOptions_IdempotencyLevel._(
-          1,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'NO_SIDE_EFFECTS');
+          1, _omitEnumNames ? '' : 'NO_SIDE_EFFECTS');
   static const MethodOptions_IdempotencyLevel IDEMPOTENT =
-      MethodOptions_IdempotencyLevel._(
-          2,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'IDEMPOTENT');
+      MethodOptions_IdempotencyLevel._(2, _omitEnumNames ? '' : 'IDEMPOTENT');
 
   static const $core.List<MethodOptions_IdempotencyLevel> values =
       <MethodOptions_IdempotencyLevel>[
@@ -317,3 +194,5 @@ class MethodOptions_IdempotencyLevel extends $pb.ProtobufEnum {
   const MethodOptions_IdempotencyLevel._($core.int v, $core.String n)
       : super(v, n);
 }
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/protoc_plugin/lib/src/generated/plugin.pb.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pb.dart
@@ -22,37 +22,14 @@ export 'plugin.pbenum.dart';
 
 class Version extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Version',
+      _omitMessageNames ? '' : 'Version',
       package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf.compiler'),
+          _omitMessageNames ? '' : 'google.protobuf.compiler'),
       createEmptyInstance: create)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'major',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'minor',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'patch',
-        $pb.PbFieldType.O3)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'suffix')
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'major', $pb.PbFieldType.O3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'minor', $pb.PbFieldType.O3)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'patch', $pb.PbFieldType.O3)
+    ..aOS(4, _omitFieldNames ? '' : 'suffix')
     ..hasRequiredFields = false;
 
   Version._() : super();
@@ -137,36 +114,16 @@ class Version extends $pb.GeneratedMessage {
 
 class CodeGeneratorRequest extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'CodeGeneratorRequest',
+      _omitMessageNames ? '' : 'CodeGeneratorRequest',
       package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf.compiler'),
+          _omitMessageNames ? '' : 'google.protobuf.compiler'),
       createEmptyInstance: create)
-    ..pPS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'fileToGenerate')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'parameter')
-    ..aOM<Version>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'compilerVersion',
+    ..pPS(1, _omitFieldNames ? '' : 'fileToGenerate')
+    ..aOS(2, _omitFieldNames ? '' : 'parameter')
+    ..aOM<Version>(3, _omitFieldNames ? '' : 'compilerVersion',
         subBuilder: Version.create)
     ..pc<$0.FileDescriptorProto>(
-        15,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'protoFile',
-        $pb.PbFieldType.PM,
+        15, _omitFieldNames ? '' : 'protoFile', $pb.PbFieldType.PM,
         subBuilder: $0.FileDescriptorProto.create);
 
   CodeGeneratorRequest._() : super();
@@ -237,34 +194,14 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
 
 class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'CodeGeneratorResponse.File',
+      _omitMessageNames ? '' : 'CodeGeneratorResponse.File',
       package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf.compiler'),
+          _omitMessageNames ? '' : 'google.protobuf.compiler'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'insertionPoint')
-    ..aOS(
-        15,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'content')
-    ..aOM<$0.GeneratedCodeInfo>(
-        16,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'generatedCodeInfo',
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOS(2, _omitFieldNames ? '' : 'insertionPoint')
+    ..aOS(15, _omitFieldNames ? '' : 'content')
+    ..aOM<$0.GeneratedCodeInfo>(16, _omitFieldNames ? '' : 'generatedCodeInfo',
         subBuilder: $0.GeneratedCodeInfo.create)
     ..hasRequiredFields = false;
 
@@ -356,32 +293,16 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
 
 class CodeGeneratorResponse extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'CodeGeneratorResponse',
+      _omitMessageNames ? '' : 'CodeGeneratorResponse',
       package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf.compiler'),
+          _omitMessageNames ? '' : 'google.protobuf.compiler'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'error')
+    ..aOS(1, _omitFieldNames ? '' : 'error')
     ..a<$fixnum.Int64>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'supportedFeatures',
-        $pb.PbFieldType.OU6,
+        2, _omitFieldNames ? '' : 'supportedFeatures', $pb.PbFieldType.OU6,
         defaultOrMaker: $fixnum.Int64.ZERO)
     ..pc<CodeGeneratorResponse_File>(
-        15,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'file',
-        $pb.PbFieldType.PM,
+        15, _omitFieldNames ? '' : 'file', $pb.PbFieldType.PM,
         subBuilder: CodeGeneratorResponse_File.create)
     ..hasRequiredFields = false;
 
@@ -446,3 +367,7 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(15)
   $core.List<CodeGeneratorResponse_File> get file => $_getList(2);
 }
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/lib/src/generated/plugin.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pbenum.dart
@@ -8,27 +8,19 @@
 // ignore_for_file: constant_identifier_names, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: undefined_shown_name, unnecessary_const, unnecessary_import
+// ignore_for_file: unnecessary_this, unused_import, unused_shown_name
 
-// ignore_for_file: undefined_shown_name
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class CodeGeneratorResponse_Feature extends $pb.ProtobufEnum {
   static const CodeGeneratorResponse_Feature FEATURE_NONE =
-      CodeGeneratorResponse_Feature._(
-          0,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'FEATURE_NONE');
+      CodeGeneratorResponse_Feature._(0, _omitEnumNames ? '' : 'FEATURE_NONE');
   static const CodeGeneratorResponse_Feature FEATURE_PROTO3_OPTIONAL =
       CodeGeneratorResponse_Feature._(
-          1,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'FEATURE_PROTO3_OPTIONAL');
+          1, _omitEnumNames ? '' : 'FEATURE_PROTO3_OPTIONAL');
 
   static const $core.List<CodeGeneratorResponse_Feature> values =
       <CodeGeneratorResponse_Feature>[
@@ -44,3 +36,5 @@ class CodeGeneratorResponse_Feature extends $pb.ProtobufEnum {
   const CodeGeneratorResponse_Feature._($core.int v, $core.String n)
       : super(v, n);
 }
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/protoc_plugin/lib/src/protobuf_field.dart
+++ b/protoc_plugin/lib/src/protobuf_field.dart
@@ -183,12 +183,13 @@ class ProtobufField {
 
   /// Returns Dart code adding this field to a BuilderInfo object.
   /// The call will start with ".." and a method name.
-  String generateBuilderInfoCall(String package) {
+  void generateBuilderInfoCall(IndentingWriter out, String package) {
     assert(descriptor.hasJsonName());
-    var quotedName = configurationDependent(
-      'protobuf.omit_field_names',
-      quoted(descriptor.jsonName),
-    );
+
+    final omitFieldNames = ConditionalConstDefinition('omit_field_names');
+    out.addSuffix(
+        omitFieldNames.constFieldName, omitFieldNames.constDefinition);
+    final quotedName = omitFieldNames.createTernary(descriptor.jsonName);
 
     var type = baseType.getDartType(parent.fileGen!);
 
@@ -303,7 +304,9 @@ class ProtobufField {
         }
       }
     }
-    return '..$invocation(${_formatArguments(args, named)})';
+
+    var result = '..$invocation(${_formatArguments(args, named)})';
+    out.println(result);
   }
 
   /// Returns a Dart expression that evaluates to this field's default value.

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -12,10 +12,10 @@ dependencies:
   protobuf: ^2.0.0
 
 dev_dependencies:
-  test: ^1.16.0
+  collection: ^1.15.0
   lints: ^1.0.0
   matcher: ^0.12.10
-  collection: ^1.15.0
+  test: ^1.16.0
 
 executables:
   protoc-gen-dart: protoc_plugin

--- a/protoc_plugin/test/const_generator_test.dart
+++ b/protoc_plugin/test/const_generator_test.dart
@@ -6,7 +6,7 @@ import 'package:protoc_plugin/const_generator.dart';
 import 'package:protoc_plugin/indenting_writer.dart';
 import 'package:test/test.dart';
 
-String toConst(val) {
+String toConst(Object? val) {
   var out = IndentingWriter();
   writeJsonConst(out, val);
   return out.toString();

--- a/protoc_plugin/test/goldens/enum
+++ b/protoc_plugin/test/goldens/enum
@@ -1,7 +1,7 @@
 class PhoneType extends $pb.ProtobufEnum {
-  static const PhoneType MOBILE = PhoneType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'MOBILE');
-  static const PhoneType HOME = PhoneType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'HOME');
-  static const PhoneType WORK = PhoneType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'WORK');
+  static const PhoneType MOBILE = PhoneType._(0, _omitEnumNames ? '' : 'MOBILE');
+  static const PhoneType HOME = PhoneType._(1, _omitEnumNames ? '' : 'HOME');
+  static const PhoneType WORK = PhoneType._(2, _omitEnumNames ? '' : 'WORK');
 
   static const PhoneType BUSINESS = WORK;
 
@@ -17,3 +17,5 @@ class PhoneType extends $pb.ProtobufEnum {
   const PhoneType._($core.int v, $core.String n) : super(v, n);
 }
 
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/protoc_plugin/test/goldens/enum.meta
+++ b/protoc_plugin/test/goldens/enum.meta
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: sample.proto
-  begin: 196
-  end: 200
+  begin: 150
+  end: 154
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: sample.proto
-  begin: 320
-  end: 324
+  begin: 228
+  end: 232
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: sample.proto
-  begin: 445
-  end: 453
+  begin: 307
+  end: 315
 }

--- a/protoc_plugin/test/goldens/extension
+++ b/protoc_plugin/test/goldens/extension
@@ -1,1 +1,4 @@
-static final clientInfo = $pb.Extension<$core.String>(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Card', const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'clientInfo', 261486461, $pb.PbFieldType.OS);
+static final clientInfo = $pb.Extension<$core.String>(_omitMessageNames ? '' : 'Card', _omitFieldNames ? '' : 'clientInfo', 261486461, $pb.PbFieldType.OS);
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -16,7 +16,7 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class Empty extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Empty', createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Empty', createEmptyInstance: create)
     ..hasRequiredFields = false
   ;
 
@@ -47,3 +47,5 @@ class Empty extends $pb.GeneratedMessage {
   static Empty? _defaultInstance;
 }
 
+
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -19,10 +19,10 @@ import 'package1.pb.dart' as $1;
 import 'package2.pb.dart' as $2;
 
 class M extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'M', createEmptyInstance: create)
-    ..aOM<M>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'm', subBuilder: M.create)
-    ..aOM<$1.M>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'm1', subBuilder: $1.M.create)
-    ..aOM<$2.M>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'm2', subBuilder: $2.M.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'M', createEmptyInstance: create)
+    ..aOM<M>(1, _omitFieldNames ? '' : 'm', subBuilder: M.create)
+    ..aOM<$1.M>(2, _omitFieldNames ? '' : 'm1', subBuilder: $1.M.create)
+    ..aOM<$2.M>(3, _omitFieldNames ? '' : 'm2', subBuilder: $2.M.create)
     ..hasRequiredFields = false
   ;
 
@@ -86,3 +86,6 @@ class M extends $pb.GeneratedMessage {
   $2.M ensureM2() => $_ensure(2);
 }
 
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -17,8 +17,8 @@ import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class Int64 extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Int64', createEmptyInstance: create)
-    ..aInt64(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Int64', createEmptyInstance: create)
+    ..aInt64(1, _omitFieldNames ? '' : 'value')
     ..hasRequiredFields = false
   ;
 
@@ -58,3 +58,6 @@ class Int64 extends $pb.GeneratedMessage {
   void clearValue() => clearField(1);
 }
 
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/test/goldens/messageGenerator
+++ b/protoc_plugin/test/goldens/messageGenerator
@@ -1,9 +1,9 @@
 class PhoneNumber extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PhoneNumber', createEmptyInstance: create)
-    ..aQS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'number')
-    ..e<PhoneNumber_PhoneType>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: PhoneNumber_PhoneType.MOBILE, valueOf: PhoneNumber_PhoneType.valueOf, enumValues: PhoneNumber_PhoneType.values)
-    ..a<$core.String>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name', $pb.PbFieldType.OS, defaultOrMaker: '\$')
-    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deprecatedField')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PhoneNumber', createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'number')
+    ..e<PhoneNumber_PhoneType>(2, _omitFieldNames ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: PhoneNumber_PhoneType.MOBILE, valueOf: PhoneNumber_PhoneType.valueOf, enumValues: PhoneNumber_PhoneType.values)
+    ..a<$core.String>(3, _omitFieldNames ? '' : 'name', $pb.PbFieldType.OS, defaultOrMaker: '\$')
+    ..aOS(4, _omitFieldNames ? '' : 'deprecatedField')
   ;
 
   PhoneNumber._() : super();
@@ -73,3 +73,6 @@ class PhoneNumber extends $pb.GeneratedMessage {
   void clearDeprecatedField() => clearField(4);
 }
 
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -9,8 +9,8 @@ annotation: {
   path: 4
   path: 0
   sourceFile: 
-  begin: 819
-  end: 830
+  begin: 589
+  end: 600
 }
 annotation: {
   path: 4
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2266
-  end: 2272
+  begin: 2036
+  end: 2042
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2314
-  end: 2320
+  begin: 2084
+  end: 2090
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2393
-  end: 2402
+  begin: 2163
+  end: 2172
 }
 annotation: {
   path: 4
@@ -45,8 +45,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2445
-  end: 2456
+  begin: 2215
+  end: 2226
 }
 annotation: {
   path: 4
@@ -54,8 +54,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2526
-  end: 2530
+  begin: 2296
+  end: 2300
 }
 annotation: {
   path: 4
@@ -63,8 +63,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2571
-  end: 2575
+  begin: 2341
+  end: 2345
 }
 annotation: {
   path: 4
@@ -72,8 +72,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2654
-  end: 2661
+  begin: 2424
+  end: 2431
 }
 annotation: {
   path: 4
@@ -81,8 +81,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2704
-  end: 2713
+  begin: 2474
+  end: 2483
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2774
-  end: 2778
+  begin: 2544
+  end: 2548
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2825
-  end: 2829
+  begin: 2595
+  end: 2599
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2902
-  end: 2909
+  begin: 2672
+  end: 2679
 }
 annotation: {
   path: 4
@@ -117,17 +117,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2952
-  end: 2961
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 3071
-  end: 3086
+  begin: 2722
+  end: 2731
 }
 annotation: {
   path: 4
@@ -135,8 +126,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3177
-  end: 3192
+  begin: 2841
+  end: 2856
 }
 annotation: {
   path: 4
@@ -144,8 +135,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3314
-  end: 3332
+  begin: 2947
+  end: 2962
 }
 annotation: {
   path: 4
@@ -153,6 +144,15 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3424
-  end: 3444
+  begin: 3084
+  end: 3102
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 3194
+  end: 3214
 }

--- a/protoc_plugin/test/goldens/messageGeneratorEnums
+++ b/protoc_plugin/test/goldens/messageGeneratorEnums
@@ -1,7 +1,7 @@
 class PhoneNumber_PhoneType extends $pb.ProtobufEnum {
-  static const PhoneNumber_PhoneType MOBILE = PhoneNumber_PhoneType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'MOBILE');
-  static const PhoneNumber_PhoneType HOME = PhoneNumber_PhoneType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'HOME');
-  static const PhoneNumber_PhoneType WORK = PhoneNumber_PhoneType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'WORK');
+  static const PhoneNumber_PhoneType MOBILE = PhoneNumber_PhoneType._(0, _omitEnumNames ? '' : 'MOBILE');
+  static const PhoneNumber_PhoneType HOME = PhoneNumber_PhoneType._(1, _omitEnumNames ? '' : 'HOME');
+  static const PhoneNumber_PhoneType WORK = PhoneNumber_PhoneType._(2, _omitEnumNames ? '' : 'WORK');
 
   static const PhoneNumber_PhoneType BUSINESS = WORK;
 
@@ -17,3 +17,5 @@ class PhoneNumber_PhoneType extends $pb.ProtobufEnum {
   const PhoneNumber_PhoneType._($core.int v, $core.String n) : super(v, n);
 }
 
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/protoc_plugin/test/goldens/messageGeneratorEnums.meta
+++ b/protoc_plugin/test/goldens/messageGeneratorEnums.meta
@@ -26,8 +26,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 244
-  end: 248
+  begin: 198
+  end: 202
 }
 annotation: {
   path: 4
@@ -37,8 +37,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 392
-  end: 396
+  begin: 300
+  end: 304
 }
 annotation: {
   path: 4
@@ -48,6 +48,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 541
-  end: 549
+  begin: 403
+  end: 411
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -16,10 +16,10 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class PhoneNumber extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PhoneNumber', createEmptyInstance: create)
-    ..aQS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'number')
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.O3)
-    ..a<$core.String>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name', $pb.PbFieldType.OS, defaultOrMaker: '\$')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PhoneNumber', createEmptyInstance: create)
+    ..aQS(1, _omitFieldNames ? '' : 'number')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'type', $pb.PbFieldType.O3)
+    ..a<$core.String>(3, _omitFieldNames ? '' : 'name', $pb.PbFieldType.OS, defaultOrMaker: '\$')
   ;
 
   PhoneNumber._() : super();
@@ -76,3 +76,6 @@ class PhoneNumber extends $pb.GeneratedMessage {
   void clearName() => clearField(3);
 }
 
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -9,8 +9,8 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 1119
-  end: 1130
+  begin: 935
+  end: 946
 }
 annotation: {
   path: 4
@@ -18,35 +18,44 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2566
+  begin: 2382
+  end: 2388
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 2430
+  end: 2436
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 2509
+  end: 2518
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 2561
   end: 2572
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 0
+  path: 1
   sourceFile: test
-  begin: 2614
-  end: 2620
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2693
-  end: 2702
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2745
-  end: 2756
+  begin: 2630
+  end: 2634
 }
 annotation: {
   path: 4
@@ -54,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2814
-  end: 2818
+  begin: 2676
+  end: 2680
 }
 annotation: {
   path: 4
@@ -63,8 +72,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2860
-  end: 2864
+  begin: 2755
+  end: 2762
 }
 annotation: {
   path: 4
@@ -72,17 +81,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2939
-  end: 2946
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: test
-  begin: 2989
-  end: 2998
+  begin: 2805
+  end: 2814
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3059
-  end: 3063
+  begin: 2875
+  end: 2879
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3110
-  end: 3114
+  begin: 2926
+  end: 2930
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3187
-  end: 3194
+  begin: 3003
+  end: 3010
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3237
-  end: 3246
+  begin: 3053
+  end: 3062
 }

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -12,8 +12,8 @@
 // ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
-import 'dart:core' as $core;
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 @$core.Deprecated('Use phoneNumberDescriptor instead')
 const PhoneNumber$json = const {
@@ -27,3 +27,4 @@ const PhoneNumber$json = const {
 
 /// Descriptor for `PhoneNumber`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List phoneNumberDescriptor = $convert.base64Decode('CgtQaG9uZU51bWJlchIWCgZudW1iZXIYASACKAlSBm51bWJlchIUCgR0eXBlGAIgASgFMgBSBHR5cGUSFQoEbmFtZRgDIAEoCToBJFIEbmFtZQ==');
+

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -17,7 +17,7 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class Empty extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Empty', createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Empty', createEmptyInstance: create)
     ..hasRequiredFields = false
   ;
 
@@ -58,3 +58,5 @@ class TestApi {
   }
 }
 
+
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -12,8 +12,8 @@
 // ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
-import 'dart:core' as $core;
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 import 'foobar.pbjson.dart' as $1;
 
@@ -24,6 +24,7 @@ const SomeRequest$json = const {
 
 /// Descriptor for `SomeRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List someRequestDescriptor = $convert.base64Decode('CgtTb21lUmVxdWVzdA==');
+
 @$core.Deprecated('Use someReplyDescriptor instead')
 const SomeReply$json = const {
   '1': 'SomeReply',
@@ -31,6 +32,7 @@ const SomeReply$json = const {
 
 /// Descriptor for `SomeReply`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List someReplyDescriptor = $convert.base64Decode('CglTb21lUmVwbHk=');
+
 const $core.Map<$core.String, $core.dynamic> TestServiceBase$json = const {
   '1': 'Test',
   '2': const [
@@ -49,3 +51,4 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TestServic
 
 /// Descriptor for `Test`. Decode as a `google.protobuf.ServiceDescriptorProto`.
 final $typed_data.Uint8List testServiceDescriptor = $convert.base64Decode('CgRUZXN0EjMKB0FNZXRob2QSFC50ZXN0cGtnLlNvbWVSZXF1ZXN0GhIudGVzdHBrZy5Tb21lUmVwbHkSPQoNQW5vdGhlck1ldGhvZBIVLmZvby5iYXIuRW1wdHlNZXNzYWdlGhUuZm9vLmJhci5Bbm90aGVyUmVwbHk=');
+

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -8,18 +8,17 @@
 // ignore_for_file: constant_identifier_names, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: undefined_shown_name, unnecessary_const, unnecessary_import
+// ignore_for_file: unnecessary_this, unused_import, unused_shown_name
 
-// ignore_for_file: undefined_shown_name
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class PhoneType extends $pb.ProtobufEnum {
-  static const PhoneType MOBILE = PhoneType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'MOBILE');
-  static const PhoneType HOME = PhoneType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'HOME');
-  static const PhoneType WORK = PhoneType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'WORK');
+  static const PhoneType MOBILE = PhoneType._(0, _omitEnumNames ? '' : 'MOBILE');
+  static const PhoneType HOME = PhoneType._(1, _omitEnumNames ? '' : 'HOME');
+  static const PhoneType WORK = PhoneType._(2, _omitEnumNames ? '' : 'WORK');
 
   static const PhoneType BUSINESS = WORK;
 
@@ -35,3 +34,5 @@ class PhoneType extends $pb.ProtobufEnum {
   const PhoneType._($core.int v, $core.String n) : super(v, n);
 }
 
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 588
-  end: 597
+  begin: 569
+  end: 578
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 650
-  end: 656
+  begin: 631
+  end: 637
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 778
-  end: 782
+  begin: 713
+  end: 717
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 902
-  end: 906
+  begin: 791
+  end: 795
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 1027
-  end: 1035
+  begin: 870
+  end: 878
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -12,8 +12,8 @@
 // ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
-import 'dart:core' as $core;
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 @$core.Deprecated('Use phoneTypeDescriptor instead')
 const PhoneType$json = const {
@@ -28,3 +28,4 @@ const PhoneType$json = const {
 
 /// Descriptor for `PhoneType`. Decode as a `google.protobuf.EnumDescriptorProto`.
 final $typed_data.Uint8List phoneTypeDescriptor = $convert.base64Decode('CglQaG9uZVR5cGUSCgoGTU9CSUxFEAASCAoESE9NRRABEggKBFdPUksQAhIMCghCVVNJTkVTUxAC');
+

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -16,7 +16,7 @@ class _ToStringMatcher extends CustomMatcher {
   _ToStringMatcher(Matcher matcher)
       : super('object where toString() returns', 'toString()', matcher);
   @override
-  String featureValueOf(actual) => actual.toString();
+  String featureValueOf(dynamic actual) => actual.toString();
 }
 
 void main() {

--- a/protoc_plugin/test/repeated_field_test.dart
+++ b/protoc_plugin/test/repeated_field_test.dart
@@ -7,9 +7,6 @@ import 'package:test/test.dart';
 
 import '../out/protos/google/protobuf/unittest.pb.dart';
 
-// Suppress an analyzer warning for a deliberate type mismatch.
-dynamic cast(x) => x;
-
 void main() {
   test('check properties are initialized for repeated fields', () {
     var msg = TestAllTypes();

--- a/protoc_plugin/test/send_protos_via_sendports_test.dart
+++ b/protoc_plugin/test/send_protos_via_sendports_test.dart
@@ -15,7 +15,7 @@ Future<T> sendReceive<T>(T object) async {
   return (await rp.first) as T;
 }
 
-Future main() async {
+void main() async {
   test('Normal proto can be transferred via ports', () async {
     final object = Outer()
       ..inner = (Inner()..value = 'pip')


### PR DESCRIPTION
This improves the readability of the generated code (see https://github.com/google/protobuf.dart/issues/771 for context).

- use shared consts to reduce the number of repeated `bool.fromEnvironment()` expressions (all the `bool.fromEnvironment()` expressions are gathered up while generated the file and written as consts at the end of the file)
- turn on a few additional lints
- update the changelog

Done as three commits for easier review (the dart code changes, regenerating the lib/src/generated files, and regenerating the test goldens). cc @osa1 