### PR TITLE
Fix avoid_renaming_method_parameters linter warning.

### DIFF
--- a/protoc_plugin/lib/src/service_generator.dart
+++ b/protoc_plugin/lib/src/service_generator.dart
@@ -154,15 +154,15 @@ class ServiceGenerator {
 
   void _generateRequestMethod(IndentingWriter out) {
     out.addBlock(
-        '$_generatedMessage createRequest($coreImportPrefix.String method) {',
+        '$_generatedMessage createRequest($coreImportPrefix.String methodName) {',
         '}', () {
-      out.addBlock('switch (method) {', '}', () {
+      out.addBlock('switch (methodName) {', '}', () {
         for (var m in _methodDescriptors) {
           var inputClass = _getDartClassName(m.inputType);
           out.println("case '${m.name}': return $inputClass();");
         }
         out.println('default: '
-            "throw $coreImportPrefix.ArgumentError('Unknown method: \$method');");
+            "throw $coreImportPrefix.ArgumentError('Unknown method: \$methodName');");
       });
     });
     out.println();
@@ -171,9 +171,9 @@ class ServiceGenerator {
   void _generateDispatchMethod(IndentingWriter out) {
     out.addBlock(
         '$_future<$_generatedMessage> handleCall($_serverContext ctx, '
-            '$coreImportPrefix.String method, $_generatedMessage request) {',
+            '$coreImportPrefix.String methodName, $_generatedMessage request) {',
         '}', () {
-      out.addBlock('switch (method) {', '}', () {
+      out.addBlock('switch (methodName) {', '}', () {
         for (var m in _methodDescriptors) {
           var methodName = _methodName(m.name);
           var inputClass = _getDartClassName(m.inputType);
@@ -181,7 +181,7 @@ class ServiceGenerator {
               '(ctx, request as $inputClass);');
         }
         out.println('default: '
-            "throw $coreImportPrefix.ArgumentError('Unknown method: \$method');");
+            "throw $coreImportPrefix.ArgumentError('Unknown method: \$methodName');");
       });
     });
     out.println();

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -23,17 +23,17 @@ export 'test.pb.dart';
 abstract class TestServiceBase extends $pb.GeneratedService {
   $async.Future<$0.Empty> ping($pb.ServerContext ctx, $0.Empty request);
 
-  $pb.GeneratedMessage createRequest($core.String method) {
-    switch (method) {
+  $pb.GeneratedMessage createRequest($core.String methodName) {
+    switch (methodName) {
       case 'Ping': return $0.Empty();
-      default: throw $core.ArgumentError('Unknown method: $method');
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String method, $pb.GeneratedMessage request) {
-    switch (method) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+    switch (methodName) {
       case 'Ping': return this.ping(ctx, request as $0.Empty);
-      default: throw $core.ArgumentError('Unknown method: $method');
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 

--- a/protoc_plugin/test/goldens/serviceGenerator
+++ b/protoc_plugin/test/goldens/serviceGenerator
@@ -2,19 +2,19 @@ abstract class TestServiceBase extends $pb.GeneratedService {
   $async.Future<$0.SomeReply> aMethod($pb.ServerContext ctx, $0.SomeRequest request);
   $async.Future<$1.AnotherReply> anotherMethod($pb.ServerContext ctx, $1.EmptyMessage request);
 
-  $pb.GeneratedMessage createRequest($core.String method) {
-    switch (method) {
+  $pb.GeneratedMessage createRequest($core.String methodName) {
+    switch (methodName) {
       case 'AMethod': return $0.SomeRequest();
       case 'AnotherMethod': return $1.EmptyMessage();
-      default: throw $core.ArgumentError('Unknown method: $method');
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String method, $pb.GeneratedMessage request) {
-    switch (method) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+    switch (methodName) {
       case 'AMethod': return this.aMethod(ctx, request as $0.SomeRequest);
       case 'AnotherMethod': return this.anotherMethod(ctx, request as $1.EmptyMessage);
-      default: throw $core.ArgumentError('Unknown method: $method');
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 


### PR DESCRIPTION
Fixes the generated file causes the following linter warning:

```
The parameter name 'method' doesn't match the name 'methodName' in the overridden method.
Try changing the name to 'methodName'.
```