### PR TITLE
Removes a non-existing lint rule.

### DIFF
--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -408,9 +408,7 @@ class FileGenerator extends ProtobufContainer {
     if (!_linked) throw StateError('not linked');
 
     var out = makeWriter();
-    _writeHeading(out, extraIgnores: {
-      if (enumCount > 0) 'undefined_shown_name',
-    });
+    _writeHeading(out);
 
     var importWriter = ImportWriter();
 

--- a/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, undefined_shown_name
+// ignore_for_file: return_of_invalid_type
 // ignore_for_file: unnecessary_this
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, undefined_shown_name
+// ignore_for_file: return_of_invalid_type
 // ignore_for_file: unnecessary_this
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -7,8 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type
-// ignore_for_file: unnecessary_this
+// ignore_for_file: return_of_invalid_type, unnecessary_this
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 455
-  end: 464
+  begin: 414
+  end: 423
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 517
-  end: 523
+  begin: 476
+  end: 482
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 599
-  end: 603
+  begin: 558
+  end: 562
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 677
-  end: 681
+  begin: 636
+  end: 640
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 756
-  end: 764
+  begin: 715
+  end: 723
 }


### PR DESCRIPTION
Removes `undefined_shown_name` lint rule which does not exist.

https://dart-lang.github.io/linter/lints/undefined_shown_name.html