### PR TITLE
contribute a publishing automation action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,8 @@
-# Set update schedule for GitHub Actions
-# See https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+# Dependabot configuration file.
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
 
 version: 2
 updates:
-
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -270,23 +270,23 @@ jobs:
       - job_005
       - job_006
   job_008:
-    name: "run_tests; linux; Dart 2.12.0; PKG: protoc_plugin; `./../tool/setup.sh`, `make protos`, `dart test`"
+    name: "run_tests; linux; Dart 2.17.0; PKG: protoc_plugin; `./../tool/setup.sh`, `make protos`, `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protoc_plugin;commands:command_0-command_3-test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:protoc_plugin;commands:command_0-command_3-test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protoc_plugin
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:protoc_plugin
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "2.12.0"
+          sdk: "2.17.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
@@ -525,23 +525,23 @@ jobs:
       - job_005
       - job_006
   job_015:
-    name: "run_legacy_tests; linux; Dart 2.12.0; PKG: protoc_plugin; `./../tool/setup.sh`, `make protos`, `dart test legacy_tests/generated_message_test.dart`"
+    name: "run_legacy_tests; linux; Dart 2.17.0; PKG: protoc_plugin; `./../tool/setup.sh`, `make protos`, `dart test legacy_tests/generated_message_test.dart`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protoc_plugin;commands:command_0-command_3-test_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:protoc_plugin;commands:command_0-command_3-test_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:protoc_plugin
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:protoc_plugin
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "2.12.0"
+          sdk: "2.17.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,14 @@
+# A CI configuration to auto-publish pub packages.
+
+name: Publish
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
+
+jobs:
+  publish:
+    if: ${{ github.repository_owner == 'google' }}
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ master ]
   push:
-    tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
+    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,11 +3,16 @@
 name: Publish
 
 on:
+  # Trigger on pull requests that target the default branch.
   pull_request:
     branches: [ master ]
+  # Also, trigger when tags are pushed to the repo.
   push:
     tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 
+# The script below will perform publishing checks (version checks, publishing
+# dry run, ...) when run on a PR, and perform an actual pub publish when run as
+# a result of a git tag event.
 jobs:
   publish:
     if: ${{ github.repository_owner == 'google' }}

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Package | Description | Published Version
 [protoc_plugin](protoc_plugin/) | A Dart back-end for the protoc compiler | [![pub package](https://img.shields.io/pub/v/protoc_plugin.svg)](https://pub.dev/packages/protoc_plugin)
 [api_benchmark](api_benchmark/) | Benchmarking for various API calls |
 [query_benchmark](query_benchmark/) | Benchmark for encoding and decoding of a "real-world" protobuf |
+
+## Publishing automation
+
+For information about our publishing automation and release process, see
+https://github.com/dart-lang/ecosystem/wiki/Publishing-automation.

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,8 +1,8 @@
 name: protobuf
 version: 3.0.0-dev
 description: >-
-  Runtime library for protocol buffers support.
-  Use https://pub.dev/packages/protoc_plugin to generate dart code for your '.proto' files.
+  Runtime library for protocol buffers support. Use with package:protoc_plugin
+  to generate dart code for your '.proto' files.
 repository: https://github.com/google/protobuf.dart/tree/master/protobuf
 
 environment:

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Remove message constructor arguments. Constructors with arguments cause
   increase in release binary sizes even when no arguments are passed to the
   constructors. ([#703])
+* Require Dart `2.17`.
 
   **Migration:**
 

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: protoc_plugin
 version: 21.0.0-dev
-description: Protoc compiler plugin to generate Dart code
+description: A protobuf protoc compiler plugin used to generate Dart code.
 repository: https://github.com/google/protobuf.dart/tree/master/protoc_plugin
 
 environment:
@@ -19,7 +19,3 @@ dev_dependencies:
 
 executables:
   protoc-gen-dart: protoc_plugin
-
-dependency_overrides:
-  protobuf:
-    path: ../protobuf

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -4,7 +4,7 @@ description: A protobuf protoc compiler plugin used to generate Dart code.
 repository: https://github.com/google/protobuf.dart/tree/master/protoc_plugin
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   fixnum: ^1.0.0

--- a/protoc_plugin/pubspec_overrides.yaml
+++ b/protoc_plugin/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  protobuf:
+    path: ../protobuf


### PR DESCRIPTION
This PR contributes a publishing automation action. You can find more info here: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose, but briefly:

- on PRs, general publishing information is validated (pubspec version, changelog version, pub publish dry run, ...)
- after a change (intended for publishing) has landed on the default branch, tagging that commit with a well formed git tag (`package_name-v1.2.3`) will trigger a github workflow which will invoke `dart pub publish --force` w/ the correct package

@osa1 - after landing this there is some minor config that needs to happen in the pub.dev admin pages for package:protobuf and package:protoc_plugin. And fair warning, anyone with push access to this repo will be able to trigger a publish (it's possible to lock it down more than that - using github environments and some additional signoff on publish - but that's not enabled by default).
