### PR TITLE
Remove duplicate consts

### DIFF
--- a/protoc_plugin/lib/const_generator.dart
+++ b/protoc_plugin/lib/const_generator.dart
@@ -10,21 +10,19 @@ import 'string_escape.dart';
 void writeJsonConst(IndentingWriter out, Object? val) {
   if (val is Map) {
     if (val.values.any(_nonEmptyListOrMap)) {
-      out.addBlock(
-          /*const*/ '{', '}', () => _writeMapItems(out, val, vertical: true),
+      out.addBlock('{', '}', () => _writeMapItems(out, val, vertical: true),
           endWithNewline: false);
     } else {
-      /*const*/ out.print('{');
+      out.print('{');
       _writeMapItems(out, val);
       out.print('}');
     }
   } else if (val is List) {
     if (val.any(_nonEmptyListOrMap)) {
-      out.addBlock(
-          /*const*/ '[', ']', () => _writeListItems(out, val, vertical: true),
+      out.addBlock('[', ']', () => _writeListItems(out, val, vertical: true),
           endWithNewline: false);
     } else {
-      /*const*/ out.print('[');
+      out.print('[');
       _writeListItems(out, val);
       out.print(']');
     }

--- a/protoc_plugin/lib/const_generator.dart
+++ b/protoc_plugin/lib/const_generator.dart
@@ -11,20 +11,20 @@ void writeJsonConst(IndentingWriter out, Object? val) {
   if (val is Map) {
     if (val.values.any(_nonEmptyListOrMap)) {
       out.addBlock(
-          'const {', '}', () => _writeMapItems(out, val, vertical: true),
+          /*const*/ '{', '}', () => _writeMapItems(out, val, vertical: true),
           endWithNewline: false);
     } else {
-      out.print('const {');
+      /*const*/ out.print('{');
       _writeMapItems(out, val);
       out.print('}');
     }
   } else if (val is List) {
     if (val.any(_nonEmptyListOrMap)) {
       out.addBlock(
-          'const [', ']', () => _writeListItems(out, val, vertical: true),
+          /*const*/ '[', ']', () => _writeListItems(out, val, vertical: true),
           endWithNewline: false);
     } else {
-      out.print('const [');
+      /*const*/ out.print('[');
       _writeListItems(out, val);
       out.print(']');
     }

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -454,7 +454,8 @@ class FileGenerator extends ProtobufContainer {
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     if (!_linked) throw StateError('not linked');
     var out = makeWriter();
-    _writeHeading(out);
+    _writeHeading(out,
+        extraIgnores: {'deprecated_member_use_from_same_package'});
 
     if (serviceGenerators.isNotEmpty) {
       out.println(_asyncImport);

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -528,12 +528,24 @@ class FileGenerator extends ProtobufContainer {
 
   void writeBinaryDescriptor(IndentingWriter out, String identifierName,
       String name, GeneratedMessage descriptor) {
-    var descriptorText = base64Encode(descriptor.writeToBuffer());
+    var base64 = base64Encode(descriptor.writeToBuffer());
     out.println('/// Descriptor for `$name`. Decode as a '
         '`${descriptor.info_.qualifiedMessageName}`.');
+
+    var base64Lines = splitString(base64, 74).map((s) => "'$s'").join();
     out.println('final $_typedDataImportPrefix.Uint8List '
         '$identifierName = '
-        '$_convertImportPrefix.base64Decode(\'$descriptorText\');');
+        '$_convertImportPrefix.base64Decode($base64Lines);');
+  }
+
+  List<String> splitString(String str, int segmentLength) {
+    var result = <String>[];
+    while (str.length >= segmentLength) {
+      result.add(str.substring(0, segmentLength));
+      str = str.substring(segmentLength);
+    }
+    if (str.isNotEmpty) result.add(str);
+    return result;
   }
 
   /// Returns the contents of the .pbjson.dart file for this .proto file.

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -459,10 +459,9 @@ class FileGenerator extends ProtobufContainer {
 
     if (serviceGenerators.isNotEmpty) {
       out.println(_asyncImport);
+      out.println(_coreImport);
       out.println();
       out.println(_protobufImport);
-      out.println();
-      out.println(_coreImport);
     }
 
     // Import .pb.dart files needed for requests and responses.
@@ -500,7 +499,6 @@ class FileGenerator extends ProtobufContainer {
     _writeHeading(out);
 
     out.println(_asyncImport);
-    out.println();
     out.println(_coreImport);
     out.println();
     out.println(_grpcImport);
@@ -697,12 +695,12 @@ const _fileIgnores = {
   'annotate_overrides',
   'camel_case_types',
   'constant_identifier_names',
+  'deprecated_member_use',
   'directives_ordering',
   'library_prefixes',
   'non_constant_identifier_names',
   'prefer_final_fields',
   'return_of_invalid_type',
-  'unnecessary_const',
   'unnecessary_import',
   'unnecessary_this',
   'unused_import',

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -454,14 +454,14 @@ class FileGenerator extends ProtobufContainer {
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     if (!_linked) throw StateError('not linked');
     var out = makeWriter();
-    _writeHeading(out,
-        extraIgnores: {'deprecated_member_use_from_same_package'});
+    _writeHeading(out);
 
     if (serviceGenerators.isNotEmpty) {
       out.println(_asyncImport);
       out.println(_coreImport);
       out.println();
       out.println(_protobufImport);
+      out.println();
     }
 
     // Import .pb.dart files needed for requests and responses.
@@ -502,6 +502,7 @@ class FileGenerator extends ProtobufContainer {
     out.println(_coreImport);
     out.println();
     out.println(_grpcImport);
+    out.println();
 
     // Import .pb.dart files needed for requests and responses.
     var imports = <FileGenerator>{};
@@ -530,13 +531,18 @@ class FileGenerator extends ProtobufContainer {
     out.println('/// Descriptor for `$name`. Decode as a '
         '`${descriptor.info_.qualifiedMessageName}`.');
 
-    var base64Lines = splitString(base64, 74).map((s) => "'$s'").join();
+    const indent = '    ';
+
+    var base64Lines =
+        _splitString(base64, 74).map((s) => "'$s'").join('\n$indent');
     out.println('final $_typedDataImportPrefix.Uint8List '
         '$identifierName = '
-        '$_convertImportPrefix.base64Decode($base64Lines);');
+        '$_convertImportPrefix.base64Decode(\n$indent$base64Lines);');
   }
 
-  List<String> splitString(String str, int segmentLength) {
+  /// Return the given [str], split into separate segments, where no segment is
+  /// longer than [segmentLength].
+  static List<String> _splitString(String str, int segmentLength) {
     var result = <String>[];
     while (str.length >= segmentLength) {
       result.add(str.substring(0, segmentLength));
@@ -551,12 +557,13 @@ class FileGenerator extends ProtobufContainer {
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     if (!_linked) throw StateError('not linked');
     var out = makeWriter();
-    _writeHeading(out,
-        extraIgnores: {'deprecated_member_use_from_same_package'});
+    _writeHeading(out);
 
     out.println(_convertImport);
     out.println(_coreImport);
     out.println(_typedDataImport);
+    out.println();
+
     // Import the .pbjson.dart files we depend on.
     var imports = _findJsonProtosToImport();
     for (var target in imports) {
@@ -691,11 +698,14 @@ class ConditionalConstDefinition {
   }
 }
 
+// TODO(devoncarew): We should be able to shrink this down to just:
+//   annotate_overrides, camel_case_types, constant_identifier_names, and
+//   library_prefixes.
+
 const _fileIgnores = {
   'annotate_overrides',
   'camel_case_types',
   'constant_identifier_names',
-  'deprecated_member_use',
   'directives_ordering',
   'library_prefixes',
   'non_constant_identifier_names',
@@ -704,5 +714,4 @@ const _fileIgnores = {
   'unnecessary_import',
   'unnecessary_this',
   'unused_import',
-  'unused_shown_name',
 };

--- a/protoc_plugin/lib/src/generated/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/generated/dart_options.pb.dart
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
@@ -42,8 +42,7 @@ class DartMixin extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   DartMixin copyWith(void Function(DartMixin) updates) =>
-      super.copyWith((message) => updates(message as DartMixin))
-          as DartMixin; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as DartMixin)) as DartMixin;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -119,8 +118,7 @@ class Imports extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   Imports copyWith(void Function(Imports) updates) =>
-      super.copyWith((message) => updates(message as Imports))
-          as Imports; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Imports)) as Imports;
 
   $pb.BuilderInfo get info_ => _i;
 

--- a/protoc_plugin/lib/src/generated/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/generated/dart_options.pb.dart
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/generated/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pb.dart
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/generated/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pb.dart
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
@@ -48,7 +48,7 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   FileDescriptorSet copyWith(void Function(FileDescriptorSet) updates) =>
       super.copyWith((message) => updates(message as FileDescriptorSet))
-          as FileDescriptorSet; // ignore: deprecated_member_use
+          as FileDescriptorSet;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -115,7 +115,7 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   FileDescriptorProto copyWith(void Function(FileDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as FileDescriptorProto))
-          as FileDescriptorProto; // ignore: deprecated_member_use
+          as FileDescriptorProto;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -247,7 +247,7 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
           void Function(DescriptorProto_ExtensionRange) updates) =>
       super.copyWith(
               (message) => updates(message as DescriptorProto_ExtensionRange))
-          as DescriptorProto_ExtensionRange; // ignore: deprecated_member_use
+          as DescriptorProto_ExtensionRange;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -332,7 +332,7 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
           void Function(DescriptorProto_ReservedRange) updates) =>
       super.copyWith(
               (message) => updates(message as DescriptorProto_ReservedRange))
-          as DescriptorProto_ReservedRange; // ignore: deprecated_member_use
+          as DescriptorProto_ReservedRange;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -422,7 +422,7 @@ class DescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   DescriptorProto copyWith(void Function(DescriptorProto) updates) =>
       super.copyWith((message) => updates(message as DescriptorProto))
-          as DescriptorProto; // ignore: deprecated_member_use
+          as DescriptorProto;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -518,7 +518,7 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
   ExtensionRangeOptions copyWith(
           void Function(ExtensionRangeOptions) updates) =>
       super.copyWith((message) => updates(message as ExtensionRangeOptions))
-          as ExtensionRangeOptions; // ignore: deprecated_member_use
+          as ExtensionRangeOptions;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -582,7 +582,7 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   FieldDescriptorProto copyWith(void Function(FieldDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as FieldDescriptorProto))
-          as FieldDescriptorProto; // ignore: deprecated_member_use
+          as FieldDescriptorProto;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -760,7 +760,7 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   OneofDescriptorProto copyWith(void Function(OneofDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as OneofDescriptorProto))
-          as OneofDescriptorProto; // ignore: deprecated_member_use
+          as OneofDescriptorProto;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -833,7 +833,7 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
           void Function(EnumDescriptorProto_EnumReservedRange) updates) =>
       super.copyWith((message) =>
               updates(message as EnumDescriptorProto_EnumReservedRange))
-          as EnumDescriptorProto_EnumReservedRange; // ignore: deprecated_member_use
+          as EnumDescriptorProto_EnumReservedRange;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -909,7 +909,7 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   EnumDescriptorProto copyWith(void Function(EnumDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as EnumDescriptorProto))
-          as EnumDescriptorProto; // ignore: deprecated_member_use
+          as EnumDescriptorProto;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -991,7 +991,7 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
   EnumValueDescriptorProto copyWith(
           void Function(EnumValueDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as EnumValueDescriptorProto))
-          as EnumValueDescriptorProto; // ignore: deprecated_member_use
+          as EnumValueDescriptorProto;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1077,7 +1077,7 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
   ServiceDescriptorProto copyWith(
           void Function(ServiceDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as ServiceDescriptorProto))
-          as ServiceDescriptorProto; // ignore: deprecated_member_use
+          as ServiceDescriptorProto;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1155,7 +1155,7 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
   MethodDescriptorProto copyWith(
           void Function(MethodDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as MethodDescriptorProto))
-          as MethodDescriptorProto; // ignore: deprecated_member_use
+          as MethodDescriptorProto;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1299,7 +1299,7 @@ class FileOptions extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   FileOptions copyWith(void Function(FileOptions) updates) =>
       super.copyWith((message) => updates(message as FileOptions))
-          as FileOptions; // ignore: deprecated_member_use
+          as FileOptions;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1593,7 +1593,7 @@ class MessageOptions extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   MessageOptions copyWith(void Function(MessageOptions) updates) =>
       super.copyWith((message) => updates(message as MessageOptions))
-          as MessageOptions; // ignore: deprecated_member_use
+          as MessageOptions;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1702,7 +1702,7 @@ class FieldOptions extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   FieldOptions copyWith(void Function(FieldOptions) updates) =>
       super.copyWith((message) => updates(message as FieldOptions))
-          as FieldOptions; // ignore: deprecated_member_use
+          as FieldOptions;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1821,7 +1821,7 @@ class OneofOptions extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   OneofOptions copyWith(void Function(OneofOptions) updates) =>
       super.copyWith((message) => updates(message as OneofOptions))
-          as OneofOptions; // ignore: deprecated_member_use
+          as OneofOptions;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1870,7 +1870,7 @@ class EnumOptions extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   EnumOptions copyWith(void Function(EnumOptions) updates) =>
       super.copyWith((message) => updates(message as EnumOptions))
-          as EnumOptions; // ignore: deprecated_member_use
+          as EnumOptions;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -1941,7 +1941,7 @@ class EnumValueOptions extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   EnumValueOptions copyWith(void Function(EnumValueOptions) updates) =>
       super.copyWith((message) => updates(message as EnumValueOptions))
-          as EnumValueOptions; // ignore: deprecated_member_use
+          as EnumValueOptions;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2001,7 +2001,7 @@ class ServiceOptions extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   ServiceOptions copyWith(void Function(ServiceOptions) updates) =>
       super.copyWith((message) => updates(message as ServiceOptions))
-          as ServiceOptions; // ignore: deprecated_member_use
+          as ServiceOptions;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2066,7 +2066,7 @@ class MethodOptions extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   MethodOptions copyWith(void Function(MethodOptions) updates) =>
       super.copyWith((message) => updates(message as MethodOptions))
-          as MethodOptions; // ignore: deprecated_member_use
+          as MethodOptions;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2139,7 +2139,7 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
           void Function(UninterpretedOption_NamePart) updates) =>
       super.copyWith(
               (message) => updates(message as UninterpretedOption_NamePart))
-          as UninterpretedOption_NamePart; // ignore: deprecated_member_use
+          as UninterpretedOption_NamePart;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2217,7 +2217,7 @@ class UninterpretedOption extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   UninterpretedOption copyWith(void Function(UninterpretedOption) updates) =>
       super.copyWith((message) => updates(message as UninterpretedOption))
-          as UninterpretedOption; // ignore: deprecated_member_use
+          as UninterpretedOption;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2340,7 +2340,7 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
   SourceCodeInfo_Location copyWith(
           void Function(SourceCodeInfo_Location) updates) =>
       super.copyWith((message) => updates(message as SourceCodeInfo_Location))
-          as SourceCodeInfo_Location; // ignore: deprecated_member_use
+          as SourceCodeInfo_Location;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2417,7 +2417,7 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   SourceCodeInfo copyWith(void Function(SourceCodeInfo) updates) =>
       super.copyWith((message) => updates(message as SourceCodeInfo))
-          as SourceCodeInfo; // ignore: deprecated_member_use
+          as SourceCodeInfo;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2468,7 +2468,7 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
           void Function(GeneratedCodeInfo_Annotation) updates) =>
       super.copyWith(
               (message) => updates(message as GeneratedCodeInfo_Annotation))
-          as GeneratedCodeInfo_Annotation; // ignore: deprecated_member_use
+          as GeneratedCodeInfo_Annotation;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -2552,7 +2552,7 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   GeneratedCodeInfo copyWith(void Function(GeneratedCodeInfo) updates) =>
       super.copyWith((message) => updates(message as GeneratedCodeInfo))
-          as GeneratedCodeInfo; // ignore: deprecated_member_use
+          as GeneratedCodeInfo;
 
   $pb.BuilderInfo get info_ => _i;
 

--- a/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
@@ -5,11 +5,12 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: undefined_shown_name, unnecessary_const, unnecessary_import
-// ignore_for_file: unnecessary_this, unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, undefined_shown_name
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: unused_shown_name
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
@@ -5,12 +5,11 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, undefined_shown_name
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-// ignore_for_file: unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: undefined_shown_name, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/generated/plugin.pb.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pb.dart
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
@@ -49,8 +49,7 @@ class Version extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   Version copyWith(void Function(Version) updates) =>
-      super.copyWith((message) => updates(message as Version))
-          as Version; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Version)) as Version;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -145,7 +144,7 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   CodeGeneratorRequest copyWith(void Function(CodeGeneratorRequest) updates) =>
       super.copyWith((message) => updates(message as CodeGeneratorRequest))
-          as CodeGeneratorRequest; // ignore: deprecated_member_use
+          as CodeGeneratorRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -226,7 +225,7 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
           void Function(CodeGeneratorResponse_File) updates) =>
       super.copyWith(
               (message) => updates(message as CodeGeneratorResponse_File))
-          as CodeGeneratorResponse_File; // ignore: deprecated_member_use
+          as CodeGeneratorResponse_File;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -326,7 +325,7 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
   CodeGeneratorResponse copyWith(
           void Function(CodeGeneratorResponse) updates) =>
       super.copyWith((message) => updates(message as CodeGeneratorResponse))
-          as CodeGeneratorResponse; // ignore: deprecated_member_use
+          as CodeGeneratorResponse;
 
   $pb.BuilderInfo get info_ => _i;
 

--- a/protoc_plugin/lib/src/generated/plugin.pb.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pb.dart
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/generated/plugin.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pbenum.dart
@@ -5,11 +5,12 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: undefined_shown_name, unnecessary_const, unnecessary_import
-// ignore_for_file: unnecessary_this, unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, undefined_shown_name
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: unused_shown_name
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/generated/plugin.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pbenum.dart
@@ -5,12 +5,11 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, undefined_shown_name
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-// ignore_for_file: unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: undefined_shown_name, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/message_generator.dart
+++ b/protoc_plugin/lib/src/message_generator.dart
@@ -662,16 +662,16 @@ class MessageGenerator extends ProtobufContainer {
 
     out.println('@$coreImportPrefix.Deprecated'
         '(\'Use ${toplevelParent!.binaryDescriptorName} instead\')');
-    out.addBlock('const $name = const {', '};', () {
+    out.addBlock('const $name = {', '};', () {
       for (var key in json.keys) {
         out.print("'$key': ");
         if (key == '$nestedTypeTag') {
           // refer to message constants by name instead of repeating each value
-          out.println("const [${nestedTypeNames.join(", ")}],");
+          out.println("[${nestedTypeNames.join(", ")}],");
           continue;
         } else if (key == '$enumTypeTag') {
           // refer to enum constants by name
-          out.println("const [${nestedEnumNames.join(", ")}],");
+          out.println("[${nestedEnumNames.join(", ")}],");
           continue;
         }
         writeJsonConst(out, json[key]);

--- a/protoc_plugin/lib/src/message_generator.dart
+++ b/protoc_plugin/lib/src/message_generator.dart
@@ -390,8 +390,7 @@ class MessageGenerator extends ProtobufContainer {
 'Will be removed in next major version')''');
       out.println('$classname copyWith(void Function($classname) updates) =>'
           ' super.copyWith((message) => updates(message as $classname))'
-          ' as $classname;'
-          ' // ignore: deprecated_member_use');
+          ' as $classname;');
 
       out.println('');
       out.println('$protobufImportPrefix.BuilderInfo get info_ => _i;');

--- a/protoc_plugin/lib/src/service_generator.dart
+++ b/protoc_plugin/lib/src/service_generator.dart
@@ -232,7 +232,7 @@ class ServiceGenerator {
     out.addBlock(
         'const $coreImportPrefix.Map<$coreImportPrefix.String,'
             ' $coreImportPrefix.Map<$coreImportPrefix.String,'
-            ' $coreImportPrefix.dynamic>> $messageJsonConstant = const {',
+            ' $coreImportPrefix.dynamic>> $messageJsonConstant = {',
         '};', () {
       for (var key in typeConstants.keys) {
         var typeConst = typeConstants[key];

--- a/protoc_plugin/test/const_generator_test.dart
+++ b/protoc_plugin/test/const_generator_test.dart
@@ -35,30 +35,30 @@ void main() {
   });
 
   test('writeJsonConst list examples', () {
-    expect(toConst([]), 'const []');
-    expect(toConst([1, 2, 3]), 'const [1, 2, 3]');
+    expect(toConst([]), '[]');
+    expect(toConst([1, 2, 3]), '[1, 2, 3]');
     expect(
         toConst([
           [1, 2],
           [3, 4]
         ]),
-        'const [\n'
-        '  const [1, 2],\n'
-        '  const [3, 4],\n'
+        '[\n'
+        '  [1, 2],\n'
+        '  [3, 4],\n'
         ']');
   });
 
   test('writeJsonConst map examples', () {
-    expect(toConst({}), 'const {}');
-    expect(toConst({'a': 1, 'b': 2}), "const {'a': 1, 'b': 2}");
+    expect(toConst({}), '{}');
+    expect(toConst({'a': 1, 'b': 2}), "{'a': 1, 'b': 2}");
     expect(
         toConst({
           'a': {'x': 1},
           'b': {'x': 2}
         }),
-        'const {\n'
-        "  'a': const {'x': 1},\n"
-        "  'b': const {'x': 2},\n"
+        '{\n'
+        "  'a': {'x': 1},\n"
+        "  'b': {'x': 2},\n"
         '}');
   });
 }

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
@@ -34,7 +34,7 @@ class Empty extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)) as Empty; // ignore: deprecated_member_use
+  Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)) as Empty;
 
   $pb.BuilderInfo get info_ => _i;
 

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -5,16 +5,16 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;
 
 import 'package:grpc/service_api.dart' as $grpc;
+
 import 'test.pb.dart' as $0;
 export 'test.pb.dart';
 

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -5,14 +5,13 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:async' as $async;
-
 import 'dart:core' as $core;
 
 import 'package:grpc/service_api.dart' as $grpc;

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
@@ -40,7 +40,7 @@ class M extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  M copyWith(void Function(M) updates) => super.copyWith((message) => updates(message as M)) as M; // ignore: deprecated_member_use
+  M copyWith(void Function(M) updates) => super.copyWith((message) => updates(message as M)) as M;
 
   $pb.BuilderInfo get info_ => _i;
 

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/imports.pbjson
+++ b/protoc_plugin/test/goldens/imports.pbjson
@@ -5,9 +5,8 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 

--- a/protoc_plugin/test/goldens/imports.pbjson
+++ b/protoc_plugin/test/goldens/imports.pbjson
@@ -5,9 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
@@ -36,7 +36,7 @@ class Int64 extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Int64 copyWith(void Function(Int64) updates) => super.copyWith((message) => updates(message as Int64)) as Int64; // ignore: deprecated_member_use
+  Int64 copyWith(void Function(Int64) updates) => super.copyWith((message) => updates(message as Int64)) as Int64;
 
   $pb.BuilderInfo get info_ => _i;
 

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/messageGenerator
+++ b/protoc_plugin/test/goldens/messageGenerator
@@ -20,7 +20,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber)) as PhoneNumber; // ignore: deprecated_member_use
+  PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber)) as PhoneNumber;
 
   $pb.BuilderInfo get info_ => _i;
 

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2036
-  end: 2042
+  begin: 2003
+  end: 2009
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2084
-  end: 2090
+  begin: 2051
+  end: 2057
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2163
-  end: 2172
+  begin: 2130
+  end: 2139
 }
 annotation: {
   path: 4
@@ -45,8 +45,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2215
-  end: 2226
+  begin: 2182
+  end: 2193
 }
 annotation: {
   path: 4
@@ -54,8 +54,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2296
-  end: 2300
+  begin: 2263
+  end: 2267
 }
 annotation: {
   path: 4
@@ -63,8 +63,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2341
-  end: 2345
+  begin: 2308
+  end: 2312
 }
 annotation: {
   path: 4
@@ -72,8 +72,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2424
-  end: 2431
+  begin: 2391
+  end: 2398
 }
 annotation: {
   path: 4
@@ -81,8 +81,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2474
-  end: 2483
+  begin: 2441
+  end: 2450
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2544
-  end: 2548
+  begin: 2511
+  end: 2515
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2595
-  end: 2599
+  begin: 2562
+  end: 2566
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2672
-  end: 2679
+  begin: 2639
+  end: 2646
 }
 annotation: {
   path: 4
@@ -117,17 +117,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2722
-  end: 2731
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 2841
-  end: 2856
+  begin: 2689
+  end: 2698
 }
 annotation: {
   path: 4
@@ -135,8 +126,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 2947
-  end: 2962
+  begin: 2808
+  end: 2823
 }
 annotation: {
   path: 4
@@ -144,8 +135,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3084
-  end: 3102
+  begin: 2914
+  end: 2929
 }
 annotation: {
   path: 4
@@ -153,6 +144,15 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3194
-  end: 3214
+  begin: 3051
+  end: 3069
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 3161
+  end: 3181
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;
@@ -36,7 +36,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber)) as PhoneNumber; // ignore: deprecated_member_use
+  PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber)) as PhoneNumber;
 
   $pb.BuilderInfo get info_ => _i;
 

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 551
-  end: 562
+  begin: 490
+  end: 501
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 939
-  end: 950
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2353
-  end: 2359
+  begin: 878
+  end: 889
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2401
-  end: 2407
+  begin: 2292
+  end: 2298
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2480
-  end: 2489
+  begin: 2340
+  end: 2346
 }
 annotation: {
   path: 4
@@ -45,17 +36,17 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2532
-  end: 2543
+  begin: 2419
+  end: 2428
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: test
-  begin: 2601
-  end: 2605
+  begin: 2471
+  end: 2482
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2647
-  end: 2651
+  begin: 2540
+  end: 2544
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2726
-  end: 2733
+  begin: 2586
+  end: 2590
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2776
-  end: 2785
+  begin: 2665
+  end: 2672
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2715
+  end: 2724
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2846
-  end: 2850
+  begin: 2785
+  end: 2789
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2897
-  end: 2901
+  begin: 2836
+  end: 2840
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2974
-  end: 2981
+  begin: 2913
+  end: 2920
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3024
-  end: 3033
+  begin: 2963
+  end: 2972
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 547
-  end: 558
+  begin: 551
+  end: 562
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 935
-  end: 946
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2382
-  end: 2388
+  begin: 939
+  end: 950
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2430
-  end: 2436
+  begin: 2353
+  end: 2359
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2509
-  end: 2518
+  begin: 2401
+  end: 2407
 }
 annotation: {
   path: 4
@@ -45,17 +36,17 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2561
-  end: 2572
+  begin: 2480
+  end: 2489
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: test
-  begin: 2630
-  end: 2634
+  begin: 2532
+  end: 2543
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2676
-  end: 2680
+  begin: 2601
+  end: 2605
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2755
-  end: 2762
+  begin: 2647
+  end: 2651
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2805
-  end: 2814
+  begin: 2726
+  end: 2733
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2776
+  end: 2785
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2875
-  end: 2879
+  begin: 2846
+  end: 2850
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2926
-  end: 2930
+  begin: 2897
+  end: 2901
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3003
-  end: 3010
+  begin: 2974
+  end: 2981
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3053
-  end: 3062
+  begin: 3024
+  end: 3033
 }

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -16,15 +16,19 @@ import 'dart:convert' as $convert;
 import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 @$core.Deprecated('Use phoneNumberDescriptor instead')
-const PhoneNumber$json = const {
+const PhoneNumber$json = {
   '1': 'PhoneNumber',
-  '2': const [
-    const {'1': 'number', '3': 1, '4': 2, '5': 9, '10': 'number'},
-    const {'1': 'type', '3': 2, '4': 1, '5': 5, '6': '', '10': 'type'},
-    const {'1': 'name', '3': 3, '4': 1, '5': 9, '7': '\$', '10': 'name'},
+  '2': [
+    {'1': 'number', '3': 1, '4': 2, '5': 9, '10': 'number'},
+    {'1': 'type', '3': 2, '4': 1, '5': 5, '6': '', '10': 'type'},
+    {'1': 'name', '3': 3, '4': 1, '5': 9, '7': '\$', '10': 'name'},
   ],
 };
 
 /// Descriptor for `PhoneNumber`. Decode as a `google.protobuf.DescriptorProto`.
+<<<<<<< Updated upstream
 final $typed_data.Uint8List phoneNumberDescriptor = $convert.base64Decode('CgtQaG9uZU51bWJlchIWCgZudW1iZXIYASACKAlSBm51bWJlchIUCgR0eXBlGAIgASgFMgBSBHR5cGUSFQoEbmFtZRgDIAEoCToBJFIEbmFtZQ==');
+=======
+final $typed_data.Uint8List phoneNumberDescriptor = $convert.base64Decode('CgtQaG9uZU51bWJlchIWCgZudW1iZXIYASACKAlSBm51bWJlchIUCgR0eXBlGAIgASgFMgBSBH''R5cGUSFQoEbmFtZRgDIAEoCToBJFIEbmFtZQ==');
+>>>>>>> Stashed changes
 

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -5,16 +5,15 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
+// ignore_for_file: constant_identifier_names, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-// ignore_for_file: unused_shown_name
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
+
 @$core.Deprecated('Use phoneNumberDescriptor instead')
 const PhoneNumber$json = {
   '1': 'PhoneNumber',
@@ -26,5 +25,7 @@ const PhoneNumber$json = {
 };
 
 /// Descriptor for `PhoneNumber`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List phoneNumberDescriptor = $convert.base64Decode('CgtQaG9uZU51bWJlchIWCgZudW1iZXIYASACKAlSBm51bWJlchIUCgR0eXBlGAIgASgFMgBSBH''R5cGUSFQoEbmFtZRgDIAEoCToBJFIEbmFtZQ==');
+final $typed_data.Uint8List phoneNumberDescriptor = $convert.base64Decode(
+    'CgtQaG9uZU51bWJlchIWCgZudW1iZXIYASACKAlSBm51bWJlchIUCgR0eXBlGAIgASgFMgBSBH'
+    'R5cGUSFQoEbmFtZRgDIAEoCToBJFIEbmFtZQ==');
 

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -5,12 +5,12 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names
+// ignore_for_file: constant_identifier_names, deprecated_member_use
 // ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: unused_shown_name
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;
@@ -26,9 +26,5 @@ const PhoneNumber$json = {
 };
 
 /// Descriptor for `PhoneNumber`. Decode as a `google.protobuf.DescriptorProto`.
-<<<<<<< Updated upstream
-final $typed_data.Uint8List phoneNumberDescriptor = $convert.base64Decode('CgtQaG9uZU51bWJlchIWCgZudW1iZXIYASACKAlSBm51bWJlchIUCgR0eXBlGAIgASgFMgBSBHR5cGUSFQoEbmFtZRgDIAEoCToBJFIEbmFtZQ==');
-=======
 final $typed_data.Uint8List phoneNumberDescriptor = $convert.base64Decode('CgtQaG9uZU51bWJlchIWCgZudW1iZXIYASACKAlSBm51bWJlchIUCgR0eXBlGAIgASgFMgBSBH''R5cGUSFQoEbmFtZRgDIAEoCToBJFIEbmFtZQ==');
->>>>>>> Stashed changes
 

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:async' as $async;
@@ -35,7 +35,7 @@ class Empty extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)) as Empty; // ignore: deprecated_member_use
+  Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)) as Empty;
 
   $pb.BuilderInfo get info_ => _i;
 

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -5,18 +5,17 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names
+// ignore_for_file: constant_identifier_names, deprecated_member_use
 // ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: unused_shown_name
 
 import 'dart:async' as $async;
+import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
-
-import 'dart:core' as $core;
 import 'test.pb.dart' as $0;
 import 'test.pbjson.dart';
 

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -5,7 +5,8 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -5,17 +5,16 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
+// ignore_for_file: constant_identifier_names, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-// ignore_for_file: unused_shown_name
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
+
 import 'test.pb.dart' as $0;
 import 'test.pbjson.dart';
 

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -18,7 +18,7 @@ import 'dart:typed_data' as $typed_data;
 import 'foobar.pbjson.dart' as $1;
 
 @$core.Deprecated('Use someRequestDescriptor instead')
-const SomeRequest$json = const {
+const SomeRequest$json = {
   '1': 'SomeRequest',
 };
 
@@ -26,18 +26,22 @@ const SomeRequest$json = const {
 final $typed_data.Uint8List someRequestDescriptor = $convert.base64Decode('CgtTb21lUmVxdWVzdA==');
 
 @$core.Deprecated('Use someReplyDescriptor instead')
-const SomeReply$json = const {
+const SomeReply$json = {
   '1': 'SomeReply',
 };
 
 /// Descriptor for `SomeReply`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List someReplyDescriptor = $convert.base64Decode('CglTb21lUmVwbHk=');
 
+<<<<<<< Updated upstream
 const $core.Map<$core.String, $core.dynamic> TestServiceBase$json = const {
+=======
+const $core.Map<$core.String, $core.dynamic> TestServiceBase$json = {
+>>>>>>> Stashed changes
   '1': 'Test',
-  '2': const [
-    const {'1': 'AMethod', '2': '.testpkg.SomeRequest', '3': '.testpkg.SomeReply'},
-    const {'1': 'AnotherMethod', '2': '.foo.bar.EmptyMessage', '3': '.foo.bar.AnotherReply'},
+  '2': [
+    {'1': 'AMethod', '2': '.testpkg.SomeRequest', '3': '.testpkg.SomeReply'},
+    {'1': 'AnotherMethod', '2': '.foo.bar.EmptyMessage', '3': '.foo.bar.AnotherReply'},
   ],
 };
 
@@ -50,5 +54,9 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TestServic
 };
 
 /// Descriptor for `Test`. Decode as a `google.protobuf.ServiceDescriptorProto`.
+<<<<<<< Updated upstream
 final $typed_data.Uint8List testServiceDescriptor = $convert.base64Decode('CgRUZXN0EjMKB0FNZXRob2QSFC50ZXN0cGtnLlNvbWVSZXF1ZXN0GhIudGVzdHBrZy5Tb21lUmVwbHkSPQoNQW5vdGhlck1ldGhvZBIVLmZvby5iYXIuRW1wdHlNZXNzYWdlGhUuZm9vLmJhci5Bbm90aGVyUmVwbHk=');
+=======
+final $typed_data.Uint8List testServiceDescriptor = $convert.base64Decode('CgRUZXN0EjMKB0FNZXRob2QSFC50ZXN0cGtnLlNvbWVSZXF1ZXN0GhIudGVzdHBrZy5Tb21lUm''VwbHkSPQoNQW5vdGhlck1ldGhvZBIVLmZvby5iYXIuRW1wdHlNZXNzYWdlGhUuZm9vLmJhci5B''bm90aGVyUmVwbHk=');
+>>>>>>> Stashed changes
 

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -5,12 +5,12 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names
+// ignore_for_file: constant_identifier_names, deprecated_member_use
 // ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: unused_shown_name
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;
@@ -33,11 +33,7 @@ const SomeReply$json = {
 /// Descriptor for `SomeReply`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List someReplyDescriptor = $convert.base64Decode('CglTb21lUmVwbHk=');
 
-<<<<<<< Updated upstream
-const $core.Map<$core.String, $core.dynamic> TestServiceBase$json = const {
-=======
 const $core.Map<$core.String, $core.dynamic> TestServiceBase$json = {
->>>>>>> Stashed changes
   '1': 'Test',
   '2': [
     {'1': 'AMethod', '2': '.testpkg.SomeRequest', '3': '.testpkg.SomeReply'},
@@ -54,9 +50,5 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TestServic
 };
 
 /// Descriptor for `Test`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-<<<<<<< Updated upstream
-final $typed_data.Uint8List testServiceDescriptor = $convert.base64Decode('CgRUZXN0EjMKB0FNZXRob2QSFC50ZXN0cGtnLlNvbWVSZXF1ZXN0GhIudGVzdHBrZy5Tb21lUmVwbHkSPQoNQW5vdGhlck1ldGhvZBIVLmZvby5iYXIuRW1wdHlNZXNzYWdlGhUuZm9vLmJhci5Bbm90aGVyUmVwbHk=');
-=======
 final $typed_data.Uint8List testServiceDescriptor = $convert.base64Decode('CgRUZXN0EjMKB0FNZXRob2QSFC50ZXN0cGtnLlNvbWVSZXF1ZXN0GhIudGVzdHBrZy5Tb21lUm''VwbHkSPQoNQW5vdGhlck1ldGhvZBIVLmZvby5iYXIuRW1wdHlNZXNzYWdlGhUuZm9vLmJhci5B''bm90aGVyUmVwbHk=');
->>>>>>> Stashed changes
 

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -5,16 +5,15 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
+// ignore_for_file: constant_identifier_names, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-// ignore_for_file: unused_shown_name
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
+
 import 'foobar.pbjson.dart' as $1;
 
 @$core.Deprecated('Use someRequestDescriptor instead')
@@ -23,7 +22,8 @@ const SomeRequest$json = {
 };
 
 /// Descriptor for `SomeRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List someRequestDescriptor = $convert.base64Decode('CgtTb21lUmVxdWVzdA==');
+final $typed_data.Uint8List someRequestDescriptor = $convert.base64Decode(
+    'CgtTb21lUmVxdWVzdA==');
 
 @$core.Deprecated('Use someReplyDescriptor instead')
 const SomeReply$json = {
@@ -31,7 +31,8 @@ const SomeReply$json = {
 };
 
 /// Descriptor for `SomeReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List someReplyDescriptor = $convert.base64Decode('CglTb21lUmVwbHk=');
+final $typed_data.Uint8List someReplyDescriptor = $convert.base64Decode(
+    'CglTb21lUmVwbHk=');
 
 const $core.Map<$core.String, $core.dynamic> TestServiceBase$json = {
   '1': 'Test',
@@ -50,5 +51,8 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TestServic
 };
 
 /// Descriptor for `Test`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List testServiceDescriptor = $convert.base64Decode('CgRUZXN0EjMKB0FNZXRob2QSFC50ZXN0cGtnLlNvbWVSZXF1ZXN0GhIudGVzdHBrZy5Tb21lUm''VwbHkSPQoNQW5vdGhlck1ldGhvZBIVLmZvby5iYXIuRW1wdHlNZXNzYWdlGhUuZm9vLmJhci5B''bm90aGVyUmVwbHk=');
+final $typed_data.Uint8List testServiceDescriptor = $convert.base64Decode(
+    'CgRUZXN0EjMKB0FNZXRob2QSFC50ZXN0cGtnLlNvbWVSZXF1ZXN0GhIudGVzdHBrZy5Tb21lUm'
+    'VwbHkSPQoNQW5vdGhlck1ldGhvZBIVLmZvby5iYXIuRW1wdHlNZXNzYWdlGhUuZm9vLmJhci5B'
+    'bm90aGVyUmVwbHk=');
 

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -42,7 +42,7 @@ const $core.Map<$core.String, $core.dynamic> TestServiceBase$json = {
 };
 
 @$core.Deprecated('Use testServiceDescriptor instead')
-const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TestServiceBase$messageJson = const {
+const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TestServiceBase$messageJson = {
   '.testpkg.SomeRequest': SomeRequest$json,
   '.testpkg.SomeReply': SomeReply$json,
   '.foo.bar.EmptyMessage': $1.EmptyMessage$json,

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -5,10 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 // ignore_for_file: unused_import, unused_shown_name
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -5,11 +5,12 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: undefined_shown_name, unnecessary_const, unnecessary_import
-// ignore_for_file: unnecessary_this, unused_import, unused_shown_name
+// ignore_for_file: constant_identifier_names, deprecated_member_use
+// ignore_for_file: directives_ordering, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, undefined_shown_name
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: unused_shown_name
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -5,12 +5,11 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: directives_ordering, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, undefined_shown_name
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-// ignore_for_file: unused_shown_name
+// ignore_for_file: constant_identifier_names, directives_ordering
+// ignore_for_file: library_prefixes, non_constant_identifier_names
+// ignore_for_file: prefer_final_fields, return_of_invalid_type
+// ignore_for_file: undefined_shown_name, unnecessary_import, unnecessary_this
+// ignore_for_file: unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 569
-  end: 578
+  begin: 592
+  end: 601
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 631
-  end: 637
+  begin: 654
+  end: 660
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 713
-  end: 717
+  begin: 736
+  end: 740
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 791
-  end: 795
+  begin: 814
+  end: 818
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 870
-  end: 878
+  begin: 893
+  end: 901
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 592
-  end: 601
+  begin: 531
+  end: 540
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 654
-  end: 660
+  begin: 593
+  end: 599
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 736
-  end: 740
+  begin: 675
+  end: 679
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 814
-  end: 818
+  begin: 753
+  end: 757
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 893
-  end: 901
+  begin: 832
+  end: 840
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -16,16 +16,20 @@ import 'dart:convert' as $convert;
 import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 @$core.Deprecated('Use phoneTypeDescriptor instead')
-const PhoneType$json = const {
+const PhoneType$json = {
   '1': 'PhoneType',
-  '2': const [
-    const {'1': 'MOBILE', '2': 0},
-    const {'1': 'HOME', '2': 1},
-    const {'1': 'WORK', '2': 2},
-    const {'1': 'BUSINESS', '2': 2},
+  '2': [
+    {'1': 'MOBILE', '2': 0},
+    {'1': 'HOME', '2': 1},
+    {'1': 'WORK', '2': 2},
+    {'1': 'BUSINESS', '2': 2},
   ],
 };
 
 /// Descriptor for `PhoneType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+<<<<<<< Updated upstream
 final $typed_data.Uint8List phoneTypeDescriptor = $convert.base64Decode('CglQaG9uZVR5cGUSCgoGTU9CSUxFEAASCAoESE9NRRABEggKBFdPUksQAhIMCghCVVNJTkVTUxAC');
+=======
+final $typed_data.Uint8List phoneTypeDescriptor = $convert.base64Decode('CglQaG9uZVR5cGUSCgoGTU9CSUxFEAASCAoESE9NRRABEggKBFdPUksQAhIMCghCVVNJTkVTUx''AC');
+>>>>>>> Stashed changes
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -5,12 +5,12 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names
+// ignore_for_file: constant_identifier_names, deprecated_member_use
 // ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_const, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import, unused_shown_name
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: unused_shown_name
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;
@@ -27,9 +27,5 @@ const PhoneType$json = {
 };
 
 /// Descriptor for `PhoneType`. Decode as a `google.protobuf.EnumDescriptorProto`.
-<<<<<<< Updated upstream
-final $typed_data.Uint8List phoneTypeDescriptor = $convert.base64Decode('CglQaG9uZVR5cGUSCgoGTU9CSUxFEAASCAoESE9NRRABEggKBFdPUksQAhIMCghCVVNJTkVTUxAC');
-=======
 final $typed_data.Uint8List phoneTypeDescriptor = $convert.base64Decode('CglQaG9uZVR5cGUSCgoGTU9CSUxFEAASCAoESE9NRRABEggKBFdPUksQAhIMCghCVVNJTkVTUx''AC');
->>>>>>> Stashed changes
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -5,16 +5,15 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, deprecated_member_use
-// ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
+// ignore_for_file: constant_identifier_names, directives_ordering
 // ignore_for_file: library_prefixes, non_constant_identifier_names
 // ignore_for_file: prefer_final_fields, return_of_invalid_type
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-// ignore_for_file: unused_shown_name
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
+
 @$core.Deprecated('Use phoneTypeDescriptor instead')
 const PhoneType$json = {
   '1': 'PhoneType',
@@ -27,5 +26,7 @@ const PhoneType$json = {
 };
 
 /// Descriptor for `PhoneType`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List phoneTypeDescriptor = $convert.base64Decode('CglQaG9uZVR5cGUSCgoGTU9CSUxFEAASCAoESE9NRRABEggKBFdPUksQAhIMCghCVVNJTkVTUx''AC');
+final $typed_data.Uint8List phoneTypeDescriptor = $convert.base64Decode(
+    'CglQaG9uZVR5cGUSCgoGTU9CSUxFEAASCAoESE9NRRABEggKBFdPUksQAhIMCghCVVNJTkVTUx'
+    'AC');
 


### PR DESCRIPTION
A few more cleanups to the generated code:
- remove unnecessary consts (and the `ignore: unnecessary_const` directive)
- when we print out base64, don't emit lines longer than 80 chars
- adjust import ordering
