### PR TITLE
Fix a test

### DIFF
--- a/protoc_plugin/test/extension_test.dart
+++ b/protoc_plugin/test/extension_test.dart
@@ -543,8 +543,9 @@ void main() {
         isTrue);
     expect(
         identical(withUnknownFields.innerMap[1], reparsed.innerMap[1]), isTrue);
-    expect(withUnknownFields.stringMap.length, reparsed.stringMap.length);
-    expect(withUnknownFields.stringMap[0], reparsed.stringMap[0]);
+    expect(withUnknownFields.stringMap.length, 1);
+    expect(reparsed.stringMap.length, 1);
+    expect(withUnknownFields.stringMap['hello']!, reparsed.stringMap['hello']!);
   });
 
   test('consistent hashcode for reparsed messages with extensions', () {


### PR DESCRIPTION
This test is currently using an invalid map key type (int instead of string) for indexing and comparing two `null` values. It was valid in older versions where maps were represented as lists, but became invalid when we switched to a map type.

Also updated the length check to rule out the case where lists have the same length, but both are wrong.

Syncs cl/504248137 with some changes.