### PR TITLE
Format the generated code.

### DIFF
--- a/protoc_plugin/lib/protoc.dart
+++ b/protoc_plugin/lib/protoc.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:dart_style/dart_style.dart';
 import 'package:protobuf/protobuf.dart';
 
 import 'const_generator.dart' show writeJsonConst;

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -223,6 +223,13 @@ class FileGenerator extends ProtobufContainer {
   List<CodeGeneratorResponse_File> generateFiles(OutputConfiguration config) {
     if (!_linked) throw StateError('not linked');
 
+    String formatDartCode(String code) {
+      final formatter = DartFormatter();
+
+      final formattedCode = formatter.format(code);
+      return formattedCode;
+    }
+
     CodeGeneratorResponse_File makeFile(String extension, String content) {
       var protoUrl = Uri.file(descriptor.name);
       var dartUrl = config.outputPathFor(protoUrl, extension);
@@ -235,9 +242,9 @@ class FileGenerator extends ProtobufContainer {
     var enumWriter = generateEnumFile(config);
 
     final files = [
-      makeFile('.pb.dart', mainWriter.toString()),
-      makeFile('.pbenum.dart', enumWriter.toString()),
-      makeFile('.pbjson.dart', generateJsonFile(config)),
+      makeFile('.pb.dart', formatDartCode(mainWriter.toString())),
+      makeFile('.pbenum.dart', formatDartCode(enumWriter.toString())),
+      makeFile('.pbjson.dart', formatDartCode(generateJsonFile(config))),
     ];
 
     if (options.generateMetadata) {

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
+  dart_style: ^2.2.5
   fixnum: ^1.0.0
   path: ^1.8.0
   protobuf: ^2.0.0

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -4,7 +4,7 @@ description: A protobuf protoc compiler plugin used to generate Dart code.
 repository: https://github.com/google/protobuf.dart/tree/master/protoc_plugin
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   dart_style: ^2.2.5
@@ -14,9 +14,9 @@ dependencies:
 
 dev_dependencies:
   collection: ^1.15.0
-  lints: ^1.0.0
+  lints: ^2.0.0
   matcher: ^0.12.10
-  test: ^1.16.0
+  test: ^1.22.0
 
 executables:
   protoc-gen-dart: protoc_plugin

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -16,7 +16,7 @@ dev_dependencies:
   collection: ^1.15.0
   lints: ^2.0.0
   matcher: ^0.12.10
-  test: ^1.21.5
+  test: ^1.21.4
 
 executables:
   protoc-gen-dart: protoc_plugin

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -4,7 +4,7 @@ description: A protobuf protoc compiler plugin used to generate Dart code.
 repository: https://github.com/google/protobuf.dart/tree/master/protoc_plugin
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   dart_style: ^2.2.5
@@ -16,7 +16,7 @@ dev_dependencies:
   collection: ^1.15.0
   lints: ^2.0.0
   matcher: ^0.12.10
-  test: ^1.22.0
+  test: ^1.21.5
 
 executables:
   protoc-gen-dart: protoc_plugin

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  dart_style: ^2.2.5
+  dart_style: ^2.2.3
   fixnum: ^1.0.0
   path: ^1.8.0
   protobuf: ^2.0.0


### PR DESCRIPTION
This is equivalent to running `dart format .` in the directory after the code is generated.

Usually I get warnings from the generated code (Which can be turned of by the linter, i know). Also, If the code is uploaded as a package to pub.dev, It will lose 10 points for formatting.

> #### Pass static analysis
> code has no errors, warnings, lints, or formatting issues.
