### PR TITLE
Emit imports in sorted order

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -30,6 +30,8 @@
   `bool.fromEnvironment()` expressions.
 * Removed accidental `///` at the top of generated Dart files to avoid new
   `dangling_library_doc_comments` lint.
+* Generated files now have sorted imports and have fewer import-related
+  `ignore_for_file:` analysis directives.
 
 [#679]: https://github.com/google/protobuf.dart/pull/679
 [#703]: https://github.com/google/protobuf.dart/pull/703
@@ -81,7 +83,7 @@
 
   If a target is built with `dart_env = {"protobuf.omit_enum_names": "true"}`
   enum names will not be present in the compiled binary.
-* Make message and field names dependenc on a fromEnvironment constants
+* Make message and field names depend on fromEnvironment constants
   `protobuf.omit_message_names` and `protobuf.omit_field_names` respectively.
 * Omit type on a left hand side of generated static fields for extensions,
   which results in stricter type (`Extension<ExtensionType>` instead of just

--- a/protoc_plugin/lib/src/generated/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/generated/dart_options.pb.dart
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/generated/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pb.dart
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: undefined_shown_name, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, undefined_shown_name
+// ignore_for_file: unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/generated/plugin.pb.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pb.dart
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/lib/src/generated/plugin.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pbenum.dart
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: undefined_shown_name, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, undefined_shown_name
+// ignore_for_file: unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_this
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;
@@ -16,6 +15,7 @@ import 'dart:core' as $core;
 import 'package:grpc/service_api.dart' as $grpc;
 
 import 'test.pb.dart' as $0;
+
 export 'test.pb.dart';
 
 @$pb.GrpcServiceName('Test')

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/imports.pbjson
+++ b/protoc_plugin/test/goldens/imports.pbjson
@@ -5,8 +5,7 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_this
 

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 489
-  end: 500
+  begin: 434
+  end: 445
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 877
-  end: 888
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2291
-  end: 2297
+  begin: 822
+  end: 833
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2339
-  end: 2345
+  begin: 2236
+  end: 2242
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2418
-  end: 2427
+  begin: 2284
+  end: 2290
 }
 annotation: {
   path: 4
@@ -45,17 +36,17 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2470
-  end: 2481
+  begin: 2363
+  end: 2372
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: test
-  begin: 2539
-  end: 2543
+  begin: 2415
+  end: 2426
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2585
-  end: 2589
+  begin: 2484
+  end: 2488
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2664
-  end: 2671
+  begin: 2530
+  end: 2534
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2714
-  end: 2723
+  begin: 2609
+  end: 2616
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2659
+  end: 2668
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2784
-  end: 2788
+  begin: 2729
+  end: 2733
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2835
-  end: 2839
+  begin: 2780
+  end: 2784
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2912
-  end: 2919
+  begin: 2857
+  end: 2864
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2962
-  end: 2971
+  begin: 2907
+  end: 2916
 }

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_this
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -6,10 +6,9 @@
 
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names
-// ignore_for_file: deprecated_member_use_from_same_package, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_this
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_this
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -5,11 +5,10 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: undefined_shown_name, unnecessary_import, unnecessary_this
-// ignore_for_file: unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, undefined_shown_name
+// ignore_for_file: unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 530
-  end: 539
+  begin: 455
+  end: 464
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 592
-  end: 598
+  begin: 517
+  end: 523
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 674
-  end: 678
+  begin: 599
+  end: 603
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 752
-  end: 756
+  begin: 677
+  end: 681
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 831
-  end: 839
+  begin: 756
+  end: 764
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -5,10 +5,9 @@
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types
-// ignore_for_file: constant_identifier_names, directives_ordering
-// ignore_for_file: library_prefixes, non_constant_identifier_names
-// ignore_for_file: prefer_final_fields, return_of_invalid_type
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: return_of_invalid_type, unnecessary_this
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/indenting_writer_test.dart
+++ b/protoc_plugin/test/indenting_writer_test.dart
@@ -7,57 +7,93 @@ import 'package:protoc_plugin/src/generated/descriptor.pb.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('IndentingWriter can indent a block', () {
-    var out = IndentingWriter(filename: '');
-    out.addBlock('class test {', '}', () {
-      out.println('first;');
-      out.println();
-      out.println('second;');
-    });
+  group('IndentingWriter', () {
+    test('IndentingWriter can indent a block', () {
+      var out = IndentingWriter(filename: '');
+      out.addBlock('class test {', '}', () {
+        out.println('first;');
+        out.println();
+        out.println('second;');
+      });
 
-    expect(out.toString(), '''
+      expect(out.toString(), '''
 class test {
   first;
 
   second;
 }
 ''');
-  });
-
-  test('IndentingWriter annotation tracks previous output', () {
-    var out = IndentingWriter(filename: 'sample.proto');
-    out.print('13 characters');
-    out.printAnnotated('sample text', [
-      NamedLocation(name: 'text', fieldPathSegment: [1, 2, 3], start: 7)
-    ]);
-    var expected = GeneratedCodeInfo_Annotation()
-      ..path.addAll([1, 2, 3])
-      ..sourceFile = 'sample.proto'
-      ..begin = 20
-      ..end = 24;
-    var annotation = out.sourceLocationInfo.annotation[0];
-    expect(annotation, equals(expected));
-  });
-
-  test('IndentingWriter annotation counts indents correctly', () {
-    var out = IndentingWriter(filename: '');
-    out.addBlock('34 characters including newline {', '}', () {
-      out.printlnAnnotated('sample text',
-          [NamedLocation(name: 'sample', fieldPathSegment: [], start: 0)]);
     });
-    var annotation = out.sourceLocationInfo.annotation[0];
-    // The indent is 2 characters, so these should be shifted by 2.
-    expect(annotation.begin, equals(36));
-    expect(annotation.end, equals(42));
+
+    test('IndentingWriter annotation tracks previous output', () {
+      var out = IndentingWriter(filename: 'sample.proto');
+      out.print('13 characters');
+      out.printAnnotated('sample text', [
+        NamedLocation(name: 'text', fieldPathSegment: [1, 2, 3], start: 7)
+      ]);
+      var expected = GeneratedCodeInfo_Annotation()
+        ..path.addAll([1, 2, 3])
+        ..sourceFile = 'sample.proto'
+        ..begin = 20
+        ..end = 24;
+      var annotation = out.sourceLocationInfo.annotation[0];
+      expect(annotation, equals(expected));
+    });
+
+    test('IndentingWriter annotation counts indents correctly', () {
+      var out = IndentingWriter(filename: '');
+      out.addBlock('34 characters including newline {', '}', () {
+        out.printlnAnnotated('sample text',
+            [NamedLocation(name: 'sample', fieldPathSegment: [], start: 0)]);
+      });
+      var annotation = out.sourceLocationInfo.annotation[0];
+      // The indent is 2 characters, so these should be shifted by 2.
+      expect(annotation.begin, equals(36));
+      expect(annotation.end, equals(42));
+    });
+
+    test('IndentingWriter annotations counts multiline output correctly', () {
+      var out = IndentingWriter(filename: '');
+      out.print('20 characters\ntotal\n');
+      out.printlnAnnotated('20 characters before this',
+          [NamedLocation(name: 'ch', fieldPathSegment: [], start: 3)]);
+      var annotation = out.sourceLocationInfo.annotation[0];
+      expect(annotation.begin, equals(23));
+      expect(annotation.end, equals(25));
+    });
   });
 
-  test('IndentingWriter annotations counts multiline output correctly', () {
-    var out = IndentingWriter(filename: '');
-    out.print('20 characters\ntotal\n');
-    out.printlnAnnotated('20 characters before this',
-        [NamedLocation(name: 'ch', fieldPathSegment: [], start: 3)]);
-    var annotation = out.sourceLocationInfo.annotation[0];
-    expect(annotation.begin, equals(23));
-    expect(annotation.end, equals(25));
+  group('ImportWriter', () {
+    late ImportWriter importWriter;
+
+    setUp(() {
+      importWriter = ImportWriter();
+    });
+
+    test('sorting', () {
+      importWriter.addImport('dart:typed_data');
+      importWriter.addImport('dart:convert', prefix: 'convert');
+      importWriter.addImport('dart:async');
+
+      expect(importWriter.emit(), equals('''
+import 'dart:async';
+import 'dart:convert' as convert;
+import 'dart:typed_data';
+'''));
+    });
+
+    test('grouping', () {
+      importWriter.addImport('string_utilities.dart');
+      importWriter.addImport('package:path/path.dart', prefix: 'path');
+      importWriter.addImport('dart:convert', prefix: 'convert');
+
+      expect(importWriter.emit(), equals('''
+import 'dart:convert' as convert;
+
+import 'package:path/path.dart' as path;
+
+import 'string_utilities.dart';
+'''));
+    });
   });
 }


### PR DESCRIPTION
Part of https://github.com/google/protobuf.dart/issues/771 - ensure that the imports in the generated code are in lexical order.

- introduce an `ImportWriter` class
- use that when generating code
- have `ImportWriter` use regular dart import conventions (dart: first, package: second, path imports third, and lexically ordered within the groups)

Done as separate commits for easier review.
