### PR TITLE
Run non-null-safe tests with Dart 2

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -191,14 +191,14 @@ jobs:
         if: "always() && steps.protobuf_pub_upgrade.conclusion == 'success'"
         working-directory: protobuf
   job_006:
-    name: "format_analyze; linux; Dart dev; PKG: protoc_plugin; `dart format --output=none --set-exit-if-changed .`, `./../tool/setup.sh`, `make protos`, `dart analyze --fatal-infos`"
+    name: "format_analyze; linux; Dart dev; PKG: protoc_plugin; `dart format --output=none --set-exit-if-changed .`, `./../tool/setup.sh`, `make protos`, `dart analyze --fatal-infos bin lib test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:protoc_plugin;commands:format-command_0-command_3-analyze_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:protoc_plugin;commands:format-command_0-command_3-analyze_3"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:protoc_plugin
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
@@ -228,8 +228,8 @@ jobs:
         run: make protos
         if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
         working-directory: protoc_plugin
-      - name: "protoc_plugin; dart analyze --fatal-infos"
-        run: dart analyze --fatal-infos
+      - name: "protoc_plugin; dart analyze --fatal-infos bin lib test"
+        run: dart analyze --fatal-infos bin lib test
         if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
         working-directory: protoc_plugin
   job_007:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -240,7 +240,7 @@ jobs:
         uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protobuf;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protobuf;commands:test_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protobuf
             os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0
@@ -277,7 +277,7 @@ jobs:
         uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protoc_plugin;commands:command_0-command_3-test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protoc_plugin;commands:command_0-command_3-test_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protoc_plugin
             os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0
@@ -322,7 +322,7 @@ jobs:
         uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:protobuf;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:protobuf;commands:test_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:protobuf
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
@@ -359,7 +359,7 @@ jobs:
         uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:protoc_plugin;commands:command_0-command_3-test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:protoc_plugin;commands:command_0-command_3-test_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:protoc_plugin
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
@@ -404,7 +404,7 @@ jobs:
         uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:macos-latest;pub-cache-hosted;sdk:2.12.0;packages:protobuf;commands:test"
+          key: "os:macos-latest;pub-cache-hosted;sdk:2.12.0;packages:protobuf;commands:test_0"
           restore-keys: |
             os:macos-latest;pub-cache-hosted;sdk:2.12.0;packages:protobuf
             os:macos-latest;pub-cache-hosted;sdk:2.12.0
@@ -441,7 +441,7 @@ jobs:
         uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:macos-latest;pub-cache-hosted;sdk:dev;packages:protobuf;commands:test"
+          key: "os:macos-latest;pub-cache-hosted;sdk:dev;packages:protobuf;commands:test_0"
           restore-keys: |
             os:macos-latest;pub-cache-hosted;sdk:dev;packages:protobuf
             os:macos-latest;pub-cache-hosted;sdk:dev
@@ -524,3 +524,56 @@ jobs:
       - job_004
       - job_005
       - job_006
+  job_015:
+    name: "run_legacy_tests; linux; Dart 2.12.0; PKG: protoc_plugin; `./../tool/setup.sh`, `make protos`, `dart test legacy_tests/generated_message_test.dart`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protoc_plugin;commands:command_0-command_3-test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protoc_plugin
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.12.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - id: protoc_plugin_pub_upgrade
+        name: protoc_plugin; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: protoc_plugin
+      - name: protoc_plugin; ./../tool/setup.sh
+        run: ./../tool/setup.sh
+        if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
+        working-directory: protoc_plugin
+      - name: protoc_plugin; make protos
+        run: make protos
+        if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
+        working-directory: protoc_plugin
+      - name: protoc_plugin; dart test legacy_tests/generated_message_test.dart
+        run: dart test legacy_tests/generated_message_test.dart
+        if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
+        working-directory: protoc_plugin
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014

--- a/protoc_plugin/legacy_tests/generated_message_test.dart
+++ b/protoc_plugin/legacy_tests/generated_message_test.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart=2.11
+
+import 'package:test/test.dart';
+
+import '../out/protos/google/protobuf/unittest.pb.dart';
+import '../out/protos/toplevel.pb.dart';
+import '../out/protos/toplevel_import.pb.dart' as t;
+
+void main() {
+  test('testSettersRejectNull', () {
+    var message = TestAllTypes();
+    expect(() {
+      message.optionalString = null;
+    }, throwsArgumentError);
+    expect(() {
+      message.optionalBytes = null;
+    }, throwsArgumentError);
+    expect(() {
+      message.optionalNestedMessage = null;
+    }, throwsArgumentError);
+    expect(() {
+      message.optionalNestedMessage = null;
+    }, throwsArgumentError);
+    expect(() {
+      message.optionalNestedEnum = null;
+    }, throwsArgumentError);
+    expect(() {
+      message.repeatedString.add(null);
+    }, throwsArgumentError);
+    expect(() {
+      message.repeatedBytes.add(null);
+    }, throwsArgumentError);
+    expect(() {
+      message.repeatedNestedMessage.add(null);
+    }, throwsArgumentError);
+    expect(() {
+      message.repeatedNestedMessage.add(null);
+    }, throwsArgumentError);
+    expect(() {
+      message.repeatedNestedEnum.add(null);
+    }, throwsArgumentError);
+  });
+
+  test('testRepeatedSettersRejectNull', () {
+    var message = TestAllTypes();
+
+    message.repeatedString.addAll(['one', 'two']);
+    expect(() {
+      message.repeatedString[1] = null;
+    }, throwsArgumentError);
+
+    message.repeatedBytes.addAll(['one'.codeUnits, 'two'.codeUnits]);
+    expect(() {
+      message.repeatedBytes[1] = null;
+    }, throwsArgumentError);
+
+    message.repeatedNestedMessage.addAll([
+      TestAllTypes_NestedMessage()..bb = 318,
+      TestAllTypes_NestedMessage()..bb = 456
+    ]);
+    expect(() {
+      message.repeatedNestedMessage[1] = null;
+    }, throwsArgumentError);
+
+    message.repeatedNestedEnum
+        .addAll([TestAllTypes_NestedEnum.FOO, TestAllTypes_NestedEnum.BAR]);
+    expect(() {
+      message.repeatedNestedEnum[1] = null;
+    }, throwsArgumentError);
+  });
+
+  test('testRepeatedAppendRejectsNull', () {
+    var message = TestAllTypes();
+
+    expect(() {
+      message.repeatedForeignMessage.addAll([ForeignMessage()..c = 12, null]);
+    }, throwsArgumentError);
+
+    expect(() {
+      message.repeatedForeignEnum.addAll([ForeignEnum.FOREIGN_BAZ, null]);
+    }, throwsArgumentError);
+
+    expect(() {
+      message.repeatedString.addAll(['one', null]);
+    }, throwsArgumentError);
+
+    expect(() {
+      message.repeatedBytes.addAll(['one'.codeUnits, null]);
+    }, throwsArgumentError);
+  });
+
+  test('testToplevel', () {
+    var message = t.M();
+    message.t = T();
+    t.SApi(null);
+  });
+}

--- a/protoc_plugin/legacy_tests/generated_message_test.dart
+++ b/protoc_plugin/legacy_tests/generated_message_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/protoc_plugin/mono_pkg.yaml
+++ b/protoc_plugin/mono_pkg.yaml
@@ -13,3 +13,9 @@ stages:
       - command: make protos
       - test
       sdk: [pubspec, dev]
+  - run_legacy_tests:
+    - group:
+      - command: ./../tool/setup.sh
+      - command: make protos
+      - test: legacy_tests/generated_message_test.dart
+      sdk: [pubspec]

--- a/protoc_plugin/mono_pkg.yaml
+++ b/protoc_plugin/mono_pkg.yaml
@@ -5,7 +5,8 @@ stages:
       - format
       - command: ./../tool/setup.sh
       - command: make protos
-      - analyze: --fatal-infos
+      # Specify directores to exclude legacy_tests
+      - analyze: --fatal-infos bin lib test
       sdk: [dev]
   - run_tests:
     - group:

--- a/protoc_plugin/test/generated_message_test.dart
+++ b/protoc_plugin/test/generated_message_test.dart
@@ -177,7 +177,7 @@ void main() {
     // expect(MessageWithNoOuter.getDescriptor().getFile(),
     //        MultipleFilesTestProto.getDescriptor());
 
-    var tagNumber = message.getTagNumber('foreignEnum') as int;
+    var tagNumber = message.getTagNumber('foreignEnum')!;
     expect(message.getField(tagNumber), EnumWithNoOuter.BAR);
 
     // Not currently supported in Dart protobuf.

--- a/protoc_plugin/test/generated_message_test.dart
+++ b/protoc_plugin/test/generated_message_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.11
-
 import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 
@@ -18,8 +16,6 @@ import '../out/protos/package3.pb.dart' as p3;
 import '../out/protos/reserved_names.pb.dart';
 import '../out/protos/reserved_names_extension.pb.dart';
 import '../out/protos/reserved_names_message.pb.dart';
-import '../out/protos/toplevel.pb.dart';
-import '../out/protos/toplevel_import.pb.dart' as t;
 import 'test_util.dart';
 
 void main() {
@@ -36,40 +32,6 @@ void main() {
     expect(value2.repeatedInt32, value1.repeatedInt32);
     expect(value2.repeatedImportEnum, value1.repeatedImportEnum);
     expect(value2.repeatedForeignMessage, value1.repeatedForeignMessage);
-  });
-
-  test('testSettersRejectNull', () {
-    var message = TestAllTypes();
-    expect(() {
-      message.optionalString = null;
-    }, throwsArgumentError);
-    expect(() {
-      message.optionalBytes = null;
-    }, throwsArgumentError);
-    expect(() {
-      message.optionalNestedMessage = null;
-    }, throwsArgumentError);
-    expect(() {
-      message.optionalNestedMessage = null;
-    }, throwsArgumentError);
-    expect(() {
-      message.optionalNestedEnum = null;
-    }, throwsArgumentError);
-    expect(() {
-      message.repeatedString.add(null);
-    }, throwsArgumentError);
-    expect(() {
-      message.repeatedBytes.add(null);
-    }, throwsArgumentError);
-    expect(() {
-      message.repeatedNestedMessage.add(null);
-    }, throwsArgumentError);
-    expect(() {
-      message.repeatedNestedMessage.add(null);
-    }, throwsArgumentError);
-    expect(() {
-      message.repeatedNestedEnum.add(null);
-    }, throwsArgumentError);
   });
 
   test('testDefaultMessageIsReadOnly', () {
@@ -107,34 +69,6 @@ void main() {
     assertRepeatedFieldsModified(message);
   });
 
-  test('testRepeatedSettersRejectNull', () {
-    var message = TestAllTypes();
-
-    message.repeatedString.addAll(['one', 'two']);
-    expect(() {
-      message.repeatedString[1] = null;
-    }, throwsArgumentError);
-
-    message.repeatedBytes.addAll(['one'.codeUnits, 'two'.codeUnits]);
-    expect(() {
-      message.repeatedBytes[1] = null;
-    }, throwsArgumentError);
-
-    message.repeatedNestedMessage.addAll([
-      TestAllTypes_NestedMessage()..bb = 318,
-      TestAllTypes_NestedMessage()..bb = 456
-    ]);
-    expect(() {
-      message.repeatedNestedMessage[1] = null;
-    }, throwsArgumentError);
-
-    message.repeatedNestedEnum
-        .addAll([TestAllTypes_NestedEnum.FOO, TestAllTypes_NestedEnum.BAR]);
-    expect(() {
-      message.repeatedNestedEnum[1] = null;
-    }, throwsArgumentError);
-  });
-
   test('testRepeatedAppend', () {
     var message = TestAllTypes()
       ..repeatedInt32.addAll([1, 2, 3, 4])
@@ -145,26 +79,6 @@ void main() {
     expect(message.repeatedForeignEnum, [ForeignEnum.FOREIGN_BAZ]);
     expect(message.repeatedForeignMessage.length, 1);
     expect(message.repeatedForeignMessage[0].c, 12);
-  });
-
-  test('testRepeatedAppendRejectsNull', () {
-    var message = TestAllTypes();
-
-    expect(() {
-      message.repeatedForeignMessage.addAll([ForeignMessage()..c = 12, null]);
-    }, throwsArgumentError);
-
-    expect(() {
-      message.repeatedForeignEnum.addAll([ForeignEnum.FOREIGN_BAZ, null]);
-    }, throwsArgumentError);
-
-    expect(() {
-      message.repeatedString.addAll(['one', null]);
-    }, throwsArgumentError);
-
-    expect(() {
-      message.repeatedBytes.addAll(['one'.codeUnits, null]);
-    }, throwsArgumentError);
   });
 
   test('testSettingForeignMessage', () {
@@ -263,8 +177,7 @@ void main() {
     // expect(MessageWithNoOuter.getDescriptor().getFile(),
     //        MultipleFilesTestProto.getDescriptor());
 
-    var tagNumber = message.getTagNumber('foreignEnum');
-    expect(tagNumber, isNotNull);
+    var tagNumber = message.getTagNumber('foreignEnum') as int;
     expect(message.getField(tagNumber), EnumWithNoOuter.BAR);
 
     // Not currently supported in Dart protobuf.
@@ -805,12 +718,6 @@ void main() {
     message.m2M = p2.M_M();
     message.m3 = p3.M();
     message.m3M = p3.M_M();
-  });
-
-  test('testToplevel', () {
-    var message = t.M();
-    message.t = T();
-    t.SApi(null);
   });
 
   test('to toDebugString', () {

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -79,6 +79,10 @@ for PKG in ${PKGS}; do
         echo 'dart analyze test'
         dart analyze test || EXIT_CODE=$?
         ;;
+      analyze_3)
+        echo 'dart analyze --fatal-infos bin lib test'
+        dart analyze --fatal-infos bin lib test || EXIT_CODE=$?
+        ;;
       command_0)
         echo './../tool/setup.sh'
         ./../tool/setup.sh || EXIT_CODE=$?

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -99,9 +99,13 @@ for PKG in ${PKGS}; do
         echo 'dart format --output=none --set-exit-if-changed .'
         dart format --output=none --set-exit-if-changed . || EXIT_CODE=$?
         ;;
-      test)
+      test_0)
         echo 'dart test'
         dart test || EXIT_CODE=$?
+        ;;
+      test_1)
+        echo 'dart test legacy_tests/generated_message_test.dart'
+        dart test legacy_tests/generated_message_test.dart || EXIT_CODE=$?
         ;;
       *)
         echo -e "\033[31mUnknown TASK '${TASK}' - TERMINATING JOB\033[0m"


### PR DESCRIPTION
Move the non-null-safe usage of the API to another file, test the file with Dart 2.x.
