### PR TITLE
Apply internally enabled lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,6 +13,8 @@ linter:
   - directives_ordering
   - no_leading_underscores_for_local_identifiers
   - omit_local_variable_types
+  - prefer_final_in_for_each
+  - prefer_final_locals
   - prefer_relative_imports
   - prefer_single_quotes
   - prefer_spread_collections

--- a/api_benchmark/lib/benchmark.dart
+++ b/api_benchmark/lib/benchmark.dart
@@ -52,7 +52,7 @@ abstract class Benchmark {
       {Profiler? profiler}) sync* {
     checkRequest(r);
 
-    var sampleMillis = r.duration;
+    final sampleMillis = r.duration;
     setup();
 
     for (var i = 0; i < samples; i++) {
@@ -61,7 +61,7 @@ abstract class Benchmark {
 
     if (profiler != null) {
       profiler.startProfile(r);
-      var s = _measureOnce(sampleMillis);
+      final s = _measureOnce(sampleMillis);
       profiler.endProfile(s);
     }
 
@@ -84,7 +84,7 @@ abstract class Benchmark {
       return 1;
     }, 100);
 
-    var sample = _measureFor(exercise, sampleMillis);
+    final sample = _measureFor(exercise, sampleMillis);
     setCounts(sample);
     return sample;
   }
@@ -121,10 +121,10 @@ abstract class Benchmark {
   String summarizeResponse(pb.Response r) {
     checkRequest(r.request);
 
-    var prefix = summary.padRight(39);
-    var sampleCount = r.samples.length.toStringAsFixed(0).padLeft(2);
-    var median = measureSample(medianSample(r)).toStringAsFixed(0).padLeft(4);
-    var max = measureSample(maxSample(r)).toStringAsFixed(0).padLeft(4);
+    final prefix = summary.padRight(39);
+    final sampleCount = r.samples.length.toStringAsFixed(0).padLeft(2);
+    final median = measureSample(medianSample(r)).toStringAsFixed(0).padLeft(4);
+    final max = measureSample(maxSample(r)).toStringAsFixed(0).padLeft(4);
 
     return '$prefix samples: $sampleCount'
         ' median: $median max: $max $measureSampleUnits';
@@ -133,11 +133,11 @@ abstract class Benchmark {
   /// Returns the sample with the median measurement.
   pb.Sample? medianSample(pb.Response? response) {
     if (response == null || response.samples.isEmpty) return null;
-    var samples = [...response.samples];
+    final samples = [...response.samples];
     samples.sort((a, b) {
       return measureSample(a).compareTo(measureSample(b));
     });
-    var index = samples.length ~/ 2;
+    final index = samples.length ~/ 2;
     return samples[index];
   }
 
@@ -145,7 +145,7 @@ abstract class Benchmark {
   pb.Sample? maxSample(pb.Response? response) {
     if (response == null) return null;
     pb.Sample? best;
-    for (var s in response.samples) {
+    for (final s in response.samples) {
       best ??= s;
       if (measureSample(best) < measureSample(s)) {
         best = s;
@@ -166,10 +166,10 @@ abstract class Benchmark {
   /// Executes [runner] repeatedly until [minimumMillis] has been reached.
   /// [runner] should return the number of times it ran the benchmark.
   static pb.Sample _measureFor(int Function() runner, int minimumMillis) {
-    var minimumMicros = minimumMillis * 1000;
+    final minimumMicros = minimumMillis * 1000;
     var reps = 0;
     var elapsed = 0;
-    var watch = Stopwatch()..start();
+    final watch = Stopwatch()..start();
     while (elapsed < minimumMicros) {
       reps += runner();
       elapsed = watch.elapsedMicroseconds;

--- a/api_benchmark/lib/benchmarks/get_strings.dart
+++ b/api_benchmark/lib/benchmarks/get_strings.dart
@@ -18,13 +18,13 @@ class GetStringsBenchmark extends Benchmark {
 
   @override
   String get summary {
-    var fill = fillValue == null ? 'null' : "'$fillValue'";
+    final fill = fillValue == null ? 'null' : "'$fillValue'";
     return '${id.name}($height x $fill)';
   }
 
   @override
   Params makeParams() {
-    var p = Params()..messageCount = height;
+    final p = Params()..messageCount = height;
     if (fillValue != null) p.stringValue = fillValue!;
     return p;
   }
@@ -36,13 +36,13 @@ class GetStringsBenchmark extends Benchmark {
 
   // makes a rectangle where every cell has the same value.
   static pb.Grid10 _makeGrid(int height, String? fillValue) {
-    var grid = pb.Grid10();
+    final grid = pb.Grid10();
 
     for (var y = 0; y < height; y++) {
-      var line = pb.Line10();
+      final line = pb.Line10();
       if (fillValue != null) {
         for (var x = 0; x < width; x++) {
-          var tag = getTagForColumn(line, x);
+          final tag = getTagForColumn(line, x);
           line.setField(tag, fillValue);
         }
       }
@@ -76,7 +76,7 @@ class GetStringsBenchmark extends Benchmark {
 
   void _getDefaults() {
     var ok = true;
-    for (var line in grid.lines) {
+    for (final line in grid.lines) {
       ok = ok && line.cell1.isEmpty;
       ok = ok && line.cell2.isEmpty;
       ok = ok && line.cell3.isEmpty;
@@ -93,7 +93,7 @@ class GetStringsBenchmark extends Benchmark {
 
   void _getStrings() {
     var ok = true;
-    for (var line in grid.lines) {
+    for (final line in grid.lines) {
       ok = ok && line.cell1.isNotEmpty;
       ok = ok && line.cell2.isNotEmpty;
       ok = ok && line.cell3.isNotEmpty;

--- a/api_benchmark/lib/benchmarks/has_strings.dart
+++ b/api_benchmark/lib/benchmarks/has_strings.dart
@@ -18,13 +18,13 @@ class HasStringsBenchmark extends Benchmark {
 
   @override
   String get summary {
-    var fill = fillValue == null ? 'null' : "'$fillValue'";
+    final fill = fillValue == null ? 'null' : "'$fillValue'";
     return '${id.name}($height x $fill)';
   }
 
   @override
   Params makeParams() {
-    var p = Params()..messageCount = height;
+    final p = Params()..messageCount = height;
     if (fillValue != null) p.stringValue = fillValue!;
     return p;
   }
@@ -36,13 +36,13 @@ class HasStringsBenchmark extends Benchmark {
 
   // makes a rectangle where no fields have been set.
   static pb.Grid10 _makeGrid(int width, int height, String? fillValue) {
-    var grid = pb.Grid10();
+    final grid = pb.Grid10();
 
     for (var y = 0; y < height; y++) {
-      var line = pb.Line10();
+      final line = pb.Line10();
       if (fillValue != null) {
         for (var x = 0; x < width; x++) {
-          var tag = getTagForColumn(line, x);
+          final tag = getTagForColumn(line, x);
           line.setField(tag, fillValue);
         }
       }
@@ -76,7 +76,7 @@ class HasStringsBenchmark extends Benchmark {
 
   void runFilled() {
     var allPresent = true;
-    for (var line in grid.lines) {
+    for (final line in grid.lines) {
       allPresent = allPresent && line.hasCell1();
       allPresent = allPresent && line.hasCell2();
       allPresent = allPresent && line.hasCell3();
@@ -93,7 +93,7 @@ class HasStringsBenchmark extends Benchmark {
 
   void runEmpty() {
     var allEmpty = true;
-    for (var line in grid.lines) {
+    for (final line in grid.lines) {
       allEmpty = allEmpty && !line.hasCell1();
       allEmpty = allEmpty && !line.hasCell2();
       allEmpty = allEmpty && !line.hasCell3();

--- a/api_benchmark/lib/benchmarks/index.dart
+++ b/api_benchmark/lib/benchmarks/index.dart
@@ -16,7 +16,7 @@ import 'string_json.dart';
 
 /// Creates the appropriate Benchmark instance for a protobuf.
 Benchmark createBenchmark(pb.Request r) {
-  var type = allBenchmarks[r.id];
+  final type = allBenchmarks[r.id];
   if (type == null) {
     throw ArgumentError('unknown benchmark: ${r.id.name}');
   }
@@ -36,8 +36,8 @@ final Map<pb.BenchmarkID, BenchmarkType> allBenchmarks = _makeTypeMap([
 ]);
 
 Map<pb.BenchmarkID, BenchmarkType> _makeTypeMap(List<BenchmarkType> types) {
-  var out = <pb.BenchmarkID, BenchmarkType>{};
-  for (var type in types) {
+  final out = <pb.BenchmarkID, BenchmarkType>{};
+  for (final type in types) {
     if (out.containsKey(type.id)) {
       throw 'already added: $type.id.name';
     }

--- a/api_benchmark/lib/benchmarks/int32_json.dart
+++ b/api_benchmark/lib/benchmarks/int32_json.dart
@@ -26,7 +26,7 @@ class Int32Benchmark extends Benchmark {
 
   @override
   void setup() {
-    var grid = _makeGrid(width, height);
+    final grid = _makeGrid(width, height);
     json = grid.writeToJson();
     lastFieldTag = getTagForColumn(pb.Line10(), width - 1);
   }
@@ -37,12 +37,12 @@ class Int32Benchmark extends Benchmark {
   // 2 3 4 5
   static pb.Grid10 _makeGrid(int width, int height) {
     if (width > 10) throw ArgumentError('width out of range: $width');
-    var grid = pb.Grid10();
+    final grid = pb.Grid10();
 
     for (var y = 0; y < height; y++) {
-      var line = pb.Line10();
+      final line = pb.Line10();
       for (var x = 0; x < width; x++) {
-        var tag = getTagForColumn(line, x)!;
+        final tag = getTagForColumn(line, x)!;
         line.setField(tag, x + y);
       }
       grid.lines.add(line);
@@ -57,8 +57,8 @@ class Int32Benchmark extends Benchmark {
 
   @override
   void run() {
-    var grid = pb.Grid10.fromJson(json);
-    var actual = grid.lines[height - 1].getField(lastFieldTag!);
+    final grid = pb.Grid10.fromJson(json);
+    final actual = grid.lines[height - 1].getField(lastFieldTag!);
     if (actual != width + height - 2) throw 'failed; got $actual';
   }
 

--- a/api_benchmark/lib/benchmarks/int64_json.dart
+++ b/api_benchmark/lib/benchmarks/int64_json.dart
@@ -28,7 +28,7 @@ class Int64Benchmark extends Benchmark {
 
   @override
   void setup() {
-    var grid = _makeGrid(width, height);
+    final grid = _makeGrid(width, height);
     json = grid.writeToJson();
     lastFieldTag = getTagForColumn(pb.Line10(), width - 1);
   }
@@ -39,12 +39,12 @@ class Int64Benchmark extends Benchmark {
   // 2 3 4 5
   static pb.Grid10 _makeGrid(int width, int height) {
     if (width > 10) throw ArgumentError('width out of range: $width');
-    var grid = pb.Grid10();
+    final grid = pb.Grid10();
 
     for (var y = 0; y < height; y++) {
-      var line = pb.Line10();
+      final line = pb.Line10();
       for (var x = 0; x < width; x++) {
-        var tag = getTagForColumn(line, x)!;
+        final tag = getTagForColumn(line, x)!;
         line.setField(tag, Int64(x + y));
       }
       grid.lines.add(line);
@@ -59,8 +59,8 @@ class Int64Benchmark extends Benchmark {
 
   @override
   void run() {
-    var grid = pb.Grid10.fromJson(json);
-    var actual = grid.lines[height - 1].getField(lastFieldTag!);
+    final grid = pb.Grid10.fromJson(json);
+    final actual = grid.lines[height - 1].getField(lastFieldTag!);
     if (actual != width + height - 2) throw 'failed; got $actual';
   }
 

--- a/api_benchmark/lib/benchmarks/repeated_int32_json.dart
+++ b/api_benchmark/lib/benchmarks/repeated_int32_json.dart
@@ -25,7 +25,7 @@ class RepeatedInt32Benchmark extends Benchmark {
 
   @override
   void setup() {
-    var grid = _makeGrid(width, height);
+    final grid = _makeGrid(width, height);
     json = grid.writeToJson();
   }
 
@@ -34,10 +34,10 @@ class RepeatedInt32Benchmark extends Benchmark {
   // 1 2 3 4
   // 2 3 4 5
   static pb.Grid _makeGrid(int width, int height) {
-    var grid = pb.Grid();
+    final grid = pb.Grid();
 
     for (var y = 0; y < height; y++) {
-      var line = pb.Line();
+      final line = pb.Line();
       for (var x = 0; x < width; x++) {
         line.cells.add(x + y);
       }
@@ -49,8 +49,8 @@ class RepeatedInt32Benchmark extends Benchmark {
 
   @override
   void run() {
-    var grid = pb.Grid.fromJson(json);
-    var actual = grid.lines[height - 1].cells[width - 1];
+    final grid = pb.Grid.fromJson(json);
+    final actual = grid.lines[height - 1].cells[width - 1];
     if (actual != width + height - 2) throw 'failed; got $actual';
   }
 

--- a/api_benchmark/lib/benchmarks/repeated_int64_json.dart
+++ b/api_benchmark/lib/benchmarks/repeated_int64_json.dart
@@ -27,7 +27,7 @@ class RepeatedInt64Benchmark extends Benchmark {
 
   @override
   void setup() {
-    var grid = _makeGrid(width, height);
+    final grid = _makeGrid(width, height);
     json = grid.writeToJson();
   }
 
@@ -36,10 +36,10 @@ class RepeatedInt64Benchmark extends Benchmark {
   // 1 2 3 4
   // 2 3 4 5
   static pb.Grid _makeGrid(int width, int height) {
-    var grid = pb.Grid();
+    final grid = pb.Grid();
 
     for (var y = 0; y < height; y++) {
-      var line = pb.Line();
+      final line = pb.Line();
       for (var x = 0; x < width; x++) {
         line.cells.add(Int64(x + y));
       }
@@ -51,8 +51,8 @@ class RepeatedInt64Benchmark extends Benchmark {
 
   @override
   void run() {
-    var grid = pb.Grid.fromJson(json);
-    var actual = grid.lines[height - 1].cells[width - 1];
+    final grid = pb.Grid.fromJson(json);
+    final actual = grid.lines[height - 1].cells[width - 1];
     if (actual != width + height - 2) throw 'failed; got $actual';
   }
 

--- a/api_benchmark/lib/benchmarks/repeated_string_json.dart
+++ b/api_benchmark/lib/benchmarks/repeated_string_json.dart
@@ -29,7 +29,7 @@ class RepeatedStringBenchmark extends Benchmark {
 
   @override
   void setup() {
-    var grid = _makeGrid(width, height, stringSize);
+    final grid = _makeGrid(width, height, stringSize);
     json = grid.writeToJson();
   }
 
@@ -39,14 +39,14 @@ class RepeatedStringBenchmark extends Benchmark {
   // "23" "34" "45" "56"
   static pb.Grid _makeGrid(int width, int height, int stringSize) {
     if (width > 10) throw ArgumentError('width out of range: $width');
-    var grid = pb.Grid();
+    final grid = pb.Grid();
 
-    var zero = '0'.codeUnits[0];
+    final zero = '0'.codeUnits[0];
 
     for (var y = 0; y < height; y++) {
-      var line = pb.Line();
+      final line = pb.Line();
       for (var x = 0; x < width; x++) {
-        var charCodes = <int>[];
+        final charCodes = <int>[];
         for (var i = 0; i < stringSize; i++) {
           charCodes.add(zero + ((x + y + i) % 10));
         }
@@ -59,8 +59,8 @@ class RepeatedStringBenchmark extends Benchmark {
 
   @override
   void run() {
-    var grid = pb.Grid.fromJson(json);
-    var actual = grid.lines[height - 1].cells[width - 1];
+    final grid = pb.Grid.fromJson(json);
+    final actual = grid.lines[height - 1].cells[width - 1];
     if (actual.length != stringSize) throw 'failed; got $actual';
   }
 

--- a/api_benchmark/lib/benchmarks/set_strings.dart
+++ b/api_benchmark/lib/benchmarks/set_strings.dart
@@ -18,13 +18,13 @@ class SetStringsBenchmark extends Benchmark {
 
   @override
   String get summary {
-    var fill = fillValue == null ? 'null' : "'$fillValue'";
+    final fill = fillValue == null ? 'null' : "'$fillValue'";
     return '${id.name}($height x $fill)';
   }
 
   @override
   Params makeParams() {
-    var p = Params()..messageCount = height;
+    final p = Params()..messageCount = height;
     if (fillValue != null) p.stringValue = fillValue!;
     return p;
   }
@@ -36,13 +36,13 @@ class SetStringsBenchmark extends Benchmark {
 
   // makes a rectangle where no fields have been set.
   static pb.Grid10 _makeGrid(int width, int height, String? fillValue) {
-    var grid = pb.Grid10();
+    final grid = pb.Grid10();
 
     for (var y = 0; y < height; y++) {
-      var line = pb.Line10();
+      final line = pb.Line10();
       if (fillValue != null) {
         for (var x = 0; x < width; x++) {
-          var tag = getTagForColumn(line, x);
+          final tag = getTagForColumn(line, x);
           line.setField(tag, fillValue);
         }
       }
@@ -67,8 +67,8 @@ class SetStringsBenchmark extends Benchmark {
 
   @override
   void run() {
-    var newValue = '';
-    for (var line in grid.lines) {
+    final newValue = '';
+    for (final line in grid.lines) {
       line.cell1 = newValue;
       line.cell2 = newValue;
       line.cell3 = newValue;

--- a/api_benchmark/lib/benchmarks/string_json.dart
+++ b/api_benchmark/lib/benchmarks/string_json.dart
@@ -28,7 +28,7 @@ class StringBenchmark extends Benchmark {
 
   @override
   void setup() {
-    var grid = _makeGrid(width, height, stringSize);
+    final grid = _makeGrid(width, height, stringSize);
     json = grid.writeToJson();
     lastFieldTag = getTagForColumn(pb.Line10(), width - 1);
   }
@@ -39,15 +39,15 @@ class StringBenchmark extends Benchmark {
   // "23" "34" "45" "56"
   static pb.Grid10 _makeGrid(int width, int height, int stringSize) {
     if (width > 10) throw ArgumentError('width out of range: $width');
-    var grid = pb.Grid10();
+    final grid = pb.Grid10();
 
-    var zero = '0'.codeUnits[0];
+    final zero = '0'.codeUnits[0];
 
     for (var y = 0; y < height; y++) {
-      var line = pb.Line10();
+      final line = pb.Line10();
       for (var x = 0; x < width; x++) {
-        var tag = getTagForColumn(line, x)!;
-        var charCodes = <int>[];
+        final tag = getTagForColumn(line, x)!;
+        final charCodes = <int>[];
         for (var i = 0; i < stringSize; i++) {
           charCodes.add(zero + ((x + y + i) % 10));
         }
@@ -65,8 +65,8 @@ class StringBenchmark extends Benchmark {
 
   @override
   void run() {
-    var grid = pb.Grid10.fromJson(json);
-    var actual = grid.lines[height - 1].getField(lastFieldTag!);
+    final grid = pb.Grid10.fromJson(json);
+    final actual = grid.lines[height - 1].getField(lastFieldTag!);
     if (actual.length != stringSize) throw 'failed; got $actual';
   }
 

--- a/api_benchmark/lib/dashboard.dart
+++ b/api_benchmark/lib/dashboard.dart
@@ -19,18 +19,18 @@ import 'suite.dart' show runSuite;
 Future showDashboard(pb.Suite suite, Element container) async {
   // set up model
 
-  var env = await loadBrowserEnv();
-  var reports = await loadReports(suite);
+  final env = await loadBrowserEnv();
+  final reports = await loadReports(suite);
 
-  var defaultReport = pb.Report()..env = env;
+  final defaultReport = pb.Report()..env = env;
   var model = DashboardModel(reports, Table(suite), defaultReport);
 
-  var baseline = chooseBaseline(env, reports);
+  final baseline = chooseBaseline(env, reports);
   if (baseline != null) {
     model = model.withBaseline(baseline);
   }
 
-  var view = DashboardView();
+  final view = DashboardView();
 
   Future render(pb.Report report) async {
     report.env = env;
@@ -45,11 +45,11 @@ Future showDashboard(pb.Suite suite, Element container) async {
   var running = false;
   void runBenchmarks() {
     if (running) return;
-    var profiler = JsProfiler();
+    final profiler = JsProfiler();
     running = true;
     () async {
-      var requests = model.table.selections.toList();
-      for (var report in runSuite(requests, profiler: profiler)) {
+      final requests = model.table.selections.toList();
+      for (final report in runSuite(requests, profiler: profiler)) {
         await render(report);
       }
     }()
@@ -95,7 +95,7 @@ class JsProfiler implements Profiler {
 
   @override
   void startProfile(pb.Request request) {
-    var label = '$count-${request.id.name}';
+    final label = '$count-${request.id.name}';
     count++;
     console!.callMethod('profile', [label]);
   }
@@ -109,13 +109,13 @@ class JsProfiler implements Profiler {
 
 Future<pb.Env> loadBrowserEnv() async {
   const advice = 'Run a VM benchmark to create this file.';
-  var pubspecYaml =
+  final pubspecYaml =
       (await _loadDataFile(data.pubspecYamlName, advice: advice))!;
-  var pubspecLock =
+  final pubspecLock =
       (await _loadDataFile(data.pubspecLockName, advice: advice))!;
-  var hostname = (await _loadDataFile(data.hostfileName, advice: advice))!;
+  final hostname = (await _loadDataFile(data.hostfileName, advice: advice))!;
 
-  var platform = createPlatform()
+  final platform = createPlatform()
     ..hostname = hostname
     ..userAgent = window.navigator.userAgent;
 
@@ -127,13 +127,13 @@ Future<pb.Env> loadBrowserEnv() async {
 
 /// Loads all the reports saved to benchmark/data.
 Future<Map<String, pb.Report>> loadReports(pb.Suite suite) async {
-  var out = <String, pb.Report>{};
+  final out = <String, pb.Report>{};
 
-  var dataJsonContent = (await _loadDataFile('data.json'))!;
-  var dataJson = jsonDecode(dataJsonContent) as Map<String, dynamic>;
+  final dataJsonContent = (await _loadDataFile('data.json'))!;
+  final dataJson = jsonDecode(dataJsonContent) as Map<String, dynamic>;
 
-  for (var entry in dataJson.entries) {
-    var report = pb.Report.fromJson(entry.value);
+  for (final entry in dataJson.entries) {
+    final report = pb.Report.fromJson(entry.value);
     if (isCompatibleBaseline(suite, report)) {
       out[entry.key] = report;
     }
@@ -145,8 +145,8 @@ Future<Map<String, pb.Report>> loadReports(pb.Suite suite) async {
 /// Choose the report to display on the left side for comparison.
 /// Returns null if no comparable report is found.
 String? chooseBaseline(pb.Env env, Map<String, pb.Report> reports) {
-  for (var name in reports.keys) {
-    var candidate = reports[name]!;
+  for (final name in reports.keys) {
+    final candidate = reports[name]!;
     if (candidate.env.platform == env.platform) {
       return name;
     }
@@ -160,8 +160,8 @@ bool isCompatibleBaseline(pb.Suite suite, pb.Report report) {
     if (i >= report.responses.length) {
       return true; // additional benchmarks ok
     }
-    var request = suite.requests[i];
-    var response = report.responses[i];
+    final request = suite.requests[i];
+    final response = report.responses[i];
     if (request != response.request) return false;
   }
   return true;

--- a/api_benchmark/lib/dashboard_model.dart
+++ b/api_benchmark/lib/dashboard_model.dart
@@ -15,7 +15,7 @@ class DashboardModel {
   DashboardModel(this.savedReports, this.table, this.latest);
 
   DashboardModel withBaseline(String? name) {
-    var nextTable = table.withBaseline(name, savedReports[name]);
+    final nextTable = table.withBaseline(name, savedReports[name]);
     return DashboardModel(savedReports, nextTable, latest);
   }
 
@@ -41,9 +41,9 @@ class Table {
       Table._raw(suite, null, null, Set<pb.Request>.from(suite.requests));
 
   Table._raw(this.suite, this.baseline, this.report, this.selections) {
-    var it = report == null ? [].iterator : report!.responses.iterator;
-    for (var r in suite.requests) {
-      var b = createBenchmark(r);
+    final it = report == null ? [].iterator : report!.responses.iterator;
+    for (final r in suite.requests) {
+      final b = createBenchmark(r);
       pb.Sample? baseline;
       if (it.moveNext()) {
         b.checkRequest(it.current.request);
@@ -66,7 +66,7 @@ class Table {
   }
 
   Table withSelection(pb.Request? request, bool selected) {
-    var s = Set<pb.Request?>.from(selections);
+    final s = Set<pb.Request?>.from(selections);
     if (selected) {
       s.add(request);
     } else {
@@ -86,7 +86,7 @@ class Row {
 
   /// Returns the response that should be displayed in this row.
   pb.Response? findResponse(pb.Report r) {
-    for (var candidate in r.responses) {
+    for (final candidate in r.responses) {
       if (candidate.request == request) return candidate;
     }
     return null;

--- a/api_benchmark/lib/dashboard_view.dart
+++ b/api_benchmark/lib/dashboard_view.dart
@@ -111,7 +111,7 @@ Choose baseline: <select class="dv-menu"></select>
 
     _renderEnv(model.latest);
 
-    var items = [noBaseline, ...model.savedReports.keys];
+    final items = [noBaseline, ...model.savedReports.keys];
     var selected = model.table.baseline;
     selected ??= noBaseline;
     _menu.render(items, model.table.baseline);
@@ -121,7 +121,7 @@ Choose baseline: <select class="dv-menu"></select>
   }
 
   void _renderEnv(pb.Report r) {
-    var newPlatform = r.env.platform.toString();
+    final newPlatform = r.env.platform.toString();
     if (newPlatform == _renderedPlatform) return;
     _envElt!.text = newPlatform;
     _renderedPlatform = newPlatform;
@@ -129,18 +129,18 @@ Choose baseline: <select class="dv-menu"></select>
 
   /// Renders a table with one row for each benchmark.
   void _renderResponses(Table table, pb.Report r) {
-    var rowIt = table.rows.iterator;
+    final rowIt = table.rows.iterator;
 
     // Update existing rows (we assume the table never shrinks)
-    for (var view in rowViews) {
-      var hasNext = rowIt.moveNext();
+    for (final view in rowViews) {
+      final hasNext = rowIt.moveNext();
       assert(hasNext);
       view.render(rowIt.current, r, _selectionChanges);
     }
 
     // Add any new rows
     while (rowIt.moveNext()) {
-      var row = _ResponseView()..render(rowIt.current, r, _selectionChanges);
+      final row = _ResponseView()..render(rowIt.current, r, _selectionChanges);
       _responseTable!.append(row.elt);
       rowViews.add(row);
     }
@@ -175,8 +175,8 @@ class _ResponseView {
 
   void render(
       Row row, pb.Report r, EventSink<SelectEvent<pb.Request>> rowSelected) {
-    var b = row.benchmark;
-    var response = row.findResponse(r);
+    final b = row.benchmark;
+    final response = row.findResponse(r);
     _selected.render(row.selected, item: row.request, sink: rowSelected);
     _summary.render(b.summary);
     _baseline.render(b.measureSample(row.baseline));
@@ -242,18 +242,18 @@ class _Menu {
   Stream<String?> get onChange => _changes.stream;
 
   void render(List<String> items, String? selected) {
-    var it = items.iterator;
+    final it = items.iterator;
 
     // Update existing items
-    for (var opt in _options) {
-      var hasNext = it.moveNext();
+    for (final opt in _options) {
+      final hasNext = it.moveNext();
       assert(hasNext); // assume menu never shrinks
       opt.render(it.current, it.current == selected);
     }
 
     // Add any new items
     while (it.moveNext()) {
-      var opt = _MenuOption();
+      final opt = _MenuOption();
       opt.render(it.current, it.current == selected);
       elt.append(opt.elt);
       _options.add(opt);

--- a/api_benchmark/lib/report.dart
+++ b/api_benchmark/lib/report.dart
@@ -12,8 +12,8 @@ pb.Response? findUpdatedResponse(pb.Report? beforeRep, pb.Report afterRep) {
   if (beforeRep == null) return afterRep.responses[0];
   assert(beforeRep.responses.length == afterRep.responses.length);
   for (var i = 0; i < afterRep.responses.length; i++) {
-    var before = beforeRep.responses[i];
-    var after = afterRep.responses[i];
+    final before = beforeRep.responses[i];
+    final after = afterRep.responses[i];
     assert(before.request.id == after.request.id);
     assert(before.request.params == after.request.params);
     if (before.samples.length != after.samples.length) {
@@ -50,7 +50,7 @@ final bool _implicitChecksEnabled = () {
 /// Given the contents of the pubspec.yaml and pubspec.lock files,
 /// create a pb.Packages object.
 pb.Packages createPackages(String pubspecYaml, String pubspecLock) {
-  var out = pb.Packages();
+  final out = pb.Packages();
 
   for (var line in pubspecYaml.split('\n')) {
     line = line.trim();
@@ -71,17 +71,17 @@ pb.Packages createPackages(String pubspecYaml, String pubspecLock) {
 ///   start a new package
 /// - only allows known keys within a package
 Iterable<pb.PackageVersion> _parseLockFile(String contents) sync* {
-  var yaml = loadYaml(contents) as YamlMap;
-  var packages = yaml['packages'] as YamlMap;
+  final yaml = loadYaml(contents) as YamlMap;
+  final packages = yaml['packages'] as YamlMap;
 
-  for (var entry in packages.entries) {
-    var map = entry.value as YamlMap;
-    var pkgVersion = pb.PackageVersion()
+  for (final entry in packages.entries) {
+    final map = entry.value as YamlMap;
+    final pkgVersion = pb.PackageVersion()
       ..name = entry.key as String
       ..source = map['source']
       ..version = map['version'];
 
-    var path = (map['description'] as YamlMap)['path'];
+    final path = (map['description'] as YamlMap)['path'];
     if (path != null) {
       pkgVersion.path = path;
     }
@@ -91,22 +91,22 @@ Iterable<pb.PackageVersion> _parseLockFile(String contents) sync* {
 
 /// Encodes a report as nicely-formatted JSON.
 String encodeReport(pb.Report report) {
-  var json = report.writeToJsonMap();
-  var out = StringBuffer();
+  final json = report.writeToJsonMap();
+  final out = StringBuffer();
   _stringifyMap(out, json, '');
   out.writeln();
   return out.toString();
 }
 
 String _stringifyMap(StringBuffer out, Map json, String indent) {
-  var childIndent = indent + '  ';
+  final childIndent = indent + '  ';
   out.writeln('{');
   var first = true;
-  for (var key in json.keys) {
+  for (final key in json.keys) {
     if (!first) out.writeln(',');
     first = false;
 
-    var value = json[key];
+    final value = json[key];
     out.write(childIndent);
     out.write(jsonEncode(key));
     out.write(': ');
@@ -124,10 +124,10 @@ String _stringifyMap(StringBuffer out, Map json, String indent) {
 }
 
 void _stringifyList(StringBuffer out, List json, String indent) {
-  var childIndent = indent + '  ';
+  final childIndent = indent + '  ';
   out.write('[\n');
   var first = true;
-  for (var item in json) {
+  for (final item in json) {
     if (!first) out.write(',\n');
     first = false;
     out.write(childIndent);

--- a/api_benchmark/lib/suite.dart
+++ b/api_benchmark/lib/suite.dart
@@ -17,16 +17,16 @@ import 'generated/benchmark.pb.dart' as pb;
 Iterable<pb.Report> runSuite(List<pb.Request?> requests,
     {int samplesPerBatch = 1, Profiler? profiler}) sync* {
   // Create a blank report with one response per request.
-  var report = pb.Report()..status = pb.Status.RUNNING;
-  for (var request in requests) {
-    var r = pb.Response()..request = request!;
+  final report = pb.Report()..status = pb.Status.RUNNING;
+  for (final request in requests) {
+    final r = pb.Response()..request = request!;
     report.responses.add(r);
   }
 
   // Set up progress reports.
   var sampleCount = 0;
   var totalSamples = 0;
-  for (var request in requests) {
+  for (final request in requests) {
     totalSamples += request!.samples;
   }
   pb.Report progress() {
@@ -37,21 +37,21 @@ Iterable<pb.Report> runSuite(List<pb.Request?> requests,
   // Send first progress message before starting.
   yield progress();
 
-  var benchmarks = <Benchmark>[];
-  for (var r in report.responses) {
+  final benchmarks = <Benchmark>[];
+  for (final r in report.responses) {
     benchmarks.add(createBenchmark(r.request));
   }
 
   // Collect the requested number of samples.
   while (sampleCount < totalSamples) {
     for (var i = 0; i < benchmarks.length; i++) {
-      var b = benchmarks[i];
-      var r = report.responses[i];
+      final b = benchmarks[i];
+      final r = report.responses[i];
       var batchSize = r.request.samples - r.samples.length;
       if (batchSize == 0) continue;
       if (batchSize > samplesPerBatch) batchSize = samplesPerBatch;
-      var p = r.samples.isEmpty ? profiler : null;
-      for (var s in b.measure(r.request, batchSize, profiler: p)) {
+      final p = r.samples.isEmpty ? profiler : null;
+      for (final s in b.measure(r.request, batchSize, profiler: p)) {
         r.samples.add(s);
         sampleCount++;
         yield progress();

--- a/api_benchmark/lib/suites/json.dart
+++ b/api_benchmark/lib/suites/json.dart
@@ -11,7 +11,7 @@ import '../benchmarks/string_json.dart';
 import '../generated/benchmark.pb.dart';
 
 final Suite jsonSuite = () {
-  var suite = Suite();
+  final suite = Suite();
   suite.requests.addAll([
     _int32(1, 100),
     _int32(2, 100),

--- a/api_benchmark/lib/suites/props.dart
+++ b/api_benchmark/lib/suites/props.dart
@@ -8,7 +8,7 @@ import '../benchmarks/set_strings.dart';
 import '../generated/benchmark.pb.dart';
 
 final Suite propsSuite = () {
-  var suite = Suite();
+  final suite = Suite();
   suite.requests.addAll([
     _getStrings(10, null),
     _getStrings(10, 'x'),

--- a/api_benchmark/lib/vm.dart
+++ b/api_benchmark/lib/vm.dart
@@ -17,17 +17,17 @@ import 'suite.dart' show runSuite;
 /// Writes a report to latest_vm.pb.json after every change,
 /// to make progress available to the browser.
 Future<void> runSuiteInVM(pb.Suite suite) async {
-  var env = await _loadEnv();
+  final env = await _loadEnv();
 
   pb.Report? lastReport;
   pb.Response? lastUpdate;
-  for (var report in runSuite(suite.requests, samplesPerBatch: 10)) {
+  for (final report in runSuite(suite.requests, samplesPerBatch: 10)) {
     report.env = env;
 
     // show progress
-    var update = findUpdatedResponse(lastReport, report);
+    final update = findUpdatedResponse(lastReport, report);
     if (update != null) {
-      var summary = _summarize(update);
+      final summary = _summarize(update);
       if (lastUpdate == null || update.request != lastUpdate.request) {
         stdout.write('\n$summary');
       } else {
@@ -40,15 +40,15 @@ Future<void> runSuiteInVM(pb.Suite suite) async {
   }
 
   // save the report to a file
-  var outFile = '${dataDir.path}/$latestVMReportName';
-  var tmpFile = File('$outFile.tmp');
+  final outFile = '${dataDir.path}/$latestVMReportName';
+  final tmpFile = File('$outFile.tmp');
   await tmpFile.writeAsString(encodeReport(lastReport!));
   await tmpFile.rename(outFile);
   print('\nWrote result to $outFile');
 }
 
 String _summarize(pb.Response r) {
-  var b = createBenchmark(r.request);
+  final b = createBenchmark(r.request);
   return b.summarizeResponse(r);
 }
 
@@ -63,13 +63,13 @@ void _overwrite(String line) {
 Future<pb.Env> _loadEnv() async {
   await _ensureDataDir();
 
-  var platform = createPlatform()
+  final platform = createPlatform()
     ..hostname = _hostname
     ..osType = _osType
     ..dartVersion = Platform.version;
 
-  var pubspec = await (File(pubspecYaml.path).readAsString());
-  var lock = await (File(pubspecLock.path).readAsString());
+  final pubspec = await (File(pubspecYaml.path).readAsString());
+  final lock = await (File(pubspecLock.path).readAsString());
 
   return pb.Env()
     ..script = _script
@@ -99,8 +99,8 @@ String get _script {
 
 String get _hostname {
   // Only including the first part of the hostname.
-  var h = Platform.localHostname;
-  var firstDot = h.indexOf('.');
+  final h = Platform.localHostname;
+  final firstDot = h.indexOf('.');
   if (firstDot == -1) return h;
   return h.substring(0, firstDot);
 }
@@ -120,7 +120,7 @@ final Link pubspecYaml = Link('${dataDir.path}/$pubspecYamlName');
 final Link pubspecLock = Link('${dataDir.path}/$pubspecLockName');
 
 final Directory dataDir = () {
-  var d = Directory('${pubspecDir.path}/web/data');
+  final d = Directory('${pubspecDir.path}/web/data');
   if (!d.existsSync()) {
     throw "data dir doesn't exist at ${d.path}";
   }

--- a/api_benchmark/tool/builder.dart
+++ b/api_benchmark/tool/builder.dart
@@ -13,9 +13,9 @@ Builder benchmarkBuilder(BuilderOptions options) => _BenchmarkBuilder();
 class _BenchmarkBuilder implements Builder {
   @override
   Future build(BuildStep buildStep) async {
-    var data = <String, String>{};
+    final data = <String, String>{};
 
-    await for (var item in buildStep.findAssets(Glob('**/*.pb.json')).where(
+    await for (final item in buildStep.findAssets(Glob('**/*.pb.json')).where(
         (id) =>
             id.pathSegments.length > 2 &&
             id.pathSegments[0] == 'benchmark' &&

--- a/benchmarks/bin/deep_copy.dart
+++ b/benchmarks/bin/deep_copy.dart
@@ -32,11 +32,11 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> message1Proto2Input =
+  final List<int> message1Proto2Input =
       readfile('datasets/google_message1_proto2.pb');
-  List<int> message1Proto3Input =
+  final List<int> message1Proto3Input =
       readfile('datasets/google_message1_proto3.pb');
-  List<int> message2Input = readfile('datasets/google_message2.pb');
+  final List<int> message2Input = readfile('datasets/google_message2.pb');
   Benchmark(
           'deep_copy', message1Proto2Input, message1Proto3Input, message2Input)
       .report();

--- a/benchmarks/bin/from_binary.dart
+++ b/benchmarks/bin/from_binary.dart
@@ -33,11 +33,11 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> message1Proto2Input =
+  final List<int> message1Proto2Input =
       readfile('datasets/google_message1_proto2.pb');
-  List<int> message1Proto3Input =
+  final List<int> message1Proto3Input =
       readfile('datasets/google_message1_proto3.pb');
-  List<int> message2Input = readfile('datasets/google_message2.pb');
+  final List<int> message2Input = readfile('datasets/google_message2.pb');
   Benchmark('from_binary', message1Proto2Input, message1Proto3Input,
           message2Input)
       .report();

--- a/benchmarks/bin/from_json_string.dart
+++ b/benchmarks/bin/from_json_string.dart
@@ -34,11 +34,11 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> message1Proto2Input =
+  final List<int> message1Proto2Input =
       readfile('datasets/google_message1_proto2.pb');
-  List<int> message1Proto3Input =
+  final List<int> message1Proto3Input =
       readfile('datasets/google_message1_proto3.pb');
-  List<int> message2Input = readfile('datasets/google_message2.pb');
+  final List<int> message2Input = readfile('datasets/google_message2.pb');
   Benchmark('from_json_string', message1Proto2Input, message1Proto3Input,
           message2Input)
       .report();

--- a/benchmarks/bin/from_proto3_json_object.dart
+++ b/benchmarks/bin/from_proto3_json_object.dart
@@ -36,11 +36,11 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> message1Proto2Input =
+  final List<int> message1Proto2Input =
       readfile('datasets/google_message1_proto2.pb');
-  List<int> message1Proto3Input =
+  final List<int> message1Proto3Input =
       readfile('datasets/google_message1_proto3.pb');
-  List<int> message2Input = readfile('datasets/google_message2.pb');
+  final List<int> message2Input = readfile('datasets/google_message2.pb');
   Benchmark('from_proto3_json_object', message1Proto2Input, message1Proto3Input,
           message2Input)
       .report();

--- a/benchmarks/bin/from_proto3_json_string.dart
+++ b/benchmarks/bin/from_proto3_json_string.dart
@@ -39,11 +39,11 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> message1Proto2Input =
+  final List<int> message1Proto2Input =
       readfile('datasets/google_message1_proto2.pb');
-  List<int> message1Proto3Input =
+  final List<int> message1Proto3Input =
       readfile('datasets/google_message1_proto3.pb');
-  List<int> message2Input = readfile('datasets/google_message2.pb');
+  final List<int> message2Input = readfile('datasets/google_message2.pb');
   Benchmark('from_proto3_json_string', message1Proto2Input, message1Proto3Input,
           message2Input)
       .report();

--- a/benchmarks/bin/hash_code.dart
+++ b/benchmarks/bin/hash_code.dart
@@ -31,11 +31,11 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> message1Proto2Input =
+  final List<int> message1Proto2Input =
       readfile('datasets/google_message1_proto2.pb');
-  List<int> message1Proto3Input =
+  final List<int> message1Proto3Input =
       readfile('datasets/google_message1_proto3.pb');
-  List<int> message2Input = readfile('datasets/google_message2.pb');
+  final List<int> message2Input = readfile('datasets/google_message2.pb');
   Benchmark(
           'hash_code', message1Proto2Input, message1Proto3Input, message2Input)
       .report();

--- a/benchmarks/bin/query_decode_binary.dart
+++ b/benchmarks/bin/query_decode_binary.dart
@@ -18,6 +18,6 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> encoded = readfile('datasets/query_benchmark.pb');
+  final List<int> encoded = readfile('datasets/query_benchmark.pb');
   Benchmark('query_decode_binary', encoded).report();
 }

--- a/benchmarks/bin/query_decode_json.dart
+++ b/benchmarks/bin/query_decode_json.dart
@@ -20,6 +20,6 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> encoded = readfile('datasets/query_benchmark.pb');
+  final List<int> encoded = readfile('datasets/query_benchmark.pb');
   Benchmark('query_decode_json', encoded).report();
 }

--- a/benchmarks/bin/query_encode_binary.dart
+++ b/benchmarks/bin/query_encode_binary.dart
@@ -20,6 +20,6 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> encoded = readfile('datasets/query_benchmark.pb');
+  final List<int> encoded = readfile('datasets/query_benchmark.pb');
   Benchmark('query_encode_binary', encoded).report();
 }

--- a/benchmarks/bin/query_encode_json.dart
+++ b/benchmarks/bin/query_encode_json.dart
@@ -20,6 +20,6 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> encoded = readfile('datasets/query_benchmark.pb');
+  final List<int> encoded = readfile('datasets/query_benchmark.pb');
   Benchmark('query_encode_json', encoded).report();
 }

--- a/benchmarks/bin/query_set_nested_value.dart
+++ b/benchmarks/bin/query_set_nested_value.dart
@@ -29,6 +29,6 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> encoded = readfile('datasets/query_benchmark.pb');
+  final List<int> encoded = readfile('datasets/query_benchmark.pb');
   Benchmark('query_set_nested_value', encoded).report();
 }

--- a/benchmarks/bin/to_binary.dart
+++ b/benchmarks/bin/to_binary.dart
@@ -31,11 +31,11 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> message1Proto2Input =
+  final List<int> message1Proto2Input =
       readfile('datasets/google_message1_proto2.pb');
-  List<int> message1Proto3Input =
+  final List<int> message1Proto3Input =
       readfile('datasets/google_message1_proto3.pb');
-  List<int> message2Input = readfile('datasets/google_message2.pb');
+  final List<int> message2Input = readfile('datasets/google_message2.pb');
   Benchmark(
           'to_binary', message1Proto2Input, message1Proto3Input, message2Input)
       .report();

--- a/benchmarks/bin/to_json_string.dart
+++ b/benchmarks/bin/to_json_string.dart
@@ -31,11 +31,11 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> message1Proto2Input =
+  final List<int> message1Proto2Input =
       readfile('datasets/google_message1_proto2.pb');
-  List<int> message1Proto3Input =
+  final List<int> message1Proto3Input =
       readfile('datasets/google_message1_proto3.pb');
-  List<int> message2Input = readfile('datasets/google_message2.pb');
+  final List<int> message2Input = readfile('datasets/google_message2.pb');
   Benchmark('to_json_string', message1Proto2Input, message1Proto3Input,
           message2Input)
       .report();

--- a/benchmarks/bin/to_proto3_json_object.dart
+++ b/benchmarks/bin/to_proto3_json_object.dart
@@ -31,11 +31,11 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> message1Proto2Input =
+  final List<int> message1Proto2Input =
       readfile('datasets/google_message1_proto2.pb');
-  List<int> message1Proto3Input =
+  final List<int> message1Proto3Input =
       readfile('datasets/google_message1_proto3.pb');
-  List<int> message2Input = readfile('datasets/google_message2.pb');
+  final List<int> message2Input = readfile('datasets/google_message2.pb');
   Benchmark('to_proto3_json_object', message1Proto2Input, message1Proto3Input,
           message2Input)
       .report();

--- a/benchmarks/bin/to_proto3_json_string.dart
+++ b/benchmarks/bin/to_proto3_json_string.dart
@@ -33,11 +33,11 @@ class Benchmark extends BenchmarkBase {
 }
 
 void main() {
-  List<int> message1Proto2Input =
+  final List<int> message1Proto2Input =
       readfile('datasets/google_message1_proto2.pb');
-  List<int> message1Proto3Input =
+  final List<int> message1Proto3Input =
       readfile('datasets/google_message1_proto3.pb');
-  List<int> message2Input = readfile('datasets/google_message2.pb');
+  final List<int> message2Input = readfile('datasets/google_message2.pb');
   Benchmark('to_proto3_json_string', message1Proto2Input, message1Proto3Input,
           message2Input)
       .report();

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -64,7 +64,7 @@ class BuilderInfo {
       ValueOfFunc? valueOf,
       List<ProtobufEnum>? enumValues,
       {String? protoName}) {
-    var index = byIndex.length;
+    final index = byIndex.length;
     final fieldInfo = (tagNumber == 0)
         ? FieldInfo.dummy(index)
         : FieldInfo<T>(name, tagNumber, index, fieldType!,
@@ -85,7 +85,7 @@ class BuilderInfo {
       CreateBuilderFunc? valueCreator,
       {ProtobufEnum? defaultEnumValue,
       String? protoName}) {
-    var index = byIndex.length;
+    final index = byIndex.length;
     _addField(MapFieldInfo<K, V>(name, tagNumber, index, PbFieldType.M,
         keyFieldType, valueFieldType, mapEntryBuilderInfo, valueCreator,
         defaultEnumValue: defaultEnumValue, protoName: protoName));
@@ -101,7 +101,7 @@ class BuilderInfo {
       List<ProtobufEnum>? enumValues,
       {ProtobufEnum? defaultEnumValue,
       String? protoName}) {
-    var index = byIndex.length;
+    final index = byIndex.length;
     _addField(FieldInfo<T>.repeated(
         name, tagNumber, index, fieldType, check, subBuilder,
         valueOf: valueOf,
@@ -226,7 +226,7 @@ class BuilderInfo {
 
   // oneof declarations.
   void oo(int oneofIndex, List<int> tags) {
-    for (var tag in tags) {
+    for (final tag in tags) {
       oneofs[tag] = oneofIndex;
     }
   }
@@ -243,7 +243,8 @@ class BuilderInfo {
       PackageName packageName = const PackageName(''),
       String? protoName,
       dynamic valueDefaultOrMaker}) {
-    var mapEntryBuilderInfo = BuilderInfo(entryClassName, package: packageName)
+    final mapEntryBuilderInfo = BuilderInfo(entryClassName,
+        package: packageName)
       ..add(PbMap._keyFieldNumber, 'key', keyFieldType, null, null, null, null)
       ..add(PbMap._valueFieldNumber, 'value', valueFieldType,
           valueDefaultOrMaker, valueCreator, valueOf, enumValues);
@@ -256,38 +257,38 @@ class BuilderInfo {
   bool containsTagNumber(int tagNumber) => fieldInfo.containsKey(tagNumber);
 
   dynamic defaultValue(int tagNumber) {
-    var func = makeDefault(tagNumber);
+    final func = makeDefault(tagNumber);
     return func == null ? null : func();
   }
 
   // Returns the field name for a given tag number, for debugging purposes.
   String? fieldName(int tagNumber) {
-    var i = fieldInfo[tagNumber];
+    final i = fieldInfo[tagNumber];
     return i?.name;
   }
 
   int? fieldType(int tagNumber) {
-    var i = fieldInfo[tagNumber];
+    final i = fieldInfo[tagNumber];
     return i?.type;
   }
 
   MakeDefaultFunc? makeDefault(int tagNumber) {
-    var i = fieldInfo[tagNumber];
+    final i = fieldInfo[tagNumber];
     return i?.makeDefault;
   }
 
   CreateBuilderFunc? subBuilder(int tagNumber) {
-    var i = fieldInfo[tagNumber];
+    final i = fieldInfo[tagNumber];
     return i?.subBuilder;
   }
 
   int? tagNumber(String fieldName) {
-    var i = byName[fieldName];
+    final i = byName[fieldName];
     return i?.tagNumber;
   }
 
   ValueOfFunc? valueOfFunc(int tagNumber) {
-    var i = fieldInfo[tagNumber];
+    final i = fieldInfo[tagNumber];
     return i?.valueOf;
   }
 

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -9,16 +9,16 @@ void _writeToCodedBufferWriter(_FieldSet fs, CodedBufferWriter out) {
   // performance optimizations for the receiver. See:
   // https://developers.google.com/protocol-buffers/docs/encoding?hl=en#order
 
-  for (var fi in fs._infosSortedByTag) {
-    var value = fs._values[fi.index!];
+  for (final fi in fs._infosSortedByTag) {
+    final value = fs._values[fi.index!];
     if (value == null) continue;
     out.writeField(fi.tagNumber, fi.type, value);
   }
 
   final extensions = fs._extensions;
   if (extensions != null) {
-    for (var tagNumber in _sorted(extensions._tagNumbers)) {
-      var fi = extensions._getInfoOrNull(tagNumber)!;
+    for (final tagNumber in _sorted(extensions._tagNumbers)) {
+      final fi = extensions._getInfoOrNull(tagNumber)!;
       out.writeField(tagNumber, fi.type, extensions._getFieldOrNull(fi));
     }
   }
@@ -34,10 +34,10 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
   ArgumentError.checkNotNull(registry);
   fs._ensureWritable();
   while (true) {
-    var tag = input.readTag();
+    final tag = input.readTag();
     if (tag == 0) return;
-    var wireType = tag & 0x7;
-    var tagNumber = tag >> 3;
+    final wireType = tag & 0x7;
+    final tagNumber = tag >> 3;
 
     var fi = fs._nonExtensionInfo(meta, tagNumber);
     fi ??= registry.getExtension(meta.qualifiedMessageName, tagNumber);
@@ -69,18 +69,18 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         fs._setFieldUnchecked(meta, fi, input.readDouble());
         break;
       case PbFieldType._OPTIONAL_ENUM:
-        var rawValue = input.readEnum();
-        var value = meta._decodeEnum(tagNumber, registry, rawValue);
+        final rawValue = input.readEnum();
+        final value = meta._decodeEnum(tagNumber, registry, rawValue);
         if (value == null) {
-          var unknown = fs._ensureUnknownFields();
+          final unknown = fs._ensureUnknownFields();
           unknown.mergeVarintField(tagNumber, Int64(rawValue));
         } else {
           fs._setFieldUnchecked(meta, fi, value);
         }
         break;
       case PbFieldType._OPTIONAL_GROUP:
-        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
-        var oldValue = fs._getFieldOrNull(fi);
+        final subMessage = meta._makeEmptyMessage(tagNumber, registry);
+        final oldValue = fs._getFieldOrNull(fi);
         if (oldValue != null) {
           subMessage.mergeFromMessage(oldValue);
         }
@@ -118,11 +118,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         fs._setFieldUnchecked(meta, fi, input.readSfixed64());
         break;
       case PbFieldType._OPTIONAL_MESSAGE:
-        GeneratedMessage? oldValue = fs._getFieldOrNull(fi);
+        final GeneratedMessage? oldValue = fs._getFieldOrNull(fi);
         if (oldValue != null) {
           input.readMessage(oldValue, registry);
         } else {
-          var subMessage = meta._makeEmptyMessage(tagNumber, registry);
+          final subMessage = meta._makeEmptyMessage(tagNumber, registry);
           input.readMessage(subMessage, registry);
           fs._setFieldUnchecked(meta, fi, subMessage);
         }
@@ -149,7 +149,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
             meta, fs, input, wireType, fi, tagNumber, registry);
         break;
       case PbFieldType._REPEATED_GROUP:
-        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
+        final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readGroup(tagNumber, subMessage, registry);
         fs._ensureRepeatedField(meta, fi).add(subMessage);
         break;
@@ -184,7 +184,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         _readPackable(meta, fs, input, wireType, fi, input.readSfixed64);
         break;
       case PbFieldType._REPEATED_MESSAGE:
-        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
+        final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readMessage(subMessage, registry);
         fs._ensureRepeatedField(meta, fi).add(subMessage);
         break;
@@ -216,10 +216,10 @@ void _readPackableToListEnum(
     int tagNumber,
     ExtensionRegistry registry) {
   void readToList(List list) {
-    var rawValue = input.readEnum();
-    var value = meta._decodeEnum(tagNumber, registry, rawValue);
+    final rawValue = input.readEnum();
+    final value = meta._decodeEnum(tagNumber, registry, rawValue);
     if (value == null) {
-      var unknown = fs._ensureUnknownFields();
+      final unknown = fs._ensureUnknownFields();
       unknown.mergeVarintField(tagNumber, Int64(rawValue));
     } else {
       list.add(value);
@@ -236,7 +236,7 @@ void _readPackableToList(
     int wireType,
     FieldInfo fi,
     Function(List) readToList) {
-  var list = fs._ensureRepeatedField(meta, fi);
+  final list = fs._ensureRepeatedField(meta, fi);
 
   if (wireType == WIRETYPE_LENGTH_DELIMITED) {
     // Packed.

--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -52,7 +52,7 @@ class CodedBufferReader {
           ' which claimed to have negative size.');
     }
     byteLimit += _bufferPos;
-    var oldLimit = _currentLimit;
+    final oldLimit = _currentLimit;
     if ((oldLimit != -1 && byteLimit > oldLimit) || byteLimit > _sizeLimit) {
       _throwTruncatedMessageError(byteLimit);
     }
@@ -85,7 +85,7 @@ class CodedBufferReader {
       throw InvalidProtocolBufferException.recursionLimitExceeded();
     }
     ++_recursionDepth;
-    var unknownFieldSet = UnknownFieldSet();
+    final unknownFieldSet = UnknownFieldSet();
     unknownFieldSet.mergeFromCodedBufferReader(this);
     checkLastTagWas(makeTag(fieldNumber, WIRETYPE_END_GROUP));
     --_recursionDepth;
@@ -94,7 +94,7 @@ class CodedBufferReader {
 
   void readMessage(
       GeneratedMessage message, ExtensionRegistry extensionRegistry) {
-    var length = readInt32();
+    final length = readInt32();
     if (_recursionDepth >= _recursionLimit) {
       throw InvalidProtocolBufferException.recursionLimitExceeded();
     }
@@ -104,7 +104,7 @@ class CodedBufferReader {
           ' which claimed to have negative size.');
     }
 
-    var oldLimit = _currentLimit;
+    final oldLimit = _currentLimit;
     _currentLimit = _bufferPos + length;
     if (_currentLimit > oldLimit) {
       _throwTruncatedMessageError(_currentLimit);
@@ -127,14 +127,14 @@ class CodedBufferReader {
   Int64 readFixed64() => readSfixed64();
   int readSfixed32() => _readByteData(4).getInt32(0, Endian.little);
   Int64 readSfixed64() {
-    var data = _readByteData(8);
-    var view = Uint8List.view(data.buffer, data.offsetInBytes, 8);
+    final data = _readByteData(8);
+    final view = Uint8List.view(data.buffer, data.offsetInBytes, 8);
     return Int64.fromBytes(view);
   }
 
   bool readBool() => _readRawVarint32(true) != 0;
   List<int> readBytes() {
-    var length = readInt32();
+    final length = readInt32();
     _checkLimit(length);
     return Uint8List.view(
         _buffer.buffer, _buffer.offsetInBytes + _bufferPos - length, length);
@@ -184,7 +184,7 @@ class CodedBufferReader {
     if (bytes > 10) bytes = 10;
     var result = 0;
     for (var i = 0; i < bytes; i++) {
-      var byte = _buffer[bufferPos++];
+      final byte = _buffer[bufferPos++];
       result |= (byte & 0x7f) << (i * 7);
       if ((byte & 0x80) == 0) {
         result &= 0xffffffff;
@@ -202,14 +202,14 @@ class CodedBufferReader {
 
     // Read low 28 bits.
     for (var i = 0; i < 4; i++) {
-      var byte = _readRawVarintByte();
+      final byte = _readRawVarintByte();
       lo |= (byte & 0x7f) << (i * 7);
       if ((byte & 0x80) == 0) return Int64.fromInts(hi, lo);
     }
 
     // Read middle 7 bits: 4 low belong to low part above,
     // 3 remaining belong to hi.
-    var byte = _readRawVarintByte();
+    final byte = _readRawVarintByte();
     lo |= (byte & 0xf) << 28;
     hi = (byte >> 4) & 0x7;
     if ((byte & 0x80) == 0) {
@@ -218,7 +218,7 @@ class CodedBufferReader {
 
     // Read remaining bits of hi.
     for (var i = 0; i < 5; i++) {
-      var byte = _readRawVarintByte();
+      final byte = _readRawVarintByte();
       hi |= (byte & 0x7f) << ((i * 7) + 3);
       if ((byte & 0x80) == 0) return Int64.fromInts(hi, lo);
     }

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -72,7 +72,7 @@ class CodedBufferWriter {
       if (list.isNotEmpty) {
         _writeTag(fieldNumber, WIRETYPE_LENGTH_DELIMITED);
         final mark = _startLengthDelimited();
-        for (var value in list) {
+        for (final value in list) {
           _writeValueAs(valueType, value);
         }
         _endLengthDelimited(mark);
@@ -110,7 +110,7 @@ class CodedBufferWriter {
   }
 
   Uint8List toBuffer() {
-    var result = Uint8List(_bytesTotal);
+    final result = Uint8List(_bytesTotal);
     writeTo(result);
     return result;
   }
@@ -236,7 +236,7 @@ class CodedBufferWriter {
   /// of bytes written into the reserved slice space.
   int _startLengthDelimited() {
     _commitSplice();
-    var index = _splices.length;
+    final index = _splices.length;
     // Reserve a space for a splice and use it to record the current number of
     // bytes written so that we can compute the length of data later in
     // _endLengthDelimited.
@@ -423,14 +423,14 @@ class CodedBufferWriter {
   /// Has a specialization for Uint8List for performance.
   int _copyInto(Uint8List buffer, int pos, TypedData value) {
     if (value is Uint8List) {
-      var len = value.length;
+      final len = value.length;
       for (var j = 0; j < len; j++) {
         buffer[pos++] = value[j];
       }
       return pos;
     } else {
-      var len = value.lengthInBytes;
-      var u8 = Uint8List.view(
+      final len = value.lengthInBytes;
+      final u8 = Uint8List.view(
           value.buffer, value.offsetInBytes, value.lengthInBytes);
       for (var j = 0; j < len; j++) {
         buffer[pos++] = u8[j];

--- a/protobuf/lib/src/protobuf/extension.dart
+++ b/protobuf/lib/src/protobuf/extension.dart
@@ -37,7 +37,7 @@ class Extension<T> extends FieldInfo<T> {
   bool operator ==(Object other) {
     if (other is! Extension) return false;
 
-    var o = other;
+    final o = other;
     return extendee == o.extendee && tagNumber == o.tagNumber;
   }
 }

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -20,7 +20,7 @@ class _ExtensionFieldSet {
     // TODO(skybrian) seems unnecessary to add info?
     // I think this was originally here for repeated extensions.
     _addInfoUnchecked(fi);
-    var value = _getFieldOrNull(fi);
+    final value = _getFieldOrNull(fi);
     if (value == null) {
       _checkNotInUnknown(fi);
       return fi.makeDefault!();
@@ -29,7 +29,7 @@ class _ExtensionFieldSet {
   }
 
   bool _hasField(int tagNumber) {
-    var value = _values[tagNumber];
+    final value = _values[tagNumber];
     if (value == null) return false;
     if (value is List) return value.isNotEmpty;
     return true;
@@ -44,14 +44,14 @@ class _ExtensionFieldSet {
     assert(fi.isRepeated);
     assert(fi.extendee == '' || fi.extendee == _parent._messageName);
 
-    var list = _values[fi.tagNumber];
+    final list = _values[fi.tagNumber];
     if (list != null) return list;
 
     return _addInfoAndCreateList(fi);
   }
 
   List<T> _getList<T>(Extension<T> fi) {
-    var value = _values[fi.tagNumber];
+    final value = _values[fi.tagNumber];
     if (value != null) return value;
     _checkNotInUnknown(fi);
     if (_isReadOnly) return List<T>.unmodifiable(const []);
@@ -60,7 +60,7 @@ class _ExtensionFieldSet {
 
   List<T> _addInfoAndCreateList<T>(Extension<T> fi) {
     _validateInfo(fi);
-    var newList = fi._createRepeatedField(_parent._message!);
+    final newList = fi._createRepeatedField(_parent._message!);
     _addInfoUnchecked(fi);
     _setFieldUnchecked(fi, newList);
     return newList;
@@ -86,7 +86,7 @@ class _ExtensionFieldSet {
   /// Sets a value for a non-repeated extension that has already been added.
   /// Does error-checking.
   void _setField(int tagNumber, value) {
-    var fi = _getInfoOrNull(tagNumber);
+    final fi = _getInfoOrNull(tagNumber);
     if (fi == null) {
       throw ArgumentError(
           'tag $tagNumber not defined in $_parent._messageName');
@@ -161,8 +161,8 @@ class _ExtensionFieldSet {
   /// Repeated fields are copied.
   /// Extensions cannot contain map fields.
   void _shallowCopyValues(_ExtensionFieldSet original) {
-    for (var tagNumber in original._tagNumbers) {
-      var extension = original._getInfoOrNull(tagNumber)!;
+    for (final tagNumber in original._tagNumbers) {
+      final extension = original._getInfoOrNull(tagNumber)!;
       _addInfoUnchecked(extension);
 
       final value = original._getFieldOrNull(extension);
@@ -179,7 +179,7 @@ class _ExtensionFieldSet {
   void _markReadOnly() {
     if (_isReadOnly) return;
     _isReadOnly = true;
-    for (var field in _info.values) {
+    for (final field in _info.values) {
       if (field.isRepeated) {
         final entriesDynamic = _values[field.tagNumber];
         if (entriesDynamic == null) continue;
@@ -188,7 +188,7 @@ class _ExtensionFieldSet {
       } else if (field.isGroupOrMessage) {
         final entry = _values[field.tagNumber];
         if (entry != null) {
-          GeneratedMessage msg = entry;
+          final GeneratedMessage msg = entry;
           msg.freeze();
         }
       }

--- a/protobuf/lib/src/protobuf/extension_registry.dart
+++ b/protobuf/lib/src/protobuf/extension_registry.dart
@@ -15,7 +15,7 @@ class ExtensionRegistry {
 
   /// Stores an [extension] in the registry.
   void add(Extension extension) {
-    var map =
+    final map =
         _extensions.putIfAbsent(extension.extendee, () => <int, Extension>{});
     map[extension.tagNumber] = extension;
   }
@@ -28,7 +28,7 @@ class ExtensionRegistry {
   /// Retrieves an extension from the registry that adds tag number [tagNumber]
   /// to the [messageName] message type.
   Extension? getExtension(String messageName, int tagNumber) {
-    var map = _extensions[messageName];
+    final map = _extensions[messageName];
     if (map != null) {
       return map[tagNumber];
     }
@@ -106,9 +106,9 @@ T _reparseMessage<T extends GeneratedMessage>(
   UnknownFieldSet ensureUnknownFields() =>
       resultUnknownFields ??= ensureResult()._fieldSet._unknownFields!;
 
-  var messageUnknownFields = message._fieldSet._unknownFields;
+  final messageUnknownFields = message._fieldSet._unknownFields;
   if (messageUnknownFields != null) {
-    var codedBufferWriter = CodedBufferWriter();
+    final codedBufferWriter = CodedBufferWriter();
     extensionRegistry._extensions[message.info_.qualifiedMessageName]
         ?.forEach((tagNumber, extension) {
       final unknownField = messageUnknownFields._fields[tagNumber];
@@ -124,7 +124,7 @@ T _reparseMessage<T extends GeneratedMessage>(
     }
   }
 
-  for (var field in message._fieldSet._meta.byIndex) {
+  for (final field in message._fieldSet._meta.byIndex) {
     PbList? resultEntries;
     PbList ensureEntries() =>
         resultEntries ??= ensureResult()._fieldSet._values[field.index!];
@@ -151,7 +151,7 @@ T _reparseMessage<T extends GeneratedMessage>(
       if (messageMapDynamic == null) continue;
       final PbMap messageMap = messageMapDynamic;
       if (_isGroupOrMessage(field.valueFieldType)) {
-        for (var key in messageMap.keys) {
+        for (final key in messageMap.keys) {
           final GeneratedMessage value = messageMap[key];
           final reparsedValue = _reparseMessage(value, extensionRegistry);
           if (!identical(value, reparsedValue)) {

--- a/protobuf/lib/src/protobuf/field_info.dart
+++ b/protobuf/lib/src/protobuf/field_info.dart
@@ -172,11 +172,11 @@ class FieldInfo<T> {
 
     if (!isRepeated) {
       // A required message: recurse.
-      GeneratedMessage message = value;
+      final GeneratedMessage message = value;
       return message._fieldSet._hasRequiredValues();
     }
 
-    List<GeneratedMessage> list = value;
+    final List<GeneratedMessage> list = value;
     if (list.isEmpty) return true;
 
     // For message types that (recursively) contain no required fields,
@@ -195,10 +195,10 @@ class FieldInfo<T> {
       // primitive and present
     } else if (!isRepeated) {
       // Required message/group: recurse.
-      GeneratedMessage message = value;
+      final GeneratedMessage message = value;
       message._fieldSet._appendInvalidFields(problems, '$prefix$name.');
     } else {
-      List<GeneratedMessage> list = value;
+      final List<GeneratedMessage> list = value;
       if (list.isEmpty) return;
 
       // For message types that (recursively) contain no required fields,
@@ -207,7 +207,7 @@ class FieldInfo<T> {
 
       // Recurse on each item in the list.
       var position = 0;
-      for (var message in list) {
+      for (final message in list) {
         message._fieldSet
             ._appendInvalidFields(problems, '$prefix$name[$position].');
         position++;

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -121,14 +121,14 @@ class _FieldSet {
   /// Returns the FieldInfo for a regular or extension field.
   /// throws ArgumentException if no info is found.
   FieldInfo _ensureInfo(int tagNumber) {
-    var fi = _getFieldInfoOrNull(tagNumber);
+    final fi = _getFieldInfoOrNull(tagNumber);
     if (fi != null) return fi;
     throw ArgumentError('tag $tagNumber not defined in $_messageName');
   }
 
   /// Returns the FieldInfo for a regular or extension field.
   FieldInfo? _getFieldInfoOrNull(int tagNumber) {
-    var fi = _nonExtensionInfo(_meta, tagNumber);
+    final fi = _nonExtensionInfo(_meta, tagNumber);
     if (fi != null) return fi;
     return _extensions?._getInfoOrNull(tagNumber);
   }
@@ -136,19 +136,19 @@ class _FieldSet {
   void _markReadOnly() {
     if (_isReadOnly) return;
     _frozenState = true;
-    for (var field in _meta.sortedByTag) {
+    for (final field in _meta.sortedByTag) {
       if (field.isRepeated) {
-        PbList? list = _values[field.index!];
+        final PbList? list = _values[field.index!];
         if (list == null) continue;
         list.freeze();
       } else if (field.isMapField) {
-        PbMap? map = _values[field.index!];
+        final PbMap? map = _values[field.index!];
         if (map == null) continue;
         map.freeze();
       } else if (field.isGroupOrMessage) {
         final entry = _values[field.index!];
         if (entry != null) {
-          GeneratedMessage msg = entry;
+          final GeneratedMessage msg = entry;
           msg.freeze();
         }
       }
@@ -172,15 +172,15 @@ class _FieldSet {
   /// Creates repeated fields (unless read-only).
   /// Suitable for public API.
   dynamic _getField(int tagNumber) {
-    var fi = _nonExtensionInfo(_meta, tagNumber);
+    final fi = _nonExtensionInfo(_meta, tagNumber);
     if (fi != null) {
-      var value = _values[fi.index!];
+      final value = _values[fi.index!];
       if (value != null) return value;
       return _getDefault(fi);
     }
     final extensions = _extensions;
     if (extensions != null) {
-      var fi = extensions._getInfoOrNull(tagNumber);
+      final fi = extensions._getInfoOrNull(tagNumber);
       if (fi != null) {
         return extensions._getFieldOrDefault(fi);
       }
@@ -192,13 +192,13 @@ class _FieldSet {
     if (!fi.isRepeated && !fi.isMapField) return fi.makeDefault!();
     if (_isReadOnly) return fi.readonlyDefault;
 
-    var value = fi.makeDefault!();
+    final value = fi.makeDefault!();
     _setNonExtensionFieldUnchecked(_meta, fi, value);
     return value;
   }
 
   dynamic _getFieldOrNullByTag(int tagNumber) {
-    var fi = _getFieldInfoOrNull(tagNumber);
+    final fi = _getFieldInfoOrNull(tagNumber);
     if (fi == null) return null;
     return _getFieldOrNull(fi);
   }
@@ -213,7 +213,7 @@ class _FieldSet {
   }
 
   bool _hasField(int tagNumber) {
-    var fi = _nonExtensionInfo(_meta, tagNumber);
+    final fi = _nonExtensionInfo(_meta, tagNumber);
     if (fi != null) return _$has(fi.index!);
     return _extensions?._hasField(tagNumber) ?? false;
   }
@@ -243,7 +243,7 @@ class _FieldSet {
 
     final extensions = _extensions;
     if (extensions != null) {
-      var fi = extensions._getInfoOrNull(tagNumber);
+      final fi = extensions._getInfoOrNull(tagNumber);
       if (fi != null) {
         extensions._clearField(fi);
         return;
@@ -262,7 +262,7 @@ class _FieldSet {
     ArgumentError.checkNotNull(value, 'value');
 
     final meta = _meta;
-    var fi = _nonExtensionInfo(meta, tagNumber);
+    final fi = _nonExtensionInfo(meta, tagNumber);
     if (fi == null) {
       final extensions = _extensions;
       if (extensions == null) {
@@ -308,10 +308,10 @@ class _FieldSet {
     if (fi.index == null) {
       return _ensureExtensions()._ensureRepeatedField(fi as Extension<T>);
     }
-    var value = _getFieldOrNull(fi);
+    final value = _getFieldOrNull(fi);
     if (value != null) return value;
 
-    var newValue = fi._createRepeatedField(_message!);
+    final newValue = fi._createRepeatedField(_message!);
     _setNonExtensionFieldUnchecked(meta, fi, newValue);
     return newValue;
   }
@@ -321,10 +321,10 @@ class _FieldSet {
     assert(fi.isMapField);
     assert(fi.index != null); // Map fields are not allowed to be extensions.
 
-    var value = _getFieldOrNull(fi);
+    final value = _getFieldOrNull(fi);
     if (value != null) return value;
 
-    var newValue = fi._createMapField(_message!);
+    final newValue = fi._createMapField(_message!);
     _setNonExtensionFieldUnchecked(meta, fi, newValue);
     return newValue as PbMap<K, V>;
   }
@@ -356,7 +356,7 @@ class _FieldSet {
 
   /// The implementation of a generated getter.
   T _$get<T>(int index, T? defaultValue) {
-    var value = _values[index];
+    final value = _values[index];
     if (value != null) return value;
     if (defaultValue != null) return defaultValue;
     return _getDefault(_nonExtensionInfoByIndex(index)) as T;
@@ -366,14 +366,14 @@ class _FieldSet {
   /// the field definition value. Common case for submessages. dynamic type
   /// pushes the type check to the caller.
   dynamic _$getND(int index) {
-    var value = _values[index];
+    final value = _values[index];
     if (value != null) return value;
     return _getDefault(_nonExtensionInfoByIndex(index));
   }
 
   T _$ensure<T>(int index) {
     if (!_$has(index)) {
-      dynamic value = _nonExtensionInfoByIndex(index).subBuilder!();
+      final dynamic value = _nonExtensionInfoByIndex(index).subBuilder!();
       _$set(index, value);
       return value;
     }
@@ -384,7 +384,7 @@ class _FieldSet {
 
   /// The implementation of a generated getter for repeated fields.
   List<T> _$getList<T>(int index) {
-    var value = _values[index];
+    final value = _values[index];
     if (value != null) return value;
 
     final fi = _nonExtensionInfoByIndex(index) as FieldInfo<T>;
@@ -394,14 +394,14 @@ class _FieldSet {
       return fi.readonlyDefault;
     }
 
-    var list = fi._createRepeatedFieldWithType<T>(_message!);
+    final list = fi._createRepeatedFieldWithType<T>(_message!);
     _setNonExtensionFieldUnchecked(_meta, fi, list);
     return list;
   }
 
   /// The implementation of a generated getter for map fields.
   Map<K, V> _$getMap<K, V>(GeneratedMessage parentMessage, int index) {
-    var value = _values[index];
+    final value = _values[index];
     if (value != null) return value as Map<K, V>;
 
     final fi = _nonExtensionInfoByIndex(index) as MapFieldInfo<K, V>;
@@ -412,7 +412,7 @@ class _FieldSet {
           PbMap<K, V>(fi.keyFieldType, fi.valueFieldType));
     }
 
-    var map = fi._createMapField(_message!);
+    final map = fi._createMapField(_message!);
     _setNonExtensionFieldUnchecked(_meta, fi, map);
     return map;
   }
@@ -468,7 +468,7 @@ class _FieldSet {
 
   /// The implementation of a generated 'has' method.
   bool _$has(int index) {
-    var value = _values[index];
+    final value = _values[index];
     if (value == null) return false;
     if (value is List) return value.isNotEmpty;
     return true;
@@ -491,8 +491,8 @@ class _FieldSet {
       eventPlugin.beforeSetField(_nonExtensionInfoByIndex(index), value);
     }
     final meta = _meta;
-    var tag = meta.byIndex[index].tagNumber;
-    var oneofIndex = meta.oneofs[tag];
+    final tag = meta.byIndex[index].tagNumber;
+    final oneofIndex = meta.oneofs[tag];
 
     if (oneofIndex != null) {
       final currentOneofTag = _oneofCases![oneofIndex];
@@ -521,14 +521,14 @@ class _FieldSet {
 
     final eventPlugin = _eventPlugin;
     if (eventPlugin != null && eventPlugin.hasObservers) {
-      for (var fi in _infos) {
+      for (final fi in _infos) {
         if (_values[fi.index!] != null) {
           eventPlugin.beforeClearField(fi);
         }
       }
       if (extensions != null) {
-        for (var key in extensions._tagNumbers) {
-          var fi = extensions._getInfoOrNull(key)!;
+        for (final key in extensions._tagNumbers) {
+          final fi = extensions._getInfoOrNull(key)!;
           eventPlugin.beforeClearField(fi);
         }
       }
@@ -572,7 +572,7 @@ class _FieldSet {
   bool _equalFieldValues(left, right) {
     if (left != null && right != null) return _deepEquals(left, right);
 
-    var val = left ?? right;
+    final val = left ?? right;
 
     // Two uninitialized fields are equal.
     if (val == null) return true;
@@ -658,11 +658,11 @@ class _FieldSet {
     } else if (fi.isRepeated) {
       final PbList list = value;
       hash = _HashUtils._combine(hash, _HashUtils._hashObjects(list.map((enm) {
-        ProtobufEnum enm_ = enm;
+        final ProtobufEnum enm_ = enm;
         return enm_.value;
       })));
     } else {
-      ProtobufEnum enm = value;
+      final ProtobufEnum enm = value;
       hash = _HashUtils._combine(hash, enm.value);
     }
 
@@ -685,11 +685,11 @@ class _FieldSet {
     void writeFieldValue(fieldValue, String name) {
       if (fieldValue == null) return;
       if (fieldValue is PbList) {
-        for (var value in fieldValue) {
+        for (final value in fieldValue) {
           renderValue(name, value);
         }
       } else if (fieldValue is PbMap) {
-        for (var entry in fieldValue.entries) {
+        for (final entry in fieldValue.entries) {
           renderValue(name, entry);
         }
       } else {
@@ -697,7 +697,7 @@ class _FieldSet {
       }
     }
 
-    for (var fi in _infosSortedByTag) {
+    for (final fi in _infosSortedByTag) {
       writeFieldValue(_values[fi.index!],
           fi.name == '' ? fi.tagNumber.toString() : fi.name);
     }
@@ -730,16 +730,16 @@ class _FieldSet {
     // this case, we can merge the non-extension fields without field lookups or
     // validation checks.
     _ensureWritable();
-    for (var fi in other._infosSortedByTag) {
-      var value = other._values[fi.index!];
+    for (final fi in other._infosSortedByTag) {
+      final value = other._values[fi.index!];
       if (value != null) _mergeField(fi, value, isExtension: false);
     }
 
     final otherExtensions = other._extensions;
     if (otherExtensions != null) {
-      for (var tagNumber in otherExtensions._tagNumbers) {
-        var extension = otherExtensions._getInfoOrNull(tagNumber)!;
-        var value = otherExtensions._getFieldOrNull(extension);
+      for (final tagNumber in otherExtensions._tagNumbers) {
+        final extension = otherExtensions._getInfoOrNull(tagNumber)!;
+        final value = otherExtensions._getFieldOrNull(extension);
         _mergeField(extension, value, isExtension: true);
       }
     }
@@ -770,7 +770,7 @@ class _FieldSet {
       final PbMap<dynamic, dynamic> map =
           f._ensureMapField(meta, this) as dynamic;
       if (_isGroupOrMessage(f.valueFieldType)) {
-        PbMap<dynamic, GeneratedMessage> fieldValueMap = fieldValue;
+        final PbMap<dynamic, GeneratedMessage> fieldValueMap = fieldValue;
         for (final entry in fieldValueMap.entries) {
           map[entry.key] = entry.value.deepCopy();
         }
@@ -783,14 +783,14 @@ class _FieldSet {
     if (fi.isRepeated) {
       if (_isGroupOrMessage(otherFi.type)) {
         // fieldValue must be a PbList of GeneratedMessage.
-        PbList<GeneratedMessage> pbList = fieldValue;
-        var repeatedFields = fi._ensureRepeatedField(meta, this);
+        final PbList<GeneratedMessage> pbList = fieldValue;
+        final repeatedFields = fi._ensureRepeatedField(meta, this);
         for (var i = 0; i < pbList.length; ++i) {
           repeatedFields.add(pbList[i].deepCopy());
         }
       } else {
         // fieldValue must be at least a PbList.
-        PbList pbList = fieldValue;
+        final PbList pbList = fieldValue;
         fi._ensureRepeatedField(meta, this).addAll(pbList);
       }
       return;
@@ -801,7 +801,7 @@ class _FieldSet {
           ? _ensureExtensions()._getFieldOrNull(fi as Extension<dynamic>)
           : _values[fi.index!];
 
-      GeneratedMessage msg = fieldValue;
+      final GeneratedMessage msg = fieldValue;
       if (currentFi == null) {
         fieldValue = msg.deepCopy();
       } else {
@@ -830,7 +830,7 @@ class _FieldSet {
   /// type. For example, when setting a proto `string` field a Dart `int`.
   void _validateField(FieldInfo fi, var newValue) {
     _ensureWritable();
-    var message = _getFieldError(fi.type, newValue);
+    final message = _getFieldError(fi.type, newValue);
     if (message != null) {
       throw ArgumentError(_setFieldFailedMessage(fi, newValue, message));
     }
@@ -843,8 +843,8 @@ class _FieldSet {
 
   bool _hasRequiredValues() {
     if (!_hasRequiredFields) return true;
-    for (var fi in _infos) {
-      var value = _values[fi.index!];
+    for (final fi in _infos) {
+      final value = _values[fi.index!];
       if (!fi._hasRequiredValues(value)) return false;
     }
     return _hasRequiredExtensionValues();
@@ -853,8 +853,8 @@ class _FieldSet {
   bool _hasRequiredExtensionValues() {
     final extensions = _extensions;
     if (extensions == null) return true;
-    for (var fi in extensions._infos) {
-      var value = extensions._getFieldOrNull(fi);
+    for (final fi in extensions._infos) {
+      final value = extensions._getFieldOrNull(fi);
       if (!fi._hasRequiredValues(value)) return false;
     }
     return true; // No problems found.
@@ -863,8 +863,8 @@ class _FieldSet {
   /// Adds the path to each uninitialized field to the list.
   void _appendInvalidFields(List<String> problems, String prefix) {
     if (!_hasRequiredFields) return;
-    for (var fi in _infos) {
-      var value = _values[fi.index!];
+    for (final fi in _infos) {
+      final value = _values[fi.index!];
       fi._appendInvalidFields(problems, value, prefix);
     }
     // TODO(skybrian): search extensions as well
@@ -878,16 +878,16 @@ class _FieldSet {
     _values.setRange(0, original._values.length, original._values);
     final info = _meta;
     for (var index = 0; index < info.byIndex.length; index++) {
-      var fieldInfo = info.byIndex[index];
+      final fieldInfo = info.byIndex[index];
       if (fieldInfo.isMapField) {
-        PbMap? map = _values[index];
+        final PbMap? map = _values[index];
         if (map != null) {
           _values[index] = (fieldInfo as MapFieldInfo)
               ._createMapField(_message!)
             ..addAll(map);
         }
       } else if (fieldInfo.isRepeated) {
-        PbList? list = _values[index];
+        final PbList? list = _values[index];
         if (list != null) {
           _values[index] = fieldInfo._createRepeatedField(_message!)
             ..addAll(list);

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -148,22 +148,22 @@ abstract class GeneratedMessage {
   /// This generates the same output as [toString], but can be used by mixins
   /// to compose debug strings with additional information.
   String toDebugString() {
-    var out = StringBuffer();
+    final out = StringBuffer();
     _fieldSet.writeString(out, '');
     return out.toString();
   }
 
   void check() {
     if (!isInitialized()) {
-      var invalidFields = <String>[];
+      final invalidFields = <String>[];
       _fieldSet._appendInvalidFields(invalidFields, '');
-      var missingFields = (invalidFields..sort()).join(', ');
+      final missingFields = (invalidFields..sort()).join(', ');
       throw StateError('Message missing required fields: $missingFields');
     }
   }
 
   Uint8List writeToBuffer() {
-    var out = CodedBufferWriter();
+    final out = CodedBufferWriter();
     writeToCodedBufferWriter(out);
     return out.toBuffer();
   }
@@ -187,7 +187,7 @@ abstract class GeneratedMessage {
   ///   the existing sub-message.
   void mergeFromBuffer(List<int> input,
       [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
-    var codedInput = CodedBufferReader(input);
+    final codedInput = CodedBufferReader(input);
     final meta = _fieldSet._meta;
     _mergeFromCodedBufferReader(meta, _fieldSet, codedInput, extensionRegistry);
     codedInput.checkLastTagWas(0);

--- a/protobuf/lib/src/protobuf/json.dart
+++ b/protobuf/lib/src/protobuf/json.dart
@@ -6,7 +6,7 @@ part of protobuf;
 
 Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
   dynamic convertToMap(dynamic fieldValue, int fieldType) {
-    var baseType = PbFieldType._baseType(fieldType);
+    final baseType = PbFieldType._baseType(fieldType);
 
     if (_isRepeated(fieldType)) {
       final PbList list = fieldValue;
@@ -65,9 +65,9 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
                 convertToMap(e.value, fi.valueFieldType)
           }));
 
-  var result = <String, dynamic>{};
-  for (var fi in fs._infosSortedByTag) {
-    var value = fs._values[fi.index!];
+  final result = <String, dynamic>{};
+  for (final fi in fs._infosSortedByTag) {
+    final value = fs._values[fi.index!];
     if (value == null || (value is List && value.isEmpty)) {
       continue; // It's missing, repeated, or an empty byte array.
     }
@@ -80,12 +80,12 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
   }
   final extensions = fs._extensions;
   if (extensions != null) {
-    for (var tagNumber in _sorted(extensions._tagNumbers)) {
-      var value = extensions._values[tagNumber];
+    for (final tagNumber in _sorted(extensions._tagNumbers)) {
+      final value = extensions._values[tagNumber];
       if (value is List && value.isEmpty) {
         continue; // It's repeated or an empty byte array.
       }
-      var fi = extensions._getInfoOrNull(tagNumber)!;
+      final fi = extensions._getInfoOrNull(tagNumber)!;
       result['$tagNumber'] = convertToMap(value, fi.type);
     }
   }
@@ -99,7 +99,7 @@ void _mergeFromJsonMap(
   fs._ensureWritable();
   final keys = json.keys;
   final meta = fs._meta;
-  for (var key in keys) {
+  for (final key in keys) {
     var fi = meta.byTagAsString[key];
     if (fi == null) {
       if (registry == null) continue; // Unknown tag; skip
@@ -125,7 +125,7 @@ void _appendJsonList(BuilderInfo meta, _FieldSet fs, List jsonList,
   //   for (t1 = J.get$iterator$ax(json), t2 = fi.tagNumber, t3 = fi.type,
   //       t4 = J.getInterceptor$ax(repeated); t1.moveNext$0();)
   for (var i = 0, len = jsonList.length; i < len; i++) {
-    var value = jsonList[i];
+    final value = jsonList[i];
     var convertedValue =
         _convertJsonValue(meta, fs, value, fi.tagNumber, fi.type, registry);
     // In the case of an unknown enum value, the converted value may return
@@ -140,8 +140,8 @@ void _appendJsonMap(BuilderInfo meta, _FieldSet fs, List jsonList,
     MapFieldInfo fi, ExtensionRegistry? registry) {
   final entryMeta = fi.mapEntryBuilderInfo;
   final map = fi._ensureMapField(meta, fs) as PbMap<dynamic, dynamic>;
-  for (var jsonEntryDynamic in jsonList) {
-    var jsonEntry = jsonEntryDynamic as Map<String, dynamic>;
+  for (final jsonEntryDynamic in jsonList) {
+    final jsonEntry = jsonEntryDynamic as Map<String, dynamic>;
     final entryFieldSet = _FieldSet(null, entryMeta, null);
     final convertedKey = _convertJsonValue(
         entryMeta,
@@ -278,7 +278,7 @@ dynamic _convertJsonValue(BuilderInfo meta, _FieldSet fs, value, int tagNumber,
     case PbFieldType._MESSAGE_BIT:
       if (value is Map) {
         final messageValue = value as Map<String, dynamic>;
-        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
+        final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         _mergeFromJsonMap(subMessage._fieldSet, messageValue, registry);
         return subMessage;
       }

--- a/protobuf/lib/src/protobuf/json_parsing_context.dart
+++ b/protobuf/lib/src/protobuf/json_parsing_context.dart
@@ -26,7 +26,7 @@ class JsonParsingContext {
 
   /// Creates a [FormatException] indicating the indices to the current path.
   Exception parseException(String message, Object? source) {
-    var formattedPath = _path.map((s) => '["$s"]').join();
+    final formattedPath = _path.map((s) => '["$s"]').join();
     return FormatException(
         'Protobuf JSON decoding failed at: root$formattedPath. $message',
         source);

--- a/protobuf/lib/src/protobuf/mixins/event_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/event_mixin.dart
@@ -59,7 +59,7 @@ class EventBuffer extends EventPlugin {
   }
 
   Stream<List<PbFieldChange>> get changes {
-    var controller = _controller ??= StreamController.broadcast(sync: true);
+    final controller = _controller ??= StreamController.broadcast(sync: true);
     return controller.stream;
   }
 
@@ -67,7 +67,7 @@ class EventBuffer extends EventPlugin {
   bool get hasObservers => _controller != null && _controller!.hasListener;
 
   void deliverChanges() {
-    var records = _buffer;
+    final records = _buffer;
     _buffer = null;
     if (records != null && hasObservers) {
       _controller!.add(UnmodifiableListView<PbFieldChange>(records));
@@ -93,9 +93,9 @@ class EventBuffer extends EventPlugin {
 
   @override
   void beforeClearField(FieldInfo fi) {
-    var oldValue = _parent!.getFieldOrNull(fi.tagNumber);
+    final oldValue = _parent!.getFieldOrNull(fi.tagNumber);
     if (oldValue == null) return;
-    var newValue = fi.readonlyDefault;
+    final newValue = fi.readonlyDefault;
     addEvent(PbFieldChange(_parent, fi, oldValue, newValue));
   }
 }

--- a/protobuf/lib/src/protobuf/mixins/map_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/map_mixin.dart
@@ -21,13 +21,13 @@ abstract class PbMapMixin {
 
   dynamic operator [](Object? key) {
     if (key is! String) return null;
-    var tag = getTagNumber(key);
+    final tag = getTagNumber(key);
     if (tag == null) return null;
     return getField(tag);
   }
 
   void operator []=(Object? key, Object? val) {
-    var tag = getTagNumber(key as String);
+    final tag = getTagNumber(key as String);
     if (tag == null) {
       throw ArgumentError.value(key, 'key',
           "field '$key' not found in ${info_.qualifiedMessageName}");

--- a/protobuf/lib/src/protobuf/mixins/well_known.dart
+++ b/protobuf/lib/src/protobuf/mixins/well_known.dart
@@ -78,16 +78,16 @@ abstract class AnyMixin implements GeneratedMessage {
   //     }
   static Object toProto3JsonHelper(
       GeneratedMessage message, TypeRegistry typeRegistry) {
-    var any = message as AnyMixin;
-    var info = typeRegistry.lookup(_typeNameFromUrl(any.typeUrl));
+    final any = message as AnyMixin;
+    final info = typeRegistry.lookup(_typeNameFromUrl(any.typeUrl));
     if (info == null) {
       throw ArgumentError(
           'The type of the Any message (${any.typeUrl}) is not in the given typeRegistry.');
     }
-    var unpacked = info.createEmptyInstance!()..mergeFromBuffer(any.value);
-    var proto3Json = unpacked.toProto3Json(typeRegistry: typeRegistry);
+    final unpacked = info.createEmptyInstance!()..mergeFromBuffer(any.value);
+    final proto3Json = unpacked.toProto3Json(typeRegistry: typeRegistry);
     if (info.toProto3Json == null) {
-      var map = proto3Json as Map<String, dynamic>;
+      final map = proto3Json as Map<String, dynamic>;
       map['@type'] = any.typeUrl;
       return map;
     } else {
@@ -105,20 +105,20 @@ abstract class AnyMixin implements GeneratedMessage {
     final typeUrl = object['@type'];
 
     if (typeUrl is String) {
-      var any = message as AnyMixin;
-      var info = typeRegistry.lookup(_typeNameFromUrl(typeUrl));
+      final any = message as AnyMixin;
+      final info = typeRegistry.lookup(_typeNameFromUrl(typeUrl));
       if (info == null) {
         throw context.parseException(
             'Decoding Any of type $typeUrl not in TypeRegistry $typeRegistry',
             json);
       }
 
-      Object? subJson = info.fromProto3Json == null
+      final Object? subJson = info.fromProto3Json == null
           // TODO(sigurdm): avoid cloning [object] here.
           ? (Map<String, dynamic>.from(object)..remove('@type'))
           : object['value'];
       // TODO(sigurdm): We lose [context.path].
-      var packedMessage = info.createEmptyInstance!()
+      final packedMessage = info.createEmptyInstance!()
         ..mergeFromProto3Json(subJson,
             typeRegistry: typeRegistry,
             supportNamesWithUnderscores: context.supportNamesWithUnderscores,
@@ -134,7 +134,7 @@ abstract class AnyMixin implements GeneratedMessage {
 }
 
 String _typeNameFromUrl(String typeUrl) {
-  var index = typeUrl.lastIndexOf('/');
+  final index = typeUrl.lastIndexOf('/');
   return index < 0 ? '' : typeUrl.substring(index + 1);
 }
 
@@ -162,7 +162,7 @@ abstract class TimestampMixin {
   ///
   /// Time zone information will not be preserved.
   static void setFromDateTime(TimestampMixin target, DateTime dateTime) {
-    var micros = dateTime.microsecondsSinceEpoch;
+    final micros = dateTime.microsecondsSinceEpoch;
     target.seconds = Int64((micros / Duration.microsecondsPerSecond).floor());
     target.nanos = (micros % Duration.microsecondsPerSecond).toInt() * 1000;
   }
@@ -193,8 +193,8 @@ abstract class TimestampMixin {
   // 01:30 UTC on January 15, 2017.
   static Object toProto3JsonHelper(
       GeneratedMessage message, TypeRegistry typeRegistry) {
-    var timestamp = message as TimestampMixin;
-    var dateTime = timestamp.toDateTime();
+    final timestamp = message as TimestampMixin;
+    final dateTime = timestamp.toDateTime();
 
     if (timestamp.nanos < 0) {
       throw ArgumentError(
@@ -211,12 +211,12 @@ abstract class TimestampMixin {
 
     // Because [DateTime] doesn't have nano-second precision, we cannot use
     // dateTime.toIso8601String().
-    var y = '${dateTime.year}'.padLeft(4, '0');
-    var m = _twoDigits(dateTime.month);
-    var d = _twoDigits(dateTime.day);
-    var h = _twoDigits(dateTime.hour);
-    var min = _twoDigits(dateTime.minute);
-    var sec = _twoDigits(dateTime.second);
+    final y = '${dateTime.year}'.padLeft(4, '0');
+    final m = _twoDigits(dateTime.month);
+    final d = _twoDigits(dateTime.day);
+    final h = _twoDigits(dateTime.hour);
+    final min = _twoDigits(dateTime.minute);
+    final sec = _twoDigits(dateTime.second);
     var secFrac = '';
     if (timestamp.nanos > 0) {
       secFrac =
@@ -230,9 +230,9 @@ abstract class TimestampMixin {
     if (json is String) {
       var jsonWithoutFracSec = json;
       var nanos = 0;
-      Match? fracSecsMatch = RegExp(r'\.(\d+)').firstMatch(json);
+      final Match? fracSecsMatch = RegExp(r'\.(\d+)').firstMatch(json);
       if (fracSecsMatch != null) {
-        var fracSecs = fracSecsMatch[1]!;
+        final fracSecs = fracSecsMatch[1]!;
         if (fracSecs.length > 9) {
           throw context.parseException(
               'Timestamp can have at most than 9 decimal digits', json);
@@ -241,12 +241,12 @@ abstract class TimestampMixin {
         jsonWithoutFracSec =
             json.replaceRange(fracSecsMatch.start, fracSecsMatch.end, '');
       }
-      var dateTimeWithoutFractionalSeconds =
+      final dateTimeWithoutFractionalSeconds =
           DateTime.tryParse(jsonWithoutFracSec) ??
               (throw context.parseException(
                   'Timestamp not well formatted. ', json));
 
-      var timestamp = message as TimestampMixin;
+      final timestamp = message as TimestampMixin;
       setFromDateTime(timestamp, dateTimeWithoutFractionalSeconds);
       timestamp.nanos = nanos;
     } else {
@@ -267,14 +267,14 @@ abstract class DurationMixin {
 
   static Object toProto3JsonHelper(
       GeneratedMessage message, TypeRegistry typeRegistry) {
-    var duration = message as DurationMixin;
-    var secFrac = duration.nanos
+    final duration = message as DurationMixin;
+    final secFrac = duration.nanos
         // nanos and seconds should always have the same sign.
         .abs()
         .toString()
         .padLeft(9, '0')
         .replaceFirst(finalZeroes, '');
-    var secPart = secFrac == '' ? '' : '.$secFrac';
+    final secPart = secFrac == '' ? '' : '.$secFrac';
     return '${duration.seconds}${secPart}s';
   }
 
@@ -282,18 +282,18 @@ abstract class DurationMixin {
 
   static void fromProto3JsonHelper(GeneratedMessage message, Object json,
       TypeRegistry typeRegistry, JsonParsingContext context) {
-    var duration = message as DurationMixin;
+    final duration = message as DurationMixin;
     if (json is String) {
-      var match = durationPattern.matchAsPrefix(json);
+      final match = durationPattern.matchAsPrefix(json);
       if (match == null) {
         throw context.parseException(
             'Expected a String of the form `<seconds>.<nanos>s`', json);
       } else {
-        var secondsString = match[1]!;
-        var seconds =
+        final secondsString = match[1]!;
+        final seconds =
             secondsString == '' ? Int64.ZERO : Int64.parseInt(secondsString);
         duration.seconds = seconds;
-        var nanos = int.parse((match[2] ?? '').padRight(9, '0'));
+        final nanos = int.parse((match[2] ?? '').padRight(9, '0'));
         duration.nanos = seconds < 0 ? -nanos : nanos;
       }
     } else {
@@ -311,7 +311,7 @@ abstract class StructMixin implements GeneratedMessage {
   // The JSON representation for `Struct` is JSON object.
   static Object toProto3JsonHelper(
       GeneratedMessage message, TypeRegistry typeRegistry) {
-    var struct = message as StructMixin;
+    final struct = message as StructMixin;
     return struct.fields.map((key, value) =>
         MapEntry(key, ValueMixin.toProto3JsonHelper(value, typeRegistry)));
   }
@@ -322,8 +322,8 @@ abstract class StructMixin implements GeneratedMessage {
       // Check for emptiness to avoid setting `.fields` if there are no
       // values.
       if (json.isNotEmpty) {
-        var fields = (message as StructMixin).fields;
-        var valueCreator =
+        final fields = (message as StructMixin).fields;
+        final valueCreator =
             (message.info_.fieldInfo[_fieldsFieldTagNumber] as MapFieldInfo)
                 .valueCreator!;
 
@@ -331,7 +331,7 @@ abstract class StructMixin implements GeneratedMessage {
           if (key is! String) {
             throw context.parseException('Expected String key', json);
           }
-          var v = valueCreator() as ValueMixin;
+          final v = valueCreator() as ValueMixin;
           context.addMapIndex(key);
           ValueMixin.fromProto3JsonHelper(v, value, typeRegistry, context);
           context.popIndex();
@@ -369,7 +369,7 @@ abstract class ValueMixin implements GeneratedMessage {
   // The JSON representation for `Value` is JSON value
   static Object? toProto3JsonHelper(
       GeneratedMessage message, TypeRegistry typeRegistry) {
-    var value = message as ValueMixin;
+    final value = message as ValueMixin;
     // This would ideally be a switch, but we cannot import the enum we are
     // switching over.
     if (value.hasNullValue()) {
@@ -391,7 +391,7 @@ abstract class ValueMixin implements GeneratedMessage {
 
   static void fromProto3JsonHelper(GeneratedMessage message, Object? json,
       TypeRegistry typeRegistry, JsonParsingContext context) {
-    var value = message as ValueMixin;
+    final value = message as ValueMixin;
     if (json == null) {
       // Rely on the getter retrieving the default to provide an instance.
       value.nullValue = value.nullValue;
@@ -403,13 +403,13 @@ abstract class ValueMixin implements GeneratedMessage {
       value.boolValue = json;
     } else if (json is Map) {
       // Clone because the default instance is frozen.
-      var structValue = value.structValue.deepCopy();
+      final structValue = value.structValue.deepCopy();
       StructMixin.fromProto3JsonHelper(
           structValue, json, typeRegistry, context);
       value.structValue = structValue;
     } else if (json is List) {
       // Clone because the default instance is frozen.
-      var listValue = value.listValue.deepCopy();
+      final listValue = value.listValue.deepCopy();
       ListValueMixin.fromProto3JsonHelper(
           listValue, json, typeRegistry, context);
       value.listValue = listValue;
@@ -428,7 +428,7 @@ abstract class ListValueMixin implements GeneratedMessage {
   // The JSON representation for `ListValue` is JSON array.
   static Object toProto3JsonHelper(
       GeneratedMessage message, TypeRegistry typeRegistry) {
-    var list = message as ListValueMixin;
+    final list = message as ListValueMixin;
     return list.values
         .map((value) => ValueMixin.toProto3JsonHelper(value, typeRegistry))
         .toList();
@@ -438,12 +438,12 @@ abstract class ListValueMixin implements GeneratedMessage {
 
   static void fromProto3JsonHelper(GeneratedMessage message, Object json,
       TypeRegistry typeRegistry, JsonParsingContext context) {
-    var list = message as ListValueMixin;
+    final list = message as ListValueMixin;
     if (json is List) {
-      var subBuilder = message.info_.subBuilder(_valueFieldTagNumber)!;
+      final subBuilder = message.info_.subBuilder(_valueFieldTagNumber)!;
       for (var i = 0; i < json.length; i++) {
-        Object element = json[i];
-        var v = subBuilder() as ValueMixin;
+        final Object element = json[i];
+        final v = subBuilder() as ValueMixin;
         context.addListIndex(i);
         ValueMixin.fromProto3JsonHelper(v, element, typeRegistry, context);
         context.popIndex();
@@ -466,8 +466,8 @@ abstract class FieldMaskMixin {
   // to/from lower-camel naming conventions.
   static Object toProto3JsonHelper(
       GeneratedMessage message, TypeRegistry typeRegistry) {
-    var fieldMask = message as FieldMaskMixin;
-    for (var path in fieldMask.paths) {
+    final fieldMask = message as FieldMaskMixin;
+    for (final path in fieldMask.paths) {
       if (path.contains(RegExp('[A-Z]|_[^a-z]'))) {
         throw ArgumentError(
             'Bad fieldmask $path. Does not round-trip to json.');

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -186,7 +186,7 @@ class PbList<E> extends ListBase<E> {
     // Per spec `repeated map<..>` and `repeated repeated ..` are not allowed
     // so we only check for messages
     if (_wrappedList.isNotEmpty && _wrappedList[0] is GeneratedMessage) {
-      for (var elem in _wrappedList as Iterable<GeneratedMessage>) {
+      for (final elem in _wrappedList as Iterable<GeneratedMessage>) {
         elem.freeze();
       }
     }

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -96,16 +96,16 @@ class PbMap<K, V> extends MapBase<K, V> {
 
   void _mergeEntry(BuilderInfo mapEntryMeta, CodedBufferReader input,
       ExtensionRegistry registry) {
-    var length = input.readInt32();
-    var oldLimit = input._currentLimit;
+    final length = input.readInt32();
+    final oldLimit = input._currentLimit;
     input._currentLimit = input._bufferPos + length;
     final entryFieldSet = _FieldSet(null, mapEntryMeta, null);
     _mergeFromCodedBufferReader(mapEntryMeta, entryFieldSet, input, registry);
     input.checkLastTagWas(0);
     input._currentLimit = oldLimit;
-    var key =
+    final key =
         entryFieldSet._values[0] ?? mapEntryMeta.byIndex[0].makeDefault!();
-    var value =
+    final value =
         entryFieldSet._values[1] ?? mapEntryMeta.byIndex[1].makeDefault!();
     _wrappedMap[key] = value;
   }
@@ -113,7 +113,7 @@ class PbMap<K, V> extends MapBase<K, V> {
   PbMap freeze() {
     _isReadonly = true;
     if (_isGroupOrMessage(valueFieldType)) {
-      for (var subMessage in values as Iterable<GeneratedMessage>) {
+      for (final subMessage in values as Iterable<GeneratedMessage>) {
         subMessage.freeze();
       }
     }

--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -6,7 +6,7 @@ part of protobuf;
 
 Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
   String? convertToMapKey(dynamic key, int keyType) {
-    var baseType = PbFieldType._baseType(keyType);
+    final baseType = PbFieldType._baseType(keyType);
 
     assert(!_isRepeated(keyType));
 
@@ -41,7 +41,7 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
     } else if (_isEnum(fieldType)) {
       return (fieldValue as ProtobufEnum).name;
     } else {
-      var baseType = PbFieldType._baseType(fieldType);
+      final baseType = PbFieldType._baseType(fieldType);
       switch (baseType) {
         case PbFieldType._BOOL_BIT:
           return fieldValue as bool;
@@ -60,7 +60,7 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
           return fieldValue.toString();
         case PbFieldType._FLOAT_BIT:
         case PbFieldType._DOUBLE_BIT:
-          double value = fieldValue;
+          final double value = fieldValue;
           if (value.isNaN) {
             return _nan;
           }
@@ -87,16 +87,16 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
     return meta.toProto3Json!(fs._message!, typeRegistry);
   }
 
-  var result = <String, dynamic>{};
-  for (var fieldInfo in fs._infosSortedByTag) {
-    var value = fs._values[fieldInfo.index!];
+  final result = <String, dynamic>{};
+  for (final fieldInfo in fs._infosSortedByTag) {
+    final value = fs._values[fieldInfo.index!];
     if (value == null || (value is List && value.isEmpty)) {
       continue; // It's missing, repeated, or an empty byte array.
     }
     dynamic jsonValue;
     if (fieldInfo.isMapField) {
       jsonValue = (value as PbMap).map((key, entryValue) {
-        var mapEntryInfo = fieldInfo as MapFieldInfo;
+        final mapEntryInfo = fieldInfo as MapFieldInfo;
         return MapEntry(convertToMapKey(key, mapEntryInfo.keyFieldType),
             valueToProto3Json(entryValue, mapEntryInfo.valueFieldType));
       });
@@ -143,7 +143,7 @@ Int64 _tryParse64BitProto3(Object? json, String s, JsonParsingContext context) {
 /// TODO(paulberry): find a better home for this?
 extension _FindFirst<E> on Iterable<E> {
   E? findFirst(bool Function(E) test) {
-    for (var element in this) {
+    for (final element in this) {
       if (test(element)) return element;
     }
     return null;
@@ -160,12 +160,12 @@ void _mergeFromProto3Json(
     bool supportNamesWithUnderscores,
     bool permissiveEnums) {
   fieldSet._ensureWritable();
-  var context = JsonParsingContext(
+  final context = JsonParsingContext(
       ignoreUnknownFields, supportNamesWithUnderscores, permissiveEnums);
 
   void recursionHelper(Object? json, _FieldSet fieldSet) {
     Object? convertProto3JsonValue(Object value, FieldInfo fieldInfo) {
-      var fieldType = fieldInfo.type;
+      final fieldType = fieldInfo.type;
       switch (PbFieldType._baseType(fieldType)) {
         case PbFieldType._BOOL_BIT:
           if (value is bool) {
@@ -277,7 +277,7 @@ void _mergeFromProto3Json(
               'Expected int or stringified int', value);
         case PbFieldType._GROUP_BIT:
         case PbFieldType._MESSAGE_BIT:
-          var subMessage = fieldInfo.subBuilder!();
+          final subMessage = fieldInfo.subBuilder!();
           recursionHelper(value, subMessage._fieldSet);
           return subMessage;
         default:
@@ -378,7 +378,7 @@ void _mergeFromProto3Json(
             }
           } else if (_isRepeated(fieldInfo.type)) {
             if (value is List) {
-              var values = fieldSet._ensureRepeatedField(meta, fieldInfo);
+              final values = fieldSet._ensureRepeatedField(meta, fieldInfo);
               for (var i = 0; i < value.length; i++) {
                 final entry = value[i];
                 context.addListIndex(i);
@@ -391,9 +391,10 @@ void _mergeFromProto3Json(
           } else if (_isGroupOrMessage(fieldInfo.type)) {
             // TODO(sigurdm) consider a cleaner separation between parsing and
             // merging.
-            var parsedSubMessage =
+            final parsedSubMessage =
                 convertProto3JsonValue(value, fieldInfo) as GeneratedMessage;
-            GeneratedMessage? original = fieldSet._values[fieldInfo.index!];
+            final GeneratedMessage? original =
+                fieldSet._values[fieldInfo.index!];
             if (original == null) {
               fieldSet._setNonExtensionFieldUnchecked(
                   meta, fieldInfo, parsedSubMessage);

--- a/protobuf/lib/src/protobuf/protobuf_enum.dart
+++ b/protobuf/lib/src/protobuf/protobuf_enum.dart
@@ -40,8 +40,8 @@ class ProtobufEnum {
   /// Creates a Map for all of the [ProtobufEnum]s in [byIndex], mapping each
   /// [ProtobufEnum]'s [value] to the [ProtobufEnum].
   static Map<int, T> initByValue<T extends ProtobufEnum>(List<T> byIndex) {
-    var byValue = <int, T>{};
-    for (var v in byIndex) {
+    final byValue = <int, T>{};
+    for (final v in byIndex) {
       byValue[v.value] = v;
     }
     return byValue;

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -56,7 +56,7 @@ class UnknownFieldSet {
 
   bool mergeFieldFromBuffer(int tag, CodedBufferReader input) {
     _ensureWritable('mergeFieldFromBuffer');
-    var number = getTagFieldNumber(tag);
+    final number = getTagFieldNumber(tag);
     switch (getTagWireType(tag)) {
       case WIRETYPE_VARINT:
         mergeVarintField(number, input.readInt64());
@@ -68,7 +68,7 @@ class UnknownFieldSet {
         mergeLengthDelimitedField(number, input.readBytes());
         return true;
       case WIRETYPE_START_GROUP:
-        var subGroup = input.readUnknownFieldSetGroup(number);
+        final subGroup = input.readUnknownFieldSetGroup(number);
         mergeGroupField(number, subGroup);
         return true;
       case WIRETYPE_END_GROUP:
@@ -84,7 +84,7 @@ class UnknownFieldSet {
   void mergeFromCodedBufferReader(CodedBufferReader input) {
     _ensureWritable('mergeFromCodedBufferReader');
     while (true) {
-      var tag = input.readTag();
+      final tag = input.readTag();
       if (tag == 0 || !mergeFieldFromBuffer(tag, input)) {
         break;
       }
@@ -93,7 +93,7 @@ class UnknownFieldSet {
 
   void mergeFromUnknownFieldSet(UnknownFieldSet other) {
     _ensureWritable('mergeFromUnknownFieldSet');
-    for (var key in other._fields.keys) {
+    for (final key in other._fields.keys) {
       mergeField(key, other._fields[key]!);
     }
   }
@@ -139,7 +139,7 @@ class UnknownFieldSet {
   bool operator ==(Object other) {
     if (other is! UnknownFieldSet) return false;
 
-    var o = other;
+    final o = other;
     return _areMapsEqual(o._fields, _fields);
   }
 
@@ -157,11 +157,11 @@ class UnknownFieldSet {
   String toString() => _toString('');
 
   String _toString(String indent) {
-    var stringBuffer = StringBuffer();
+    final stringBuffer = StringBuffer();
 
-    for (var tag in _sorted(_fields.keys)) {
-      var field = _fields[tag]!;
-      for (var value in field.values) {
+    for (final tag in _sorted(_fields.keys)) {
+      final field = _fields[tag]!;
+      for (final value in field.values) {
         if (value is UnknownFieldSet) {
           stringBuffer
             ..write('$indent$tag: {\n')
@@ -177,14 +177,14 @@ class UnknownFieldSet {
   }
 
   void writeToCodedBufferWriter(CodedBufferWriter output) {
-    for (var key in _fields.keys) {
+    for (final key in _fields.keys) {
       _fields[key]!.writeTo(key, output);
     }
   }
 
   void _markReadOnly() {
     if (_isReadOnly) return;
-    for (var f in _fields.values) {
+    for (final f in _fields.values) {
       f._markReadOnly();
     }
     _isReadOnly = true;
@@ -227,7 +227,7 @@ class UnknownFieldSetField {
   bool operator ==(Object other) {
     if (other is! UnknownFieldSetField) return false;
 
-    var o = other;
+    final o = other;
     if (lengthDelimited.length != o.lengthDelimited.length) return false;
     for (var i = 0; i < lengthDelimited.length; i++) {
       if (!_areListsEqual(o.lengthDelimited[i], lengthDelimited[i])) {

--- a/protobuf/lib/src/protobuf/unpack.dart
+++ b/protobuf/lib/src/protobuf/unpack.dart
@@ -23,7 +23,7 @@ void unpackIntoHelper<T extends GeneratedMessage>(
   //   in the type URL, for example "foo.bar.com/x/y.z" will yield type
   //   name "y.z".
   if (!canUnpackIntoHelper(instance, typeUrl)) {
-    var typeName = instance.info_.qualifiedMessageName;
+    final typeName = instance.info_.qualifiedMessageName;
     throw InvalidProtocolBufferException.wrongAnyMessage(
         _typeNameFromUrl(typeUrl), typeName);
   }
@@ -41,6 +41,6 @@ bool canUnpackIntoHelper(GeneratedMessage instance, String typeUrl) {
 }
 
 String _typeNameFromUrl(String typeUrl) {
-  var index = typeUrl.lastIndexOf('/');
+  final index = typeUrl.lastIndexOf('/');
   return index == -1 ? '' : typeUrl.substring(index + 1);
 }

--- a/protobuf/test/codec_test.dart
+++ b/protobuf/test/codec_test.dart
@@ -15,7 +15,7 @@ void main() {
   ByteData makeData(Uint8List bytes) => ByteData.view(bytes.buffer);
 
   Uint8List Function(dynamic) convertToBytes(fieldType) => (value) {
-        var writer = CodedBufferWriter()..writeField(0, fieldType, value);
+        final writer = CodedBufferWriter()..writeField(0, fieldType, value);
         return writer.toBuffer().sublist(1);
       };
 
@@ -138,7 +138,7 @@ void main() {
 
   void test32(int bits, double value) {
     double readFloat(int bits) {
-      var bytes = dataToBytes(ByteData(4)..setUint32(0, bits, Endian.little));
+      final bytes = dataToBytes(ByteData(4)..setUint32(0, bits, Endian.little));
       return CodedBufferReader(bytes).readFloat();
     }
 
@@ -150,8 +150,8 @@ void main() {
 
   void test64(List<int> hilo, double value) {
     // Encode a double to its wire format.
-    var data = makeData(doubleToBytes(value));
-    var actualHilo = [
+    final data = makeData(doubleToBytes(value));
+    final actualHilo = [
       data.getUint32(4, Endian.little),
       data.getUint32(0, Endian.little)
     ];
@@ -159,8 +159,8 @@ void main() {
     expect(actualHilo, hilo);
 
     // Decode it again (round trip).
-    var bytes = dataToBytes(data);
-    var reencoded = CodedBufferReader(bytes).readDouble();
+    final bytes = dataToBytes(data);
+    final reencoded = CodedBufferReader(bytes).readDouble();
     expect(reencoded, doubleEquals(value));
   }
 
@@ -705,12 +705,12 @@ void main() {
   });
 
   test('testWriteTo', () {
-    var writer = CodedBufferWriter()..writeField(0, PbFieldType.O3, 1337);
+    final writer = CodedBufferWriter()..writeField(0, PbFieldType.O3, 1337);
     expect(writer.lengthInBytes, 3);
-    var buffer = Uint8List(5);
+    final buffer = Uint8List(5);
     buffer[0] = 0x55;
     buffer[4] = 0xAA;
-    var expected = writer.toBuffer();
+    final expected = writer.toBuffer();
     expect(writer.writeTo(buffer, 1), isTrue);
     expect(buffer[0], 0x55);
     expect(buffer[4], 0xAA);

--- a/protobuf/test/coded_buffer_reader_test.dart
+++ b/protobuf/test/coded_buffer_reader_test.dart
@@ -100,9 +100,9 @@ void main() {
   });
 
   test('testReadMaliciouslyLargeBlob', () {
-    var output = CodedBufferWriter();
+    final output = CodedBufferWriter();
 
-    var tag = makeTag(1, WIRETYPE_LENGTH_DELIMITED);
+    final tag = makeTag(1, WIRETYPE_LENGTH_DELIMITED);
     output.writeInt32NoTag(tag);
     output.writeInt32NoTag(0x7FFFFFFF);
     // Pad with a few random bytes.
@@ -110,7 +110,7 @@ void main() {
     output.writeInt32NoTag(32);
     output.writeInt32NoTag(47);
 
-    var input = CodedBufferReader(output.toBuffer());
+    final input = CodedBufferReader(output.toBuffer());
     expect(input.readTag(), tag);
 
     expect(() {
@@ -122,8 +122,8 @@ void main() {
   /// is thrown. Instead, the invalid bytes are replaced with the Unicode
   /// 'replacement character' U+FFFD.
   test('testReadInvalidUtf8', () {
-    var input = CodedBufferReader([1, 0x80]);
-    var text = input.readString();
+    final input = CodedBufferReader([1, 0x80]);
+    final text = input.readString();
     expect(text.codeUnitAt(0), 0xfffd);
   });
 

--- a/protobuf/test/event_test.dart
+++ b/protobuf/test/event_test.dart
@@ -23,8 +23,8 @@ Extension comment = Extension('Rec', 'comment', 6, PbFieldType.OS);
 
 void main() {
   test('Events are sent when setting and clearing a non-repeated field', () {
-    var log = makeLog();
-    var r = Rec();
+    final log = makeLog();
+    final r = Rec();
     r.changes.listen((List<PbFieldChange> changes) {
       log.add(changes);
     });
@@ -51,8 +51,8 @@ void main() {
   });
 
   test('Events are sent when creating and clearing a repeated field', () {
-    var log = makeLog();
-    var r = Rec();
+    final log = makeLog();
+    final r = Rec();
     r.changes.listen((List<PbFieldChange> changes) {
       log.add(changes);
     });
@@ -60,7 +60,7 @@ void main() {
     // Accessing a repeated field replaces the default,
     // read-only [] with a mutable [],
     // which counts as a change.
-    var list = r.int32s;
+    final list = r.int32s;
     r.deliverChanges();
     checkLogOnce(log, [4, [], []]);
 
@@ -79,8 +79,8 @@ void main() {
   });
 
   test('Events are sent when clearing multiple fields', () {
-    var log = makeLog();
-    var r = Rec()
+    final log = makeLog();
+    final r = Rec()
       ..val = 123
       ..str = 'hello'
       ..child = Rec()
@@ -109,14 +109,14 @@ void main() {
   });
 
   test('Events are sent when merging from another protobuf', () {
-    var log = makeLog();
-    var src = Rec()
+    final log = makeLog();
+    final src = Rec()
       ..val = 123
       ..str = 'hello'
       ..child = Rec()
       ..int32s.add(456);
 
-    var dest = Rec();
+    final dest = Rec();
     dest.changes.listen((List<PbFieldChange> changes) {
       checkHasAllFields(dest, true);
       log.add(changes);
@@ -139,8 +139,8 @@ void main() {
   });
 
   test('Events are sent when merging JSON', () {
-    var log = makeLog();
-    var r = Rec();
+    final log = makeLog();
+    final r = Rec();
     r.changes.listen((List<PbFieldChange> changes) {
       // verify that we are not called until all fields are set
       checkHasAllFields(r, true);
@@ -165,16 +165,16 @@ void main() {
   });
 
   test('Events are sent when merging binary', () {
-    var log = makeLog();
+    final log = makeLog();
 
-    var bytes = (Rec()
+    final bytes = (Rec()
           ..val = 123
           ..str = 'hello'
           ..child = Rec()
           ..int32s.add(456))
         .writeToBuffer();
 
-    var r = Rec();
+    final r = Rec();
     r.changes.listen((List<PbFieldChange> changes) {
       // verify that we are not called until all fields are set
       checkHasAllFields(r, true);
@@ -199,8 +199,8 @@ void main() {
   });
 
   test('Events are sent for extensions', () {
-    var log = makeLog();
-    var r = Rec();
+    final log = makeLog();
+    final r = Rec();
     r.changes.listen((List<PbFieldChange> changes) {
       log.add(changes);
     });
@@ -238,21 +238,21 @@ void main() {
     r.deliverChanges();
     checkLogOnce(log, [tag, 'hello', '']);
 
-    var registry = ExtensionRegistry()..add(comment);
+    final registry = ExtensionRegistry()..add(comment);
     r.mergeFromJson('{"$tag": "hello"}', registry);
     expect(r.getExtension(comment), 'hello');
     r.deliverChanges();
     checkLogOnce(log, [tag, '', 'hello']);
     clear('hello');
 
-    var src = Rec()..setExtension(comment, 'hello');
+    final src = Rec()..setExtension(comment, 'hello');
     r.mergeFromMessage(src);
     expect(r.getExtension(comment), 'hello');
     r.deliverChanges();
     checkLogOnce(log, [tag, '', 'hello']);
     clear('hello');
 
-    var bytes = src.writeToBuffer();
+    final bytes = src.writeToBuffer();
     r.mergeFromBuffer(bytes, registry);
     expect(r.getExtension(comment), 'hello');
     r.deliverChanges();
@@ -269,10 +269,10 @@ void checkLogOnce(List<List<PbFieldChange>> log, List expectedEntry) =>
     ]);
 
 void checkLog(List<List<PbFieldChange>> log, List<List<List>> expected) {
-  var actual = <List<List>>[];
-  for (var list in log) {
-    var tuples = <List>[];
-    for (var item in list) {
+  final actual = <List<List>>[];
+  for (final list in log) {
+    final tuples = <List>[];
+    for (final item in list) {
       tuples.add(toTuple(item));
     }
     actual.add(tuples);

--- a/protobuf/test/json_test.dart
+++ b/protobuf/test/json_test.dart
@@ -14,7 +14,7 @@ import 'package:test/test.dart';
 import 'mock_util.dart' show T, mockEnumValues;
 
 void main() {
-  var example = T()
+  final example = T()
     ..val = 123
     ..str = 'hello'
     ..int32s.addAll(<int>[1, 2, 3]);
@@ -72,7 +72,7 @@ void main() {
   });
 
   test('testWriteToJson', () {
-    var json = example.writeToJson();
+    final json = example.writeToJson();
     checkJsonMap(jsonDecode(json));
   });
 
@@ -83,18 +83,18 @@ void main() {
   });
 
   test('writeToJsonMap', () {
-    Map m = example.writeToJsonMap();
+    final Map m = example.writeToJsonMap();
     checkJsonMap(m);
   });
 
   test('testMergeFromJson', () {
-    var t = T();
+    final t = T();
     t.mergeFromJson('''{"1": 123, "2": "hello"}''');
     checkMessage(t);
   });
 
   test('testMergeFromJsonMap', () {
-    var t = T();
+    final t = T();
     t.mergeFromJsonMap({'1': 123, '2': 'hello'});
     checkMessage(t);
   });

--- a/protobuf/test/list_test.dart
+++ b/protobuf/test/list_test.dart
@@ -16,7 +16,7 @@ T cast<T>(Object? x) => x as T;
 
 void main() {
   test('testPbList handles basic operations', () {
-    var lb1 = PbList<int>();
+    final lb1 = PbList<int>();
     expect(lb1, []);
 
     lb1.add(1);
@@ -38,18 +38,18 @@ void main() {
     expect(lb1.firstWhere((e) => e % 2 == 0), 0);
 
     expect(lb1.last, 99);
-    var last = lb1.removeLast();
+    final last = lb1.removeLast();
     expect(last, 99);
     expect(lb1.last, 6);
 
     var count = 0;
-    for (var i in lb1) {
+    for (final i in lb1) {
       count += i;
     }
     expect(count, 108);
 
     bool isEven(int i) => i % 2 == 0;
-    var evens = List<int>.from(lb1.where(isEven));
+    final evens = List<int>.from(lb1.where(isEven));
     expect(evens, [0, 2, 6]);
 
     expect(lb1.any(isEven), isTrue);
@@ -62,7 +62,7 @@ void main() {
   });
 
   test('PbList handles range operations', () {
-    var lb2 = PbList<int>();
+    final lb2 = PbList<int>();
 
     lb2.addAll([1, 2, 3, 4, 5, 6, 7, 8, 9]);
     expect(lb2.sublist(3, 7), [4, 5, 6, 7]);
@@ -96,7 +96,7 @@ void main() {
   });
 
   test('PbList for signed int32 validates items', () {
-    List<int> list = PbList(check: getCheckFunction(PbFieldType.P3));
+    final List<int> list = PbList(check: getCheckFunction(PbFieldType.P3));
 
     expect(() {
       list.add(-2147483649);
@@ -116,7 +116,7 @@ void main() {
   });
 
   test('PBList for unsigned int32 validates items', () {
-    List<int> list = PbList(check: getCheckFunction(PbFieldType.PU3));
+    final List<int> list = PbList(check: getCheckFunction(PbFieldType.PU3));
 
     expect(() {
       list.add(-1);
@@ -136,7 +136,7 @@ void main() {
   });
 
   test('PbList for float validates items', () {
-    List<double> list = PbList(check: getCheckFunction(PbFieldType.PF));
+    final List<double> list = PbList(check: getCheckFunction(PbFieldType.PF));
 
     expect(() {
       list.add(3.4028234663852886E39);
@@ -156,7 +156,7 @@ void main() {
   });
 
   test('PbList for signed Int64 validates items', () {
-    List<Int64> list = PbList();
+    final List<Int64> list = PbList();
     expect(() {
       list.add(cast(0)); // not an Int64
     }, badArgument);
@@ -175,7 +175,7 @@ void main() {
   });
 
   test('PbList for unsigned Int64 validates items', () {
-    List<Int64> list = PbList();
+    final List<Int64> list = PbList();
     expect(() {
       list.add(cast(0)); // not an Int64
     }, badArgument);

--- a/protobuf/test/map_mixin_test.dart
+++ b/protobuf/test/map_mixin_test.dart
@@ -27,7 +27,7 @@ class Rec extends MockMessage with MapMixin<Object?, Object>, PbMapMixin {
 
 void main() {
   test('PbMapMixin methods return default field values', () {
-    var r = Rec();
+    final r = Rec();
 
     expect(r.isEmpty, false);
     expect(r.isNotEmpty, true);
@@ -39,7 +39,7 @@ void main() {
     expect(r['child'].toString(), 'Rec(42, "")');
     expect(r['int32s'], []);
 
-    var v = r.values;
+    final v = r.values;
     expect(v.length, 6);
     expect(v.first, 42);
     expect(v.toList()[1], '');
@@ -49,7 +49,7 @@ void main() {
   });
 
   test('operator []= sets record fields', () {
-    var r = Rec();
+    final r = Rec();
 
     r['val'] = 123;
     expect(r.val, 123);
@@ -59,7 +59,7 @@ void main() {
     expect(r.str, 'hello');
     expect(r['str'], 'hello');
 
-    var child = Rec();
+    final child = Rec();
     r['child'] = child;
     expect(r.child, same(child));
     expect(r['child'], same(child));
@@ -71,12 +71,12 @@ void main() {
   });
 
   test('operator== and hashCode work for Map mixin', () {
-    var a = Rec();
+    final a = Rec();
     expect(a == a, true);
     expect(a == {}, false);
     expect({} == a, false);
 
-    var b = Rec();
+    final b = Rec();
     expect(a.info_ == b.info_, true, reason: 'BuilderInfo should be the same');
     expect(a == b, true);
     expect(a.hashCode, b.hashCode);
@@ -95,14 +95,14 @@ void main() {
   });
 
   test("protobuf doesn't compare equal to a map with the same values", () {
-    var a = Rec();
+    final a = Rec();
     expect(a == Map.from(a), false);
     expect(Map.from(a) == a, false);
   });
 
   test("reading protobuf values shouldn't change equality", () {
-    var a = Rec();
-    var b = Rec();
+    final a = Rec();
+    final b = Rec();
     expect(a == b, true);
     Map.from(a);
     expect(a == b, true);

--- a/protobuf/test/message_test.dart
+++ b/protobuf/test/message_test.dart
@@ -27,14 +27,14 @@ Matcher throwsError(Type expectedType, String expectedMessage) =>
 
 void main() {
   test('getField with invalid tag throws exception', () {
-    var r = Rec();
+    final r = Rec();
     expect(() {
       r.getField(123);
     }, throwsError(ArgumentError, 'tag 123 not defined in Rec'));
   });
 
   test('getDefaultForField with invalid tag throws exception', () {
-    var r = Rec();
+    final r = Rec();
     expect(() {
       r.getDefaultForField(123);
     }, throwsError(ArgumentError, 'tag 123 not defined in Rec'));
@@ -68,10 +68,10 @@ void main() {
   });
 
   test('operator== and hashCode work for a simple record', () {
-    var a = Rec();
+    final a = Rec();
     expect(a == a, true);
 
-    var b = Rec();
+    final b = Rec();
     expect(a.info_ == b.info_, true, reason: 'BuilderInfo should be the same');
     expect(a == b, true);
     expect(a.hashCode, b.hashCode);

--- a/protobuf/test/mock_util.dart
+++ b/protobuf/test/mock_util.dart
@@ -52,7 +52,7 @@ abstract class MockMessage extends GeneratedMessage {
 
   @override
   GeneratedMessage clone() {
-    var create = info_.byName['child']!.subBuilder!;
+    final create = info_.byName['child']!.subBuilder!;
     return create()..mergeFromMessage(this);
   }
 }

--- a/protobuf/test/readonly_message_test.dart
+++ b/protobuf/test/readonly_message_test.dart
@@ -106,8 +106,8 @@ void main() {
   });
 
   test("can't modify sub-messages on a read-only message", () {
-    var subMessage = Rec.create()..value = 1;
-    var r = Rec.create()
+    final subMessage = Rec.create()..value = 1;
+    final r = Rec.create()
       ..sub.add(Rec.create()..sub.add(subMessage))
       ..freeze();
     expect(r.sub[0].sub[0].value, 1);

--- a/protoc_plugin/bin/protoc_plugin_bazel.dart
+++ b/protoc_plugin/bin/protoc_plugin_bazel.dart
@@ -9,7 +9,7 @@ import 'package:protoc_plugin/bazel.dart';
 import 'package:protoc_plugin/protoc.dart';
 
 void main() {
-  var packages = <String, BazelPackage>{};
+  final packages = <String, BazelPackage>{};
   CodeGenerator(stdin, stdout).generate(
       optionParsers: {bazelOptionId: BazelOptionParser(packages)},
       config: BazelOutputConfiguration(packages));

--- a/protoc_plugin/legacy_tests/generated_message_test.dart
+++ b/protoc_plugin/legacy_tests/generated_message_test.dart
@@ -12,7 +12,7 @@ import '../out/protos/toplevel_import.pb.dart' as t;
 
 void main() {
   test('testSettersRejectNull', () {
-    var message = TestAllTypes();
+    final message = TestAllTypes();
     expect(() {
       message.optionalString = null;
     }, throwsArgumentError);
@@ -46,7 +46,7 @@ void main() {
   });
 
   test('testRepeatedSettersRejectNull', () {
-    var message = TestAllTypes();
+    final message = TestAllTypes();
 
     message.repeatedString.addAll(['one', 'two']);
     expect(() {
@@ -74,7 +74,7 @@ void main() {
   });
 
   test('testRepeatedAppendRejectsNull', () {
-    var message = TestAllTypes();
+    final message = TestAllTypes();
 
     expect(() {
       message.repeatedForeignMessage.addAll([ForeignMessage()..c = 12, null]);
@@ -94,7 +94,7 @@ void main() {
   });
 
   test('testToplevel', () {
-    var message = t.M();
+    final message = t.M();
     message.t = T();
     t.SApi(null);
   });

--- a/protoc_plugin/lib/bazel.dart
+++ b/protoc_plugin/lib/bazel.dart
@@ -51,18 +51,18 @@ class BazelOptionParser implements SingleOptionParser {
       return;
     }
 
-    for (var entry in value.split(';')) {
-      var fields = entry.split('|');
+    for (final entry in value.split(';')) {
+      final fields = entry.split('|');
       if (fields.length != 3) {
         onError(
             'ERROR: expected package_name|input_root|output_root. Got: $entry');
         continue;
       }
-      var pkg = BazelPackage(fields[0], fields[1], fields[2]);
+      final pkg = BazelPackage(fields[0], fields[1], fields[2]);
       if (!output.containsKey(pkg.inputRoot)) {
         output[pkg.inputRoot] = pkg;
       } else {
-        var prev = output[pkg.inputRoot]!;
+        final prev = output[pkg.inputRoot]!;
         if (pkg.name != prev.name) {
           onError('ERROR: multiple packages with input_root ${pkg.inputRoot}: '
               '${prev.name} and ${pkg.name}');
@@ -99,7 +99,7 @@ class BazelOutputConfiguration extends DefaultOutputConfiguration {
     var index = searchPath.lastIndexOf('/');
     while (index > 0) {
       searchPath = searchPath.substring(0, index);
-      var pkg = packages[searchPath];
+      final pkg = packages[searchPath];
       if (pkg != null) return pkg;
       index = searchPath.lastIndexOf('/');
     }
@@ -108,23 +108,23 @@ class BazelOutputConfiguration extends DefaultOutputConfiguration {
 
   @override
   Uri outputPathFor(Uri inputPath, String extension) {
-    var pkg = _findPackage(inputPath.path);
+    final pkg = _findPackage(inputPath.path);
     if (pkg == null) {
       throw ArgumentError('Unable to locate package for input $inputPath.');
     }
 
     // Bazel package-relative paths.
-    var relativeInput = inputPath.path.substring('${pkg.inputRoot}/'.length);
-    var base = p.withoutExtension(relativeInput);
-    var outputPath = p.join(pkg.outputRoot, '$base$extension');
+    final relativeInput = inputPath.path.substring('${pkg.inputRoot}/'.length);
+    final base = p.withoutExtension(relativeInput);
+    final outputPath = p.join(pkg.outputRoot, '$base$extension');
     return Uri.file(outputPath);
   }
 
   @override
   Uri resolveImport(Uri target, Uri source, String extension) {
-    var targetBase = p.withoutExtension(target.path);
-    var targetUri = _packageUriFor('$targetBase$extension');
-    var sourceUri = _packageUriFor(source.path);
+    final targetBase = p.withoutExtension(target.path);
+    final targetUri = _packageUriFor('$targetBase$extension');
+    final sourceUri = _packageUriFor(source.path);
 
     if (targetUri == null && sourceUri != null) {
       // We can't reach outside of the lib/ directory of a package without
@@ -141,9 +141,9 @@ class BazelOutputConfiguration extends DefaultOutputConfiguration {
   }
 
   _PackageUri? _packageUriFor(String target) {
-    var pkg = _findPackage(target);
+    final pkg = _findPackage(target);
     if (pkg == null) return null;
-    var relPath = target.substring(pkg.inputRoot.length + 1);
+    final relPath = target.substring(pkg.inputRoot.length + 1);
     return _PackageUri(pkg.name, relPath);
   }
 }

--- a/protoc_plugin/lib/const_generator.dart
+++ b/protoc_plugin/lib/const_generator.dart
@@ -49,7 +49,7 @@ void _writeString(IndentingWriter out, String val) {
 
 void _writeListItems(IndentingWriter out, List val, {bool vertical = false}) {
   var first = true;
-  for (var item in val) {
+  for (final item in val) {
     if (!first && !vertical) {
       out.print(', ');
     }
@@ -64,7 +64,7 @@ void _writeListItems(IndentingWriter out, List val, {bool vertical = false}) {
 void _writeMapItems(IndentingWriter out, Map<dynamic, dynamic> val,
     {bool vertical = false}) {
   var first = true;
-  for (var key in val.keys) {
+  for (final key in val.keys) {
     if (!first && !vertical) out.print(', ');
     _writeString(out, key as String);
     out.print(': ');

--- a/protoc_plugin/lib/indenting_writer.dart
+++ b/protoc_plugin/lib/indenting_writer.dart
@@ -39,13 +39,13 @@ class IndentingWriter {
   /// (Indentation will be added after newline characters where needed.)
   void print(String text) {
     _previousOffset = _buffer.length;
-    var lastNewline = text.lastIndexOf('\n');
+    final lastNewline = text.lastIndexOf('\n');
     if (lastNewline == -1) {
       _writeChunk(text);
       return;
     }
 
-    for (var line in text.substring(0, lastNewline).split('\n')) {
+    for (final line in text.substring(0, lastNewline).split('\n')) {
       _writeChunk(line);
       _newline();
     }
@@ -96,7 +96,7 @@ class IndentingWriter {
 
   void _addBlockBodyAndEnd(
       String end, void Function() body, bool endWithNewline, String newIndent) {
-    var oldIndent = _indent;
+    final oldIndent = _indent;
     _indent = newIndent;
     body();
     _indent = oldIndent;
@@ -122,7 +122,7 @@ class IndentingWriter {
     if (_suffixes.isNotEmpty) {
       // TODO: We may want to introduce the notion of closing the writer.
       println('');
-      for (var key in _suffixes.keys) {
+      for (final key in _suffixes.keys) {
         println(_suffixes[key]!);
       }
       _suffixes.clear();
@@ -157,7 +157,7 @@ class IndentingWriter {
     if (_sourceFile == null) {
       return;
     }
-    var annotation = GeneratedCodeInfo_Annotation()
+    final annotation = GeneratedCodeInfo_Annotation()
       ..path.addAll(fieldPath)
       ..sourceFile = _sourceFile!
       ..begin = _previousOffset + start
@@ -184,7 +184,7 @@ class ImportWriter {
 
   /// Add an import with an optional import prefix.
   void addImport(String url, {String? prefix}) {
-    var directive =
+    final directive =
         prefix == null ? "import '$url';" : "import '$url' as $prefix;";
     if (url.startsWith('dart:')) {
       _dartImports.add(directive);
@@ -202,7 +202,7 @@ class ImportWriter {
 
   /// Return the generated text for the set of imports.
   String emit() {
-    var buf = StringBuffer();
+    final buf = StringBuffer();
 
     if (_dartImports.isNotEmpty) {
       _dartImports.forEach(buf.writeln);

--- a/protoc_plugin/lib/mixins.dart
+++ b/protoc_plugin/lib/mixins.dart
@@ -54,7 +54,7 @@ class PbMixin {
 
   /// Returns the mixin and its ancestors, in the order they should be applied.
   Iterable<PbMixin> findMixinsToApply() {
-    var result = [this];
+    final result = [this];
     for (var p = parent; p != null; p = p.parent) {
       result.add(p);
     }
@@ -63,7 +63,7 @@ class PbMixin {
 
   /// Returns all the reserved names, including from ancestor mixins.
   Iterable<String> findReservedNames() {
-    var names = <String>{};
+    final names = <String>{};
     for (PbMixin? m = this; m != null; m = m.parent) {
       names.add(m.name);
       if (m.reservedNames != null) {

--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -128,16 +128,16 @@ String legalDartIdentifier(String input) {
 /// Chooses the name of the Dart class holding top-level extensions.
 String extensionClassName(
     FileDescriptorProto descriptor, Set<String> usedNames) {
-  var s = avoidInitialUnderscore(
+  final s = avoidInitialUnderscore(
       legalDartIdentifier(_fileNameWithoutExtension(descriptor)));
-  var candidate = '${s[0].toUpperCase()}${s.substring(1)}';
+  final candidate = '${s[0].toUpperCase()}${s.substring(1)}';
   return disambiguateName(candidate, usedNames, extensionSuffixes());
 }
 
 String _fileNameWithoutExtension(FileDescriptorProto descriptor) {
-  var path = Uri.file(descriptor.name);
-  var fileName = path.pathSegments.last;
-  var dot = fileName.lastIndexOf('.');
+  final path = Uri.file(descriptor.name);
+  final fileName = path.pathSegments.last;
+  final dot = fileName.lastIndexOf('.');
   return dot == -1 ? fileName : fileName.substring(0, dot);
 }
 
@@ -171,7 +171,7 @@ String disambiguateName(
   var candidateVariants = generateVariants(name);
 
   if (!allVariantsAvailable(candidateVariants)) {
-    for (var suffix in suffixes) {
+    for (final suffix in suffixes) {
       candidateVariants = generateVariants('$name$suffix');
       if (allVariantsAvailable(candidateVariants)) {
         usedSuffix = suffix;
@@ -244,10 +244,10 @@ Iterable<String> enumSuffixes() sync* {
 MemberNames messageMemberNames(DescriptorProto descriptor,
     String parentClassName, Set<String> usedTopLevelNames,
     {Iterable<String> reserved = const []}) {
-  var fieldList = List<FieldDescriptorProto>.from(descriptor.field);
-  var sourcePositions =
+  final fieldList = List<FieldDescriptorProto>.from(descriptor.field);
+  final sourcePositions =
       fieldList.asMap().map((index, field) => MapEntry(field.name, index));
-  var sorted = fieldList
+  final sorted = fieldList
     ..sort((FieldDescriptorProto a, FieldDescriptorProto b) {
       if (a.number < b.number) return -1;
       if (a.number > b.number) return 1;
@@ -255,15 +255,15 @@ MemberNames messageMemberNames(DescriptorProto descriptor,
     });
 
   // Choose indexes first, based on their position in the sorted list.
-  var indexes = <String, int>{};
-  for (var field in sorted) {
-    var index = indexes.length;
+  final indexes = <String, int>{};
+  for (final field in sorted) {
+    final index = indexes.length;
     indexes[field.name] = index;
   }
 
-  var existingNames = <String>{...reservedMemberNames, ...reserved};
+  final existingNames = <String>{...reservedMemberNames, ...reserved};
 
-  var fieldNames = List<FieldNames?>.filled(indexes.length, null);
+  final fieldNames = List<FieldNames?>.filled(indexes.length, null);
 
   void takeFieldNames(FieldNames chosen) {
     fieldNames[chosen.index!] = chosen;
@@ -280,7 +280,7 @@ MemberNames messageMemberNames(DescriptorProto descriptor,
   // Handle fields with a dart_name option.
   // They have higher priority than automatically chosen names.
   // Explicitly setting a name that's already taken is a build error.
-  for (var field in sorted) {
+  for (final field in sorted) {
     if (_nameOption(field)!.isNotEmpty) {
       takeFieldNames(_memberNamesFromOption(descriptor, field,
           indexes[field.name]!, sourcePositions[field.name]!, existingNames));
@@ -289,16 +289,16 @@ MemberNames messageMemberNames(DescriptorProto descriptor,
 
   // Then do other fields.
   // They are automatically renamed until we find something unused.
-  for (var field in sorted) {
+  for (final field in sorted) {
     if (_nameOption(field)!.isEmpty) {
-      var index = indexes[field.name]!;
-      var sourcePosition = sourcePositions[field.name];
+      final index = indexes[field.name]!;
+      final sourcePosition = sourcePositions[field.name];
       takeFieldNames(
           _unusedMemberNames(field, index, sourcePosition, existingNames));
     }
   }
 
-  var oneofNames = <OneofNames>[];
+  final oneofNames = <OneofNames>[];
 
   void takeOneofNames(OneofNames chosen) {
     oneofNames.add(chosen);
@@ -313,16 +313,16 @@ MemberNames messageMemberNames(DescriptorProto descriptor,
 
   final realOneofCount = countRealOneofs(descriptor);
   for (var i = 0; i < realOneofCount; i++) {
-    var oneof = descriptor.oneofDecl[i];
+    final oneof = descriptor.oneofDecl[i];
 
-    var oneofName = disambiguateName(
+    final oneofName = disambiguateName(
         underscoresToCamelCase(oneof.name), existingNames, defaultSuffixes(),
         generateVariants: oneofNameVariants);
 
-    var oneofEnumName =
+    final oneofEnumName =
         oneofEnumClassName(oneof.name, usedTopLevelNames, parentClassName);
 
-    var enumMapName = disambiguateName(
+    final enumMapName = disambiguateName(
         '_${oneofEnumName}ByTag', existingNames, defaultSuffixes());
 
     takeOneofNames(OneofNames(oneof, i, _defaultClearMethodName(oneofName),
@@ -343,7 +343,7 @@ FieldNames _memberNamesFromOption(
     int sourcePosition,
     Set<String> existingNames) {
   // TODO(skybrian): provide more context in errors (filename).
-  var where = '${message.name}.${field.name}';
+  final where = '${message.name}.${field.name}';
 
   void checkAvailable(String name) {
     if (existingNames.contains(name)) {
@@ -352,7 +352,7 @@ FieldNames _memberNamesFromOption(
     }
   }
 
-  var name = _nameOption(field)!;
+  final name = _nameOption(field)!;
   if (name.isEmpty) {
     throw ArgumentError("field doesn't have dart_name option");
   }
@@ -366,10 +366,10 @@ FieldNames _memberNamesFromOption(
     return FieldNames(field, index, sourcePosition, name);
   }
 
-  var hasMethod = 'has${_capitalize(name)}';
+  final hasMethod = 'has${_capitalize(name)}';
   checkAvailable(hasMethod);
 
-  var clearMethod = 'clear${_capitalize(name)}';
+  final clearMethod = 'clear${_capitalize(name)}';
   checkAvailable(clearMethod);
 
   String? ensureMethod;
@@ -404,7 +404,7 @@ FieldNames _unusedMemberNames(FieldDescriptorProto field, int? index,
   }
 
   List<String> generateNameVariants(String name) {
-    var result = <String>[
+    final result = <String>[
       _defaultFieldName(name),
       _defaultHasMethodName(name),
       _defaultClearMethodName(name),
@@ -416,7 +416,7 @@ FieldNames _unusedMemberNames(FieldDescriptorProto field, int? index,
     return result;
   }
 
-  var name = disambiguateName(_fieldMethodSuffix(field), existingNames,
+  final name = disambiguateName(_fieldMethodSuffix(field), existingNames,
       _memberNamesSuffix(field.number),
       generateVariants: generateNameVariants);
 
@@ -457,7 +457,7 @@ String _fieldMethodSuffix(FieldDescriptorProto field) {
 
   // For groups, use capitalization of 'typeName' rather than 'name'.
   name = field.typeName;
-  var index = name.lastIndexOf('.');
+  final index = name.lastIndexOf('.');
   if (index != -1) {
     name = name.substring(index + 1);
   }

--- a/protoc_plugin/lib/src/base_type.dart
+++ b/protoc_plugin/lib/src/base_type.dart
@@ -124,7 +124,7 @@ class BaseType {
         throw ArgumentError('unimplemented type: ${field.type.name}');
     }
 
-    var generator = ctx.getFieldType(field.typeName);
+    final generator = ctx.getFieldType(field.typeName);
     if (generator == null) {
       throw 'FAILURE: Unknown type reference ${field.typeName}';
     }

--- a/protoc_plugin/lib/src/client_generator.dart
+++ b/protoc_plugin/lib/src/client_generator.dart
@@ -25,7 +25,7 @@ class ClientApiGenerator {
       out.println('${className}Api(this._client);');
       out.println();
 
-      for (var m in service._descriptor.method) {
+      for (final m in service._descriptor.method) {
         generateMethod(out, m);
       }
     });
@@ -34,19 +34,19 @@ class ClientApiGenerator {
 
   // Subclasses can override this.
   void generateMethod(IndentingWriter out, MethodDescriptorProto m) {
-    var methodName = disambiguateName(
+    final methodName = disambiguateName(
         avoidInitialUnderscore(service._methodName(m.name)),
         usedMethodNames,
         defaultSuffixes());
-    var inputType = service._getDartClassName(m.inputType, forMainFile: true);
-    var outputType = service._getDartClassName(m.outputType, forMainFile: true);
+    final inputType = service._getDartClassName(m.inputType, forMainFile: true);
+    final outputType =
+        service._getDartClassName(m.outputType, forMainFile: true);
     out.addBlock(
         '$asyncImportPrefix.Future<$outputType> $methodName('
-            '$protobufImportPrefix.ClientContext? ctx, $inputType request) {',
-        '}', () {
-      out.println('var emptyResponse = $outputType();');
-      out.println('return _client.invoke<$outputType>(ctx, \'$className\', '
-          '\'${m.name}\', request, emptyResponse);');
+            '$protobufImportPrefix.ClientContext? ctx, $inputType request) =>',
+        ';', () {
+      out.println('_client.invoke<$outputType>(ctx, \'$className\', '
+          '\'${m.name}\', request, $outputType())');
     });
   }
 }

--- a/protoc_plugin/lib/src/code_generator.dart
+++ b/protoc_plugin/lib/src/code_generator.dart
@@ -44,7 +44,7 @@ abstract class ProtobufContainer {
       '${lowerCaseFirstLetter(classname!)}Descriptor';
 
   String _getFileImportPrefix() {
-    var path = fileGen!.protoFileUri.toString();
+    final path = fileGen!.protoFileUri.toString();
     if (_importPrefixes.containsKey(path)) {
       return _importPrefixes[path]!;
     }
@@ -89,7 +89,7 @@ class CodeGenerator {
   void generate(
       {Map<String, SingleOptionParser>? optionParsers,
       OutputConfiguration config = const DefaultOutputConfiguration()}) {
-    var extensions = ExtensionRegistry();
+    final extensions = ExtensionRegistry();
     Dart_options.registerAllExtensions(extensions);
 
     _streamIn
@@ -105,10 +105,10 @@ class CodeGenerator {
       request.mergeFromCodedBufferReader(reader, extensions);
       reader.checkLastTagWas(0);
 
-      var response = CodeGeneratorResponse();
+      final response = CodeGeneratorResponse();
 
       // Parse the options in the request. Return the errors if any.
-      var options = parseGenerationOptions(request, response, optionParsers);
+      final options = parseGenerationOptions(request, response, optionParsers);
       if (options == null) {
         _streamOut.add(response.writeToBuffer());
         return;
@@ -116,8 +116,8 @@ class CodeGenerator {
 
       // Create a syntax tree for each .proto file given to us.
       // (We may import it even if we don't generate the .pb.dart file.)
-      var generators = <FileGenerator>[];
-      for (var file in request.protoFile) {
+      final generators = <FileGenerator>[];
+      for (final file in request.protoFile) {
         generators.add(FileGenerator(file, options));
       }
 
@@ -125,8 +125,8 @@ class CodeGenerator {
       link(options, generators);
 
       // Generate the .pb.dart file if requested.
-      for (var gen in generators) {
-        var name = gen.descriptor.name;
+      for (final gen in generators) {
+        final name = gen.descriptor.name;
         if (request.fileToGenerate.contains(name)) {
           response.file.addAll(gen.generateFiles(config));
         }

--- a/protoc_plugin/lib/src/enum_generator.dart
+++ b/protoc_plugin/lib/src/enum_generator.dart
@@ -48,8 +48,8 @@ class EnumGenerator extends ProtobufContainer {
         _descriptor = descriptor {
     final usedNames = {...reservedEnumNames};
     for (var i = 0; i < descriptor.value.length; i++) {
-      var value = descriptor.value[i];
-      var canonicalValue =
+      final value = descriptor.value[i];
+      final canonicalValue =
           descriptor.value.firstWhere((v) => v.number == value.number);
       if (value == canonicalValue) {
         _canonicalValues.add(value);
@@ -93,7 +93,7 @@ class EnumGenerator extends ProtobufContainer {
   /// Returns a const expression that evaluates to the JSON for this message.
   /// [usage] represents the .pb.dart file where the expression will be used.
   String getJsonConstant(FileGenerator usage) {
-    var name = '$classname\$json';
+    final name = '$classname\$json';
     if (usage.protoFileUri == fileGen!.protoFileUri) {
       return name;
     }
@@ -114,7 +114,7 @@ class EnumGenerator extends ProtobufContainer {
       // -----------------------------------------------------------------
       // Define enum types.
       for (var i = 0; i < _canonicalValues.length; i++) {
-        var val = _canonicalValues[i];
+        final val = _canonicalValues[i];
         final name = dartNames[val.name]!;
         final omitEnumNames = ConditionalConstDefinition('omit_enum_names');
         out.addSuffix(
@@ -134,7 +134,7 @@ class EnumGenerator extends ProtobufContainer {
       if (_aliases.isNotEmpty) {
         out.println();
         for (var i = 0; i < _aliases.length; i++) {
-          var alias = _aliases[i];
+          final alias = _aliases[i];
           final name = dartNames[alias.value.name]!;
           out.printlnAnnotated(
               'static const $classname $name ='
@@ -152,7 +152,7 @@ class EnumGenerator extends ProtobufContainer {
 
       out.println('static const $coreImportPrefix.List<$classname> values ='
           ' <$classname> [');
-      for (var val in _canonicalValues) {
+      for (final val in _canonicalValues) {
         final name = dartNames[val.name];
         out.println('  $name,');
       }
@@ -174,8 +174,8 @@ class EnumGenerator extends ProtobufContainer {
 
   /// Writes a Dart constant containing the JSON for the EnumProtoDescriptor.
   void generateConstants(IndentingWriter out) {
-    var name = getJsonConstant(fileGen!);
-    var json = _descriptor.writeToJsonMap();
+    final name = getJsonConstant(fileGen!);
+    final json = _descriptor.writeToJsonMap();
 
     out.println('@$coreImportPrefix.Deprecated'
         '(\'Use ${toplevelParent!.binaryDescriptorName} instead\')');

--- a/protoc_plugin/lib/src/extension_generator.dart
+++ b/protoc_plugin/lib/src/extension_generator.dart
@@ -40,7 +40,7 @@ class ExtensionGenerator {
     _field = ProtobufField.extension(_descriptor, _parent, ctx);
     _resolved = true;
 
-    var extendedType = ctx.getFieldType(_descriptor.extendee);
+    final extendedType = ctx.getFieldType(_descriptor.extendee);
     // TODO(skybrian) When would this be null?
     if (extendedType != null) {
       _extendedFullName = extendedType.fullName;
@@ -54,7 +54,7 @@ class ExtensionGenerator {
 
   String get name {
     if (!_resolved) throw StateError('resolve not called');
-    var name = _extensionName;
+    final name = _extensionName;
     return _parent is MessageGenerator ? '${_parent.classname}.$name' : name;
   }
 
@@ -70,7 +70,7 @@ class ExtensionGenerator {
   void addImportsTo(
       Set<FileGenerator> imports, Set<FileGenerator> enumImports) {
     if (!_resolved) throw StateError('resolve not called');
-    var typeGen = _field.baseType.generator;
+    final typeGen = _field.baseType.generator;
     if (typeGen is EnumGenerator) {
       // Enums are always in a different file.
       enumImports.add(typeGen.fileGen!);
@@ -89,9 +89,9 @@ class ExtensionGenerator {
   void generate(IndentingWriter out) {
     if (!_resolved) throw StateError('resolve not called');
 
-    var name = _extensionName;
-    var type = _field.baseType;
-    var dartType = type.getDartType(fileGen!);
+    final name = _extensionName;
+    final type = _field.baseType;
+    final dartType = type.getDartType(fileGen!);
 
     final omitFieldNames = ConditionalConstDefinition('omit_field_names');
     out.addSuffix(
@@ -104,13 +104,13 @@ class ExtensionGenerator {
         omitMessageNames.createTernary(_extendedFullName);
 
     String invocation;
-    var positionals = <String>[];
+    final positionals = <String>[];
     positionals.add(conditionalExtendedName);
     positionals.add(conditionalName);
     positionals.add('${_field.number}');
     positionals.add(_field.typeConstant);
 
-    var named = <String, String?>{};
+    final named = <String, String?>{};
     named['protoName'] = _field.quotedProtoName;
     if (_field.isRepeated) {
       invocation = '$protobufImportPrefix.Extension<$dartType>.repeated';
@@ -128,12 +128,12 @@ class ExtensionGenerator {
       if (type.isMessage || type.isGroup) {
         named['subBuilder'] = '$dartType.create';
       } else if (type.isEnum) {
-        var dartEnum = type.getDartType(fileGen!);
+        final dartEnum = type.getDartType(fileGen!);
         named['valueOf'] = '$dartEnum.valueOf';
         named['enumValues'] = '$dartEnum.values';
       }
     }
-    var fieldDefinition = 'static final ';
+    final fieldDefinition = 'static final ';
     out.printAnnotated(
         '$fieldDefinition$name = '
         '$invocation(${ProtobufField._formatArguments(positionals, named)});\n',

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -42,10 +42,10 @@ class FileGenerator extends ProtobufContainer {
         !desc.options.hasExtension(Dart_options.imports)) {
       return <String, PbMixin>{};
     }
-    var dartMixins = <String, DartMixin>{};
+    final dartMixins = <String, DartMixin>{};
     final importedMixins =
         desc.options.getExtension(Dart_options.imports) as Imports;
-    for (var mixin in importedMixins.mixins) {
+    for (final mixin in importedMixins.mixins) {
       if (dartMixins.containsKey(mixin.name)) {
         throw mixinError('Duplicate mixin name: "${mixin.name}"');
       }
@@ -61,15 +61,15 @@ class FileGenerator extends ProtobufContainer {
     }
 
     // Detect cycles and unknown parents.
-    for (var mixin in dartMixins.values) {
+    for (final mixin in dartMixins.values) {
       if (!mixin.hasParent()) continue;
       var currentMixin = mixin;
-      var parentChain = <String>[];
+      final parentChain = <String>[];
       while (currentMixin.hasParent()) {
-        var parentName = currentMixin.parent;
+        final parentName = currentMixin.parent;
 
-        var declaredMixin = dartMixins.containsKey(parentName);
-        var internalMixin = !declaredMixin && findMixin(parentName) != null;
+        final declaredMixin = dartMixins.containsKey(parentName);
+        final internalMixin = !declaredMixin && findMixin(parentName) != null;
 
         if (internalMixin) break; // No further validation of parent chain.
 
@@ -79,7 +79,7 @@ class FileGenerator extends ProtobufContainer {
         }
 
         if (parentChain.contains(parentName)) {
-          var cycle = '${parentChain.join('->')}->$parentName';
+          final cycle = '${parentChain.join('->')}->$parentName';
           throw mixinError('Cycle in parent chain: $cycle');
         }
         parentChain.add(parentName);
@@ -92,8 +92,8 @@ class FileGenerator extends ProtobufContainer {
     PbMixin? resolveMixin(String name) {
       if (pbMixins.containsKey(name)) return pbMixins[name];
       if (dartMixins.containsKey(name)) {
-        var dartMixin = dartMixins[name]!;
-        var pbMixin = PbMixin(dartMixin.name,
+        final dartMixin = dartMixins[name]!;
+        final pbMixin = PbMixin(dartMixin.name,
             importFrom: dartMixin.importFrom,
             parent: resolveMixin(dartMixin.parent));
         pbMixins[name] = pbMixin;
@@ -102,7 +102,7 @@ class FileGenerator extends ProtobufContainer {
       return findMixin(name);
     }
 
-    for (var mixin in dartMixins.values) {
+    for (final mixin in dartMixins.values) {
       resolveMixin(mixin.name);
     }
     return pbMixins;
@@ -149,11 +149,11 @@ class FileGenerator extends ProtobufContainer {
       throw 'FAILURE: Import with absolute path is not supported';
     }
 
-    var declaredMixins = _getDeclaredMixins(descriptor);
-    var defaultMixinName =
+    final declaredMixins = _getDeclaredMixins(descriptor);
+    final defaultMixinName =
         descriptor.options.getExtension(Dart_options.defaultMixin) as String? ??
             '';
-    var defaultMixin =
+    final defaultMixin =
         declaredMixins[defaultMixinName] ?? findMixin(defaultMixinName);
     if (defaultMixin == null && defaultMixinName.isNotEmpty) {
       throw ('Option default_mixin on file ${descriptor.name}: Unknown mixin '
@@ -173,11 +173,11 @@ class FileGenerator extends ProtobufContainer {
       extensionGenerators.add(ExtensionGenerator.topLevel(
           descriptor.extension[i], this, usedExtensionNames, i));
     }
-    for (var service in descriptor.service) {
+    for (final service in descriptor.service) {
       if (options.useGrpc) {
         grpcGenerators.add(GrpcServiceGenerator(service, this));
       } else {
-        var serviceGen =
+        final serviceGen =
             ServiceGenerator(service, this, usedTopLevelServiceNames);
         serviceGenerators.add(serviceGen);
         clientApiGenerators
@@ -191,10 +191,10 @@ class FileGenerator extends ProtobufContainer {
   void resolve(GenerationContext ctx) {
     if (_linked) throw StateError('cross references already resolved');
 
-    for (var m in messageGenerators) {
+    for (final m in messageGenerators) {
       m.resolve(ctx);
     }
-    for (var x in extensionGenerators) {
+    for (final x in extensionGenerators) {
       x.resolve(ctx);
     }
 
@@ -224,15 +224,15 @@ class FileGenerator extends ProtobufContainer {
     if (!_linked) throw StateError('not linked');
 
     CodeGeneratorResponse_File makeFile(String extension, String content) {
-      var protoUrl = Uri.file(descriptor.name);
-      var dartUrl = config.outputPathFor(protoUrl, extension);
+      final protoUrl = Uri.file(descriptor.name);
+      final dartUrl = config.outputPathFor(protoUrl, extension);
       return CodeGeneratorResponse_File()
         ..name = dartUrl.path
         ..content = content;
     }
 
-    var mainWriter = generateMainFile(config);
-    var enumWriter = generateEnumFile(config);
+    final mainWriter = generateMainFile(config);
+    final enumWriter = generateEnumFile(config);
 
     final files = [
       makeFile('.pb.dart', mainWriter.toString()),
@@ -266,12 +266,12 @@ class FileGenerator extends ProtobufContainer {
   IndentingWriter generateMainFile(
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     if (!_linked) throw StateError('not linked');
-    var out = makeWriter();
+    final out = makeWriter();
 
     writeMainHeader(out, config);
 
     // Generate code.
-    for (var m in messageGenerators) {
+    for (final m in messageGenerators) {
       m.generate(out);
     }
 
@@ -279,22 +279,22 @@ class FileGenerator extends ProtobufContainer {
     // name derived from the file name.
     if (extensionGenerators.isNotEmpty) {
       // TODO(antonm): do not generate a class.
-      var className = extensionClassName(descriptor, usedTopLevelNames);
+      final className = extensionClassName(descriptor, usedTopLevelNames);
       out.addBlock('class $className {', '}\n', () {
-        for (var x in extensionGenerators) {
+        for (final x in extensionGenerators) {
           x.generate(out);
         }
         out.println(
             'static void registerAllExtensions($protobufImportPrefix.ExtensionRegistry '
             'registry) {');
-        for (var x in extensionGenerators) {
+        for (final x in extensionGenerators) {
           out.println('  registry.add(${x.name});');
         }
         out.println('}');
       });
     }
 
-    for (var c in clientApiGenerators) {
+    for (final c in clientApiGenerators) {
       c.generate(out);
     }
     return out;
@@ -305,7 +305,7 @@ class FileGenerator extends ProtobufContainer {
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     _writeHeading(out, extraIgnores: {'unnecessary_import'});
 
-    var importWriter = ImportWriter();
+    final importWriter = ImportWriter();
 
     // We only add the dart:async import if there are generic client API
     // generators for services in the FileDescriptorProto.
@@ -324,31 +324,31 @@ class FileGenerator extends ProtobufContainer {
       importWriter.addImport(_protobufImportUrl, prefix: protobufImportPrefix);
     }
 
-    for (var libraryUri in findMixinImports()) {
+    for (final libraryUri in findMixinImports()) {
       importWriter.addImport(libraryUri, prefix: mixinImportPrefix);
     }
 
     // Import the .pb.dart files we depend on.
-    var imports = Set<FileGenerator>.identity();
-    var enumImports = Set<FileGenerator>.identity();
+    final imports = Set<FileGenerator>.identity();
+    final enumImports = Set<FileGenerator>.identity();
     _findProtosToImport(imports, enumImports);
 
-    for (var target in imports) {
+    for (final target in imports) {
       _addImport(importWriter, config, target, '.pb.dart');
     }
 
-    for (var target in enumImports) {
+    for (final target in enumImports) {
       _addImport(importWriter, config, target, '.pbenum.dart');
     }
 
-    for (var publicDependency in descriptor.publicDependency) {
+    for (final publicDependency in descriptor.publicDependency) {
       _addExport(importWriter, config,
           Uri.file(descriptor.dependency[publicDependency]), '.pb.dart');
     }
 
     // Export enums in main file for backward compatibility.
     if (enumCount > 0) {
-      var url =
+      final url =
           config.resolveImport(protoFileUri, protoFileUri, '.pbenum.dart');
       importWriter.addExport(url.toString());
     }
@@ -357,10 +357,10 @@ class FileGenerator extends ProtobufContainer {
   }
 
   bool get _needsFixnumImport {
-    for (var m in messageGenerators) {
+    for (final m in messageGenerators) {
       if (m.needsFixnumImport) return true;
     }
-    for (var x in extensionGenerators) {
+    for (final x in extensionGenerators) {
       if (x.needsFixnumImport) return true;
     }
     return false;
@@ -374,14 +374,14 @@ class FileGenerator extends ProtobufContainer {
   /// Returns the generator for each .pb.dart file we need to import.
   void _findProtosToImport(
       Set<FileGenerator> imports, Set<FileGenerator> enumImports) {
-    for (var m in messageGenerators) {
+    for (final m in messageGenerators) {
       m.addImportsTo(imports, enumImports);
     }
-    for (var x in extensionGenerators) {
+    for (final x in extensionGenerators) {
       x.addImportsTo(imports, enumImports);
     }
     // Add imports needed for client-side services.
-    for (var x in serviceGenerators) {
+    for (final x in serviceGenerators) {
       x.addImportsTo(imports);
     }
     // Don't need to import self. (But we may need to import the enums.)
@@ -390,8 +390,8 @@ class FileGenerator extends ProtobufContainer {
 
   /// Returns a sorted list of imports needed to support all mixins.
   List<String> findMixinImports() {
-    var mixins = <PbMixin>{};
-    for (var m in messageGenerators) {
+    final mixins = <PbMixin>{};
+    for (final m in messageGenerators) {
       m.addMixinsTo(mixins);
     }
 
@@ -407,10 +407,10 @@ class FileGenerator extends ProtobufContainer {
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     if (!_linked) throw StateError('not linked');
 
-    var out = makeWriter();
+    final out = makeWriter();
     _writeHeading(out);
 
-    var importWriter = ImportWriter();
+    final importWriter = ImportWriter();
 
     if (enumCount > 0) {
       // Make sure any other symbols in dart:core don't cause name conflicts
@@ -419,7 +419,7 @@ class FileGenerator extends ProtobufContainer {
       importWriter.addImport(_protobufImportUrl, prefix: protobufImportPrefix);
     }
 
-    for (var publicDependency in descriptor.publicDependency) {
+    for (final publicDependency in descriptor.publicDependency) {
       _addExport(importWriter, config,
           Uri.file(descriptor.dependency[publicDependency]), '.pbenum.dart');
     }
@@ -428,11 +428,11 @@ class FileGenerator extends ProtobufContainer {
       out.println(importWriter.emit());
     }
 
-    for (var e in enumGenerators) {
+    for (final e in enumGenerators) {
       e.generate(out);
     }
 
-    for (var m in messageGenerators) {
+    for (final m in messageGenerators) {
       m.generateEnums(out);
     }
 
@@ -442,7 +442,7 @@ class FileGenerator extends ProtobufContainer {
   /// Returns the number of enum types generated in the .pbenum.dart file.
   int get enumCount {
     var count = enumGenerators.length;
-    for (var m in messageGenerators) {
+    for (final m in messageGenerators) {
       count += m.enumCount;
     }
     return count;
@@ -452,11 +452,11 @@ class FileGenerator extends ProtobufContainer {
   String generateServerFile(
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     if (!_linked) throw StateError('not linked');
-    var out = makeWriter();
+    final out = makeWriter();
     _writeHeading(out,
         extraIgnores: {'deprecated_member_use_from_same_package'});
 
-    var importWriter = ImportWriter();
+    final importWriter = ImportWriter();
 
     if (serviceGenerators.isNotEmpty) {
       importWriter.addImport(_asyncImportUrl, prefix: asyncImportPrefix);
@@ -465,11 +465,11 @@ class FileGenerator extends ProtobufContainer {
     }
 
     // Import .pb.dart files needed for requests and responses.
-    var imports = <FileGenerator>{};
-    for (var x in serviceGenerators) {
+    final imports = <FileGenerator>{};
+    for (final x in serviceGenerators) {
       x.addImportsTo(imports);
     }
-    for (var target in imports) {
+    for (final target in imports) {
       _addImport(importWriter, config, target, '.pb.dart');
     }
 
@@ -478,14 +478,14 @@ class FileGenerator extends ProtobufContainer {
       _addImport(importWriter, config, this, '.pbjson.dart');
     }
 
-    var url = config.resolveImport(protoFileUri, protoFileUri, '.pb.dart');
+    final url = config.resolveImport(protoFileUri, protoFileUri, '.pb.dart');
     importWriter.addExport(url.toString());
 
     if (importWriter.hasImports) {
       out.println(importWriter.emit());
     }
 
-    for (var s in serviceGenerators) {
+    for (final s in serviceGenerators) {
       s.generate(out);
     }
 
@@ -496,30 +496,30 @@ class FileGenerator extends ProtobufContainer {
   String generateGrpcFile(
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     if (!_linked) throw StateError('not linked');
-    var out = makeWriter();
+    final out = makeWriter();
     _writeHeading(out);
 
-    var importWriter = ImportWriter();
+    final importWriter = ImportWriter();
 
     importWriter.addImport(_asyncImportUrl, prefix: asyncImportPrefix);
     importWriter.addImport(_coreImportUrl, prefix: coreImportPrefix);
     importWriter.addImport(_grpcImportUrl, prefix: grpcImportPrefix);
 
     // Import .pb.dart files needed for requests and responses.
-    var imports = <FileGenerator>{};
-    for (var generator in grpcGenerators) {
+    final imports = <FileGenerator>{};
+    for (final generator in grpcGenerators) {
       generator.addImportsTo(imports);
     }
-    for (var target in imports) {
+    for (final target in imports) {
       _addImport(importWriter, config, target, '.pb.dart');
     }
 
-    var url = config.resolveImport(protoFileUri, protoFileUri, '.pb.dart');
+    final url = config.resolveImport(protoFileUri, protoFileUri, '.pb.dart');
     importWriter.addExport(url.toString());
 
     out.println(importWriter.emit());
 
-    for (var generator in grpcGenerators) {
+    for (final generator in grpcGenerators) {
       generator.generate(out);
     }
 
@@ -528,13 +528,13 @@ class FileGenerator extends ProtobufContainer {
 
   void writeBinaryDescriptor(IndentingWriter out, String identifierName,
       String name, GeneratedMessage descriptor) {
-    var base64 = base64Encode(descriptor.writeToBuffer());
+    final base64 = base64Encode(descriptor.writeToBuffer());
     out.println('/// Descriptor for `$name`. Decode as a '
         '`${descriptor.info_.qualifiedMessageName}`.');
 
     const indent = '    ';
 
-    var base64Lines =
+    final base64Lines =
         _splitString(base64, 74).map((s) => "'$s'").join('\n$indent');
     out.println('final $_typedDataImportPrefix.Uint8List '
         '$identifierName = '
@@ -544,7 +544,7 @@ class FileGenerator extends ProtobufContainer {
   /// Return the given [str], split into separate segments, where no segment is
   /// longer than [segmentLength].
   static List<String> _splitString(String str, int segmentLength) {
-    var result = <String>[];
+    final result = <String>[];
     while (str.length >= segmentLength) {
       result.add(str.substring(0, segmentLength));
       str = str.substring(segmentLength);
@@ -557,35 +557,35 @@ class FileGenerator extends ProtobufContainer {
   String generateJsonFile(
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     if (!_linked) throw StateError('not linked');
-    var out = makeWriter();
+    final out = makeWriter();
     _writeHeading(out);
 
-    var importWriter = ImportWriter();
+    final importWriter = ImportWriter();
     importWriter.addImport(_convertImportUrl, prefix: _convertImportPrefix);
     importWriter.addImport(_coreImportUrl, prefix: coreImportPrefix);
     importWriter.addImport(_typedDataImportUrl, prefix: _typedDataImportPrefix);
 
     // Import the .pbjson.dart files we depend on.
-    var imports = _findJsonProtosToImport();
-    for (var target in imports) {
+    final imports = _findJsonProtosToImport();
+    for (final target in imports) {
       _addImport(importWriter, config, target, '.pbjson.dart');
     }
 
     out.println(importWriter.emit());
 
-    for (var e in enumGenerators) {
+    for (final e in enumGenerators) {
       e.generateConstants(out);
       writeBinaryDescriptor(
           out, e.binaryDescriptorName, e._descriptor.name, e._descriptor);
       out.println('');
     }
-    for (var m in messageGenerators) {
+    for (final m in messageGenerators) {
       m.generateConstants(out);
       writeBinaryDescriptor(
           out, m.binaryDescriptorName, m._descriptor.name, m._descriptor);
       out.println('');
     }
-    for (var s in serviceGenerators) {
+    for (final s in serviceGenerators) {
       s.generateConstants(out);
       writeBinaryDescriptor(
           out, s.binaryDescriptorName, s._descriptor.name, s._descriptor);
@@ -598,14 +598,14 @@ class FileGenerator extends ProtobufContainer {
   /// Returns the generator for each .pbjson.dart file the generated
   /// .pbjson.dart needs to import.
   Set<FileGenerator> _findJsonProtosToImport() {
-    var imports = Set<FileGenerator>.identity();
-    for (var m in messageGenerators) {
+    final imports = Set<FileGenerator>.identity();
+    for (final m in messageGenerators) {
       m.addConstantImportsTo(imports);
     }
-    for (var x in extensionGenerators) {
+    for (final x in extensionGenerators) {
       x.addConstantImportsTo(imports);
     }
-    for (var x in serviceGenerators) {
+    for (final x in serviceGenerators) {
       x.addConstantImportsTo(imports);
     }
     imports.remove(this); // Don't need to import self.
@@ -620,12 +620,12 @@ class FileGenerator extends ProtobufContainer {
     final ignores = ({..._fileIgnores, ...extraIgnores}).toList()..sort();
 
     // Group the ignores into lines not longer than 80 chars.
-    var ignorelines = <String>[];
+    final ignorelines = <String>[];
 
     if (ignores.isNotEmpty) {
       ignorelines.add('// ignore_for_file: ${ignores.first}');
 
-      for (var ignore in ignores.skip(1)) {
+      for (final ignore in ignores.skip(1)) {
         if (ignorelines.last.length + ignore.length + ', '.length > 80) {
           ignorelines.add('// ignore_for_file: $ignore');
         } else {
@@ -649,7 +649,7 @@ class FileGenerator extends ProtobufContainer {
   /// (Possibly the same .proto file.)
   void _addImport(ImportWriter importWriter, OutputConfiguration config,
       FileGenerator target, String ext) {
-    var url = config.resolveImport(target.protoFileUri, protoFileUri, ext);
+    final url = config.resolveImport(target.protoFileUri, protoFileUri, ext);
 
     // .pb.dart files should always be prefixed -- the protoFileUri check will
     // evaluate to true not just for the main .pb.dart file based off the proto
@@ -665,7 +665,7 @@ class FileGenerator extends ProtobufContainer {
   /// (Possibly the same .proto file.)
   void _addExport(ImportWriter importWriter, OutputConfiguration config,
       Uri target, String ext) {
-    var url = config.resolveImport(target, protoFileUri, ext);
+    final url = config.resolveImport(target, protoFileUri, ext);
     importWriter.addExport(url.toString());
   }
 }
@@ -691,8 +691,8 @@ class ConditionalConstDefinition {
 
   // Convert foo_bar_baz to _fooBarBaz.
   String _convertToCamelCase(String lowerUnderscoreCase) {
-    var parts = lowerUnderscoreCase.split('_');
-    var rest = parts.skip(1).map((item) {
+    final parts = lowerUnderscoreCase.split('_');
+    final rest = parts.skip(1).map((item) {
       return item.substring(0, 1).toUpperCase() + item.substring(1);
     }).join();
     return '_${parts.first}$rest';

--- a/protoc_plugin/lib/src/grpc_generator.dart
+++ b/protoc_plugin/lib/src/grpc_generator.dart
@@ -56,7 +56,7 @@ class GrpcServiceGenerator {
   /// in [_undefinedDeps].
   /// Precondition: messages have been registered and resolved.
   void resolve(GenerationContext ctx) {
-    for (var method in _descriptor.method) {
+    for (final method in _descriptor.method) {
       _methods.add(_GrpcMethod(this, ctx, method));
     }
   }
@@ -81,7 +81,7 @@ class GrpcServiceGenerator {
   /// For each .pb.dart file that the generated code needs to import,
   /// add its generator.
   void addImportsTo(Set<FileGenerator> imports) {
-    for (var mg in _deps.values) {
+    for (final mg in _deps.values) {
       imports.add(mg.fileGen);
     }
   }
@@ -90,9 +90,9 @@ class GrpcServiceGenerator {
   ///
   /// Throws an exception if it can't be resolved.
   String _getDartClassName(String fqname) {
-    var mg = _deps[fqname];
+    final mg = _deps[fqname];
     if (mg == null) {
-      var location = _undefinedDeps[fqname];
+      final location = _undefinedDeps[fqname];
       // TODO(nichite): Throw more actionable error.
       throw 'FAILURE: Unknown type reference ($fqname) for $location';
     }

--- a/protoc_plugin/lib/src/linker.dart
+++ b/protoc_plugin/lib/src/linker.dart
@@ -8,31 +8,31 @@ import 'options.dart';
 
 /// Resolves all cross-references in a set of proto files.
 void link(GenerationOptions? options, Iterable<FileGenerator> files) {
-  var ctx = GenerationContext(options);
+  final ctx = GenerationContext(options);
 
   // Register the targets of cross-references.
-  for (var f in files) {
+  for (final f in files) {
     ctx.registerProtoFile(f);
 
-    for (var m in f.messageGenerators) {
+    for (final m in f.messageGenerators) {
       m.register(ctx);
     }
-    for (var e in f.enumGenerators) {
+    for (final e in f.enumGenerators) {
       e.register(ctx);
     }
   }
 
-  for (var f in files) {
+  for (final f in files) {
     f.resolve(ctx);
   }
 
   // Resolve service generators last.
   // (They depend on all messages being resolved.)
-  for (var f in files) {
-    for (var s in f.serviceGenerators) {
+  for (final f in files) {
+    for (final s in f.serviceGenerators) {
       s.resolve(ctx);
     }
-    for (var s in f.grpcGenerators) {
+    for (final s in f.grpcGenerators) {
       s.resolve(ctx);
     }
   }

--- a/protoc_plugin/lib/src/message_generator.dart
+++ b/protoc_plugin/lib/src/message_generator.dart
@@ -12,7 +12,7 @@ class OneofEnumGenerator {
   static void generate(
       IndentingWriter out, String classname, List<ProtobufField> fields) {
     out.addBlock('enum $classname {', '}\n', () {
-      for (var field in fields) {
+      for (final field in fields) {
         final name = oneofEnumMemberName(field.memberNames!.fieldName);
         out.println('$name, ');
       }
@@ -98,12 +98,12 @@ class MessageGenerator extends ProtobufContainer {
             List.generate(countRealOneofs(descriptor), (int index) => []) {
     mixin = _getMixin(declaredMixins, defaultMixin);
     for (var i = 0; i < _descriptor.enumType.length; i++) {
-      var e = _descriptor.enumType[i];
+      final e = _descriptor.enumType[i];
       _enumGenerators.add(EnumGenerator.nested(e, this, _usedTopLevelNames, i));
     }
 
     for (var i = 0; i < _descriptor.nestedType.length; i++) {
-      var n = _descriptor.nestedType[i];
+      final n = _descriptor.nestedType[i];
       _messageGenerators.add(MessageGenerator.nested(
           n, this, declaredMixins, defaultMixin, _usedTopLevelNames, i));
     }
@@ -112,7 +112,7 @@ class MessageGenerator extends ProtobufContainer {
     // to check against / be added to top-level reserved names.
     final usedExtensionNames = {...forbiddenExtensionNames};
     for (var i = 0; i < _descriptor.extension.length; i++) {
-      var x = _descriptor.extension[i];
+      final x = _descriptor.extension[i];
       _extensionGenerators
           .add(ExtensionGenerator.nested(x, this, usedExtensionNames, i));
     }
@@ -159,7 +159,7 @@ class MessageGenerator extends ProtobufContainer {
   /// Returns a const expression that evaluates to the JSON for this message.
   /// [usage] represents the .pb.dart file where the expression will be used.
   String getJsonConstant(FileGenerator usage) {
-    var name = '$classname\$json';
+    final name = '$classname\$json';
     if (usage.protoFileUri == fileGen.protoFileUri) {
       return name;
     }
@@ -171,7 +171,7 @@ class MessageGenerator extends ProtobufContainer {
     if (mixin != null) {
       output.addAll(mixin!.findMixinsToApply());
     }
-    for (var m in _messageGenerators) {
+    for (final m in _messageGenerators) {
       m.addMixinsTo(output);
     }
   }
@@ -179,10 +179,10 @@ class MessageGenerator extends ProtobufContainer {
   // Registers message and enum types that can be used elsewhere.
   void register(GenerationContext ctx) {
     ctx.registerFieldType(this);
-    for (var m in _messageGenerators) {
+    for (final m in _messageGenerators) {
       m.register(ctx);
     }
-    for (var e in _enumGenerators) {
+    for (final e in _enumGenerators) {
       e.register(ctx);
     }
   }
@@ -192,13 +192,14 @@ class MessageGenerator extends ProtobufContainer {
     if (_resolved) throw StateError('message already resolved');
     _resolved = true;
 
-    var reserved = mixin?.findReservedNames() ?? const <String>[];
-    var members = messageMemberNames(_descriptor, classname, _usedTopLevelNames,
+    final reserved = mixin?.findReservedNames() ?? const <String>[];
+    final members = messageMemberNames(
+        _descriptor, classname, _usedTopLevelNames,
         reserved: reserved);
 
     _fieldList = <ProtobufField>[];
-    for (var names in members.fieldNames) {
-      var field = ProtobufField.message(names, this, ctx);
+    for (final names in members.fieldNames) {
+      final field = ProtobufField.message(names, this, ctx);
       if (field.descriptor.hasOneofIndex() &&
           !field.descriptor.proto3Optional) {
         _oneofFields[field.descriptor.oneofIndex].add(field);
@@ -207,23 +208,23 @@ class MessageGenerator extends ProtobufContainer {
     }
     _oneofNames = members.oneofNames;
 
-    for (var m in _messageGenerators) {
+    for (final m in _messageGenerators) {
       m.resolve(ctx);
     }
-    for (var x in _extensionGenerators) {
+    for (final x in _extensionGenerators) {
       x.resolve(ctx);
     }
   }
 
   bool get needsFixnumImport {
     checkResolved();
-    for (var field in _fieldList) {
+    for (final field in _fieldList) {
       if (field.needsFixnumImport) return true;
     }
-    for (var m in _messageGenerators) {
+    for (final m in _messageGenerators) {
       if (m.needsFixnumImport) return true;
     }
-    for (var x in _extensionGenerators) {
+    for (final x in _extensionGenerators) {
       if (x.needsFixnumImport) return true;
     }
     return false;
@@ -236,18 +237,18 @@ class MessageGenerator extends ProtobufContainer {
   void addImportsTo(
       Set<FileGenerator> imports, Set<FileGenerator> enumImports) {
     checkResolved();
-    for (var field in _fieldList) {
-      var typeGen = field.baseType.generator;
+    for (final field in _fieldList) {
+      final typeGen = field.baseType.generator;
       if (typeGen is EnumGenerator) {
         enumImports.add(typeGen.fileGen!);
       } else if (typeGen != null) {
         imports.add(typeGen.fileGen!);
       }
     }
-    for (var m in _messageGenerators) {
+    for (final m in _messageGenerators) {
       m.addImportsTo(imports, enumImports);
     }
-    for (var x in _extensionGenerators) {
+    for (final x in _extensionGenerators) {
       x.addImportsTo(imports, enumImports);
     }
   }
@@ -255,7 +256,7 @@ class MessageGenerator extends ProtobufContainer {
   // Returns the number of enums in this message and all nested messages.
   int get enumCount {
     var count = _enumGenerators.length;
-    for (var m in _messageGenerators) {
+    for (final m in _messageGenerators) {
       count += m.enumCount;
     }
     return count;
@@ -267,10 +268,10 @@ class MessageGenerator extends ProtobufContainer {
   /// add its generator.
   void addConstantImportsTo(Set<FileGenerator> imports) {
     checkResolved();
-    for (var m in _messageGenerators) {
+    for (final m in _messageGenerators) {
       m.addConstantImportsTo(imports);
     }
-    for (var x in _extensionGenerators) {
+    for (final x in _extensionGenerators) {
       x.addConstantImportsTo(imports);
     }
   }
@@ -278,21 +279,21 @@ class MessageGenerator extends ProtobufContainer {
   void generate(IndentingWriter out) {
     checkResolved();
 
-    for (var m in _messageGenerators) {
+    for (final m in _messageGenerators) {
       // Don't output the generated map entry type. Instead, the `PbMap` type
       // from the protobuf library is used to hold the keys and values.
       if (m._descriptor.options.hasMapEntry()) continue;
       m.generate(out);
     }
 
-    for (var oneof in _oneofNames) {
+    for (final oneof in _oneofNames) {
       OneofEnumGenerator.generate(
           out, oneof.oneofEnumName, _oneofFields[oneof.index]);
     }
 
     var mixinClause = '';
     if (mixin != null) {
-      var mixinNames =
+      final mixinNames =
           mixin!.findMixinsToApply().map((m) => '$mixinImportPrefix.${m.name}');
       mixinClause = ' with ${mixinNames.join(", ")}';
     }
@@ -304,9 +305,9 @@ class MessageGenerator extends ProtobufContainer {
     final conditionalPackageName = 'const $protobufImportPrefix.PackageName'
         '(${omitMessageNames.createTernary(package)})';
 
-    var packageClause =
+    final packageClause =
         package == '' ? '' : ', package: $conditionalPackageName';
-    var proto3JsonClause = (mixin?.hasProto3JsonHelpers ?? false)
+    final proto3JsonClause = (mixin?.hasProto3JsonHelpers ?? false)
         ? ', toProto3Json: $mixinImportPrefix.${mixin!.name}.toProto3JsonHelper, '
             'fromProto3Json: $mixinImportPrefix.${mixin!.name}.fromProto3JsonHelper'
         : '';
@@ -329,11 +330,11 @@ class MessageGenerator extends ProtobufContainer {
           ' => create()..mergeFromJson(i, r);');
 
       out.println();
-      for (var oneof in _oneofNames) {
+      for (final oneof in _oneofNames) {
         out.addBlock(
             'static const $coreImportPrefix.Map<$coreImportPrefix.int, ${oneof.oneofEnumName}> ${oneof.byTagMapName} = {',
             '};', () {
-          for (var field in _oneofFields[oneof.index]) {
+          for (final field in _oneofFields[oneof.index]) {
             final oneofMemberName =
                 oneofEnumMemberName(field.memberNames!.fieldName);
             out.println(
@@ -355,12 +356,12 @@ class MessageGenerator extends ProtobufContainer {
               '$proto3JsonClause)',
           ';', () {
         for (var oneof = 0; oneof < _oneofFields.length; oneof++) {
-          var tags =
+          final tags =
               _oneofFields[oneof].map((ProtobufField f) => f.number).toList();
           out.println('..oo($oneof, $tags)');
         }
 
-        for (var field in _fieldList) {
+        for (final field in _fieldList) {
           field.generateBuilderInfoCall(out, package);
         }
 
@@ -372,7 +373,7 @@ class MessageGenerator extends ProtobufContainer {
         }
       });
 
-      for (var x in _extensionGenerators) {
+      for (final x in _extensionGenerators) {
         x.generate(out);
       }
 
@@ -444,7 +445,7 @@ class MessageGenerator extends ProtobufContainer {
       return true;
     }
 
-    for (var field in type._fieldList) {
+    for (final field in type._fieldList) {
       if (field.isRequired) {
         return true;
       }
@@ -459,13 +460,13 @@ class MessageGenerator extends ProtobufContainer {
   }
 
   void generateFieldsAccessorsMutators(IndentingWriter out) {
-    for (var oneof in _oneofNames) {
+    for (final oneof in _oneofNames) {
       generateOneofAccessors(out, oneof);
     }
 
-    for (var field in _fieldList) {
+    for (final field in _fieldList) {
       out.println();
-      var memberFieldPath = List<int>.from(fieldPath)
+      final memberFieldPath = List<int>.from(fieldPath)
         ..addAll([_messageFieldTag, field.sourcePosition!]);
       generateFieldAccessorsMutators(field, out, memberFieldPath);
     }
@@ -481,9 +482,9 @@ class MessageGenerator extends ProtobufContainer {
 
   void generateFieldAccessorsMutators(
       ProtobufField field, IndentingWriter out, List<int> memberFieldPath) {
-    var fieldTypeString = field.getDartType();
-    var defaultExpr = field.getDefaultExpr();
-    var names = field.memberNames;
+    final fieldTypeString = field.getDartType();
+    final defaultExpr = field.getDefaultExpr();
+    final names = field.memberNames;
 
     _emitDeprecatedIf(field.isDeprecated, out);
     _emitOverrideIf(field.overridesGetter, out);
@@ -512,7 +513,7 @@ class MessageGenerator extends ProtobufContainer {
             '${names.clearMethodName}() because it is repeated.';
       }
     } else {
-      var fastSetter = field.baseType.setter;
+      final fastSetter = field.baseType.setter;
       _emitDeprecatedIf(field.isDeprecated, out);
       _emitOverrideIf(field.overridesSetter, out);
       _emitIndexAnnotation(field.number, out);
@@ -633,11 +634,11 @@ class MessageGenerator extends ProtobufContainer {
   }
 
   void generateEnums(IndentingWriter out) {
-    for (var e in _enumGenerators) {
+    for (final e in _enumGenerators) {
       e.generate(out);
     }
 
-    for (var m in _messageGenerators) {
+    for (final m in _messageGenerators) {
       m.generateEnums(out);
     }
   }
@@ -651,17 +652,17 @@ class MessageGenerator extends ProtobufContainer {
     assert(_descriptor.info_.fieldInfo[nestedTypeTag]!.name == 'nestedType');
     assert(_descriptor.info_.fieldInfo[enumTypeTag]!.name == 'enumType');
 
-    var name = getJsonConstant(fileGen);
-    var json = _descriptor.writeToJsonMap();
-    var nestedTypeNames =
+    final name = getJsonConstant(fileGen);
+    final json = _descriptor.writeToJsonMap();
+    final nestedTypeNames =
         _messageGenerators.map((m) => m.getJsonConstant(fileGen)).toList();
-    var nestedEnumNames =
+    final nestedEnumNames =
         _enumGenerators.map((e) => e.getJsonConstant(fileGen)).toList();
 
     out.println('@$coreImportPrefix.Deprecated'
         '(\'Use ${toplevelParent!.binaryDescriptorName} instead\')');
     out.addBlock('const $name = {', '};', () {
-      for (var key in json.keys) {
+      for (final key in json.keys) {
         out.print("'$key': ");
         if (key == '$nestedTypeTag') {
           // refer to message constants by name instead of repeating each value
@@ -678,11 +679,11 @@ class MessageGenerator extends ProtobufContainer {
     });
     out.println();
 
-    for (var m in _messageGenerators) {
+    for (final m in _messageGenerators) {
       m.generateConstants(out);
     }
 
-    for (var e in _enumGenerators) {
+    for (final e in _enumGenerators) {
       e.generateConstants(out);
     }
   }
@@ -693,7 +694,7 @@ class MessageGenerator extends ProtobufContainer {
   /// then internal mixins declared by [findMixin].
   PbMixin? _getMixin(
       Map<String, PbMixin> declaredMixins, PbMixin? defaultMixin) {
-    var wellKnownMixin = wellKnownMixinForFullName(fullName);
+    final wellKnownMixin = wellKnownMixinForFullName(fullName);
     if (wellKnownMixin != null) return wellKnownMixin;
     if (!_descriptor.hasOptions() ||
         !_descriptor.options.hasExtension(Dart_options.mixin)) {
@@ -702,7 +703,7 @@ class MessageGenerator extends ProtobufContainer {
 
     final name = _descriptor.options.getExtension(Dart_options.mixin) as String;
     if (name.isEmpty) return null; // don't use any mixins (override default)
-    var mixin = declaredMixins[name] ?? findMixin(name);
+    final mixin = declaredMixins[name] ?? findMixin(name);
     if (mixin == null) {
       throw '${_descriptor.name} in ${parent!.fileGen!.descriptor.name}: mixin "$name" not found';
     }

--- a/protoc_plugin/lib/src/options.dart
+++ b/protoc_plugin/lib/src/options.dart
@@ -13,9 +13,9 @@ typedef OnError = void Function(String details);
 /// the option to it. Returns `true` if no errors were reported.
 bool genericOptionsParser(CodeGeneratorRequest request,
     CodeGeneratorResponse response, Map<String, SingleOptionParser> parsers) {
-  var parameter = request.parameter;
-  var options = parameter.trim().split(',');
-  var errors = [];
+  final parameter = request.parameter;
+  final options = parameter.trim().split(',');
+  final errors = [];
 
   for (var option in options) {
     option = option.trim();
@@ -24,19 +24,19 @@ bool genericOptionsParser(CodeGeneratorRequest request,
       errors.add('Error found trying to parse the option: $option.\n$details');
     }
 
-    var nameValue = option.split('=');
+    final nameValue = option.split('=');
     if (nameValue.length != 1 && nameValue.length != 2) {
       reportError('Options should be a single token, or a name=value pair');
       continue;
     }
-    var name = nameValue[0].trim();
-    var parser = parsers[name];
+    final name = nameValue[0].trim();
+    final parser = parsers[name];
     if (parser == null) {
       reportError('Unknown option ($name).');
       continue;
     }
 
-    var value = nameValue.length > 1 ? nameValue[1].trim() : null;
+    final value = nameValue.length > 1 ? nameValue[1].trim() : null;
     parser.parse(name, value, reportError);
   }
 

--- a/protoc_plugin/lib/src/output_config.dart
+++ b/protoc_plugin/lib/src/output_config.dart
@@ -33,15 +33,15 @@ class DefaultOutputConfiguration extends OutputConfiguration {
 
   @override
   Uri outputPathFor(Uri inputPath, String extension) {
-    var base = path.withoutExtension(path.url.fromUri(inputPath));
+    final base = path.withoutExtension(path.url.fromUri(inputPath));
     return path.url.toUri('$base$extension');
   }
 
   @override
   Uri resolveImport(Uri target, Uri source, String extension) {
-    var targetPath = path.url.fromUri(target);
-    var sourceDir = path.url.dirname(path.url.fromUri(source));
-    var base =
+    final targetPath = path.url.fromUri(target);
+    final sourceDir = path.url.dirname(path.url.fromUri(source));
+    final base =
         path.withoutExtension(path.url.relative(targetPath, from: sourceDir));
     return path.url.toUri('$base$extension');
   }

--- a/protoc_plugin/lib/src/protobuf_field.dart
+++ b/protoc_plugin/lib/src/protobuf_field.dart
@@ -144,8 +144,8 @@ class ProtobufField {
   String getDartType() {
     if (isMapField) {
       final d = baseType.generator as MessageGenerator;
-      var keyType = d._fieldList[0].baseType.getDartType(parent.fileGen!);
-      var valueType = d._fieldList[1].baseType.getDartType(parent.fileGen!);
+      final keyType = d._fieldList[0].baseType.getDartType(parent.fileGen!);
+      final valueType = d._fieldList[1].baseType.getDartType(parent.fileGen!);
       return '$coreImportPrefix.Map<$keyType, $valueType>';
     }
     if (isRepeated) return baseType.getRepeatedDartType(parent.fileGen!);
@@ -189,19 +189,19 @@ class ProtobufField {
         omitFieldNames.constFieldName, omitFieldNames.constDefinition);
     final quotedName = omitFieldNames.createTernary(descriptor.jsonName);
 
-    var type = baseType.getDartType(parent.fileGen!);
+    final type = baseType.getDartType(parent.fileGen!);
 
     String invocation;
 
-    var args = <String>[];
-    var named = <String, String?>{'protoName': quotedProtoName};
+    final args = <String>[];
+    final named = <String, String?>{'protoName': quotedProtoName};
     args.add('$number');
     args.add(quotedName);
 
     if (isMapField) {
       final generator = baseType.generator as MessageGenerator;
-      var key = generator._fieldList[0];
-      var value = generator._fieldList[1];
+      final key = generator._fieldList[0];
+      final value = generator._fieldList[1];
 
       // Key type is an integer type or string. No need to specify the default
       // value as the library knows the defaults for integer and string fields.
@@ -250,7 +250,7 @@ class ProtobufField {
       }
     } else {
       // Singular field.
-      var makeDefault = generateDefaultFunction();
+      final makeDefault = generateDefaultFunction();
 
       if (baseType.isEnum) {
         args.add(typeConstant);
@@ -303,7 +303,7 @@ class ProtobufField {
       }
     }
 
-    var result = '..$invocation(${_formatArguments(args, named)})';
+    final result = '..$invocation(${_formatArguments(args, named)})';
     out.println(result);
   }
 
@@ -378,7 +378,7 @@ class ProtobufField {
         if (!descriptor.hasDefaultValue() || descriptor.defaultValue.isEmpty) {
           return null;
         }
-        var byteList = descriptor.defaultValue.codeUnits
+        final byteList = descriptor.defaultValue.codeUnits
             .map((b) => '0x${b.toRadixString(16)}')
             .join(',');
         return '() => <$coreImportPrefix.int>[$byteList]';
@@ -386,7 +386,7 @@ class ProtobufField {
       case FieldDescriptorProto_Type.TYPE_MESSAGE:
         return '${baseType.getDartType(parent.fileGen!)}.getDefault';
       case FieldDescriptorProto_Type.TYPE_ENUM:
-        var className = baseType.getDartType(parent.fileGen!);
+        final className = baseType.getDartType(parent.fileGen!);
         final gen = baseType.generator as EnumGenerator;
         if (descriptor.hasDefaultValue() &&
             descriptor.defaultValue.isNotEmpty) {

--- a/protoc_plugin/lib/src/service_generator.dart
+++ b/protoc_plugin/lib/src/service_generator.dart
@@ -49,7 +49,7 @@ class ServiceGenerator {
   /// If a type name can't be resolved, puts it in [_undefinedDeps].
   /// Precondition: messages have been registered and resolved.
   void resolve(GenerationContext ctx) {
-    for (var m in _methodDescriptors) {
+    for (final m in _methodDescriptors) {
       _addDependency(ctx, m.inputType, 'input type of ${m.name}');
       _addDependency(ctx, m.outputType, 'output type of ${m.name}');
     }
@@ -83,7 +83,7 @@ class ServiceGenerator {
     mg.checkResolved();
     if (depth == 0) _deps[mg.dottedName] = mg;
     _transitiveDeps[mg.dottedName] = mg;
-    for (var field in mg._fieldList) {
+    for (final field in mg._fieldList) {
       if (field.baseType.isGroup || field.baseType.isMessage) {
         _addDepsRecursively(
             field.baseType.generator as MessageGenerator, depth + 1);
@@ -96,7 +96,7 @@ class ServiceGenerator {
   /// For each .pb.dart file that the generated code needs to import,
   /// add its generator.
   void addImportsTo(Set<FileGenerator> imports) {
-    for (var mg in _deps.values) {
+    for (final mg in _deps.values) {
       imports.add(mg.fileGen);
     }
   }
@@ -106,7 +106,7 @@ class ServiceGenerator {
   /// For each .pbjson.dart file that the generated code needs to import,
   /// add its generator.
   void addConstantImportsTo(Set<FileGenerator> imports) {
-    for (var mg in _transitiveDeps.values) {
+    for (final mg in _transitiveDeps.values) {
       imports.add(mg.fileGen);
     }
   }
@@ -118,9 +118,9 @@ class ServiceGenerator {
   /// should be prefixed unless the target file is the main file (the client
   /// generator calls this method). Otherwise, prefix everything.
   String _getDartClassName(String fqname, {bool forMainFile = false}) {
-    var mg = _deps[fqname];
+    final mg = _deps[fqname];
     if (mg == null) {
-      var location = _undefinedDeps[fqname];
+      final location = _undefinedDeps[fqname];
       throw 'FAILURE: Unknown type reference ($fqname) for $location';
     }
     if (forMainFile && fileGen.protoFileUri == mg.fileGen.protoFileUri) {
@@ -137,16 +137,16 @@ class ServiceGenerator {
   String get _parentClass => _generatedService;
 
   void _generateStub(IndentingWriter out, MethodDescriptorProto m) {
-    var methodName = _methodName(m.name);
-    var inputClass = _getDartClassName(m.inputType);
-    var outputClass = _getDartClassName(m.outputType);
+    final methodName = _methodName(m.name);
+    final inputClass = _getDartClassName(m.inputType);
+    final outputClass = _getDartClassName(m.outputType);
 
     out.println('$_future<$outputClass> $methodName('
         '$_serverContext ctx, $inputClass request);');
   }
 
   void _generateStubs(IndentingWriter out) {
-    for (var m in _methodDescriptors) {
+    for (final m in _methodDescriptors) {
       _generateStub(out, m);
     }
     out.println();
@@ -157,8 +157,8 @@ class ServiceGenerator {
         '$_generatedMessage createRequest($coreImportPrefix.String methodName) {',
         '}', () {
       out.addBlock('switch (methodName) {', '}', () {
-        for (var m in _methodDescriptors) {
-          var inputClass = _getDartClassName(m.inputType);
+        for (final m in _methodDescriptors) {
+          final inputClass = _getDartClassName(m.inputType);
           out.println("case '${m.name}': return $inputClass();");
         }
         out.println('default: '
@@ -174,9 +174,9 @@ class ServiceGenerator {
             '$coreImportPrefix.String methodName, $_generatedMessage request) {',
         '}', () {
       out.addBlock('switch (methodName) {', '}', () {
-        for (var m in _methodDescriptors) {
-          var methodName = _methodName(m.name);
-          var inputClass = _getDartClassName(m.inputType);
+        for (final m in _methodDescriptors) {
+          final methodName = _methodName(m.name);
+          final inputClass = _getDartClassName(m.inputType);
           out.println("case '${m.name}': return this.$methodName"
               '(ctx, request as $inputClass);');
         }
@@ -222,8 +222,8 @@ class ServiceGenerator {
     out.println(';');
     out.println();
 
-    var typeConstants = <String, String>{};
-    for (var key in _transitiveDeps.keys) {
+    final typeConstants = <String, String>{};
+    for (final key in _transitiveDeps.keys) {
       typeConstants[key] = _transitiveDeps[key]!.getJsonConstant(fileGen);
     }
 
@@ -234,16 +234,16 @@ class ServiceGenerator {
             ' $coreImportPrefix.Map<$coreImportPrefix.String,'
             ' $coreImportPrefix.dynamic>> $messageJsonConstant = {',
         '};', () {
-      for (var key in typeConstants.keys) {
-        var typeConst = typeConstants[key];
+      for (final key in typeConstants.keys) {
+        final typeConst = typeConstants[key];
         out.println("'$key': $typeConst,");
       }
     });
     out.println();
 
     if (_undefinedDeps.isNotEmpty) {
-      for (var name in _undefinedDeps.keys) {
-        var location = _undefinedDeps[name];
+      for (final name in _undefinedDeps.keys) {
+        final location = _undefinedDeps[name];
         out.println("// can't resolve ($name) used by $location");
       }
       out.println();

--- a/protoc_plugin/test/any_test.dart
+++ b/protoc_plugin/test/any_test.dart
@@ -12,16 +12,16 @@ import '../out/protos/using_any.pb.dart';
 
 void main() {
   test('pack -> unpack', () {
-    var any = Any.pack(SearchRequest()..query = 'hest');
+    final any = Any.pack(SearchRequest()..query = 'hest');
     expect(any.typeUrl, 'type.googleapis.com/service.SearchRequest');
-    var any1 = Any.pack(SearchRequest()..query = 'hest1',
+    final any1 = Any.pack(SearchRequest()..query = 'hest1',
         typeUrlPrefix: 'example.com');
     expect(any1.typeUrl, 'example.com/service.SearchRequest');
     expect(any1.canUnpackInto(SearchRequest.getDefault()), true);
     expect(any1.canUnpackInto(SearchResponse.getDefault()), false);
-    var searchRequest = any.unpackInto(SearchRequest());
+    final searchRequest = any.unpackInto(SearchRequest());
     expect(searchRequest.query, 'hest');
-    var searchRequest1 = any1.unpackInto(SearchRequest());
+    final searchRequest1 = any1.unpackInto(SearchRequest());
     expect(searchRequest1.query, 'hest1');
     expect(() {
       any.unpackInto(SearchResponse());
@@ -29,7 +29,7 @@ void main() {
   });
 
   test('any inside any', () {
-    var any = Any.pack(Any.pack(SearchRequest()..query = 'hest'));
+    final any = Any.pack(Any.pack(SearchRequest()..query = 'hest'));
     expect(any.typeUrl, 'type.googleapis.com/google.protobuf.Any');
     expect(any.canUnpackInto(Any.getDefault()), true);
     expect(any.canUnpackInto(SearchRequest.getDefault()), false);
@@ -39,31 +39,31 @@ void main() {
   });
 
   test('toplevel', () {
-    var any = Any.pack(toplevel.T()
+    final any = Any.pack(toplevel.T()
       ..a = 127
       ..b = 'hest');
     expect(any.typeUrl, 'type.googleapis.com/toplevel.T');
-    var t2 = any.unpackInto(toplevel.T());
+    final t2 = any.unpackInto(toplevel.T());
     expect(t2.a, 127);
     expect(t2.b, 'hest');
   });
 
   test('nested message', () {
-    var any = Any.pack(Container_Nested()..int32Value = 127);
+    final any = Any.pack(Container_Nested()..int32Value = 127);
     expect(
         any.typeUrl, 'type.googleapis.com/protobuf_unittest.Container.Nested');
-    var t2 = any.unpackInto(Container_Nested());
+    final t2 = any.unpackInto(Container_Nested());
     expect(t2.int32Value, 127);
   });
 
   test('using any', () {
-    var any = Any.pack(SearchRequest()..query = 'hest');
-    var any1 = Any.pack(SearchRequest()..query = 'hest1');
-    var any2 = Any.pack(SearchRequest()..query = 'hest2');
-    var testAny = TestAny()
+    final any = Any.pack(SearchRequest()..query = 'hest');
+    final any1 = Any.pack(SearchRequest()..query = 'hest1');
+    final any2 = Any.pack(SearchRequest()..query = 'hest2');
+    final testAny = TestAny()
       ..anyValue = any
       ..repeatedAnyValue.addAll(<Any>[any1, any2]);
-    var testAnyFromBuffer = TestAny.fromBuffer(testAny.writeToBuffer());
+    final testAnyFromBuffer = TestAny.fromBuffer(testAny.writeToBuffer());
     expect(
         testAnyFromBuffer.anyValue.unpackInto(SearchRequest()).query, 'hest');
     expect(

--- a/protoc_plugin/test/bazel_test.dart
+++ b/protoc_plugin/test/bazel_test.dart
@@ -124,25 +124,25 @@ void main() {
 
     group('outputPathForUri', () {
       test('should handle files at package root', () {
-        var p =
+        final p =
             config.outputPathFor(Uri.parse('foo/bar/quux.proto'), '.pb.dart');
         expect(p.path, 'baz/flob/quux.pb.dart');
       });
 
       test('should handle files below package root', () {
-        var p = config.outputPathFor(
+        final p = config.outputPathFor(
             Uri.parse('foo/bar/a/b/quux.proto'), '.pb.dart');
         expect(p.path, 'baz/flob/a/b/quux.pb.dart');
       });
 
       test('should handle files in a nested package root', () {
-        var p = config.outputPathFor(
+        final p = config.outputPathFor(
             Uri.parse('foo/bar/baz/quux.proto'), '.pb.dart');
         expect(p.path, 'baz/flob/foo/quux.pb.dart');
       });
 
       test('should handle files below a nested package root', () {
-        var p = config.outputPathFor(
+        final p = config.outputPathFor(
             Uri.parse('foo/bar/baz/a/b/quux.proto'), '.pb.dart');
         expect(p.path, 'baz/flob/foo/a/b/quux.pb.dart');
       });
@@ -157,45 +157,45 @@ void main() {
 
     group('resolveImport', () {
       test('should emit relative import if in same package', () {
-        var target = Uri.parse('foo/bar/quux.proto');
-        var source = Uri.parse('foo/bar/baz.proto');
-        var uri = config.resolveImport(target, source, '.pb.dart');
+        final target = Uri.parse('foo/bar/quux.proto');
+        final source = Uri.parse('foo/bar/baz.proto');
+        final uri = config.resolveImport(target, source, '.pb.dart');
         expect(uri.path, 'quux.pb.dart');
       });
 
       test('should emit relative import if in subdir of same package', () {
-        var target = Uri.parse('foo/bar/a/b/quux.proto');
-        var source = Uri.parse('foo/bar/baz.proto');
-        var uri = config.resolveImport(target, source, '.pb.dart');
+        final target = Uri.parse('foo/bar/a/b/quux.proto');
+        final source = Uri.parse('foo/bar/baz.proto');
+        final uri = config.resolveImport(target, source, '.pb.dart');
         expect(uri.path, 'a/b/quux.pb.dart');
       });
 
       test('should emit relative import if in parent dir in same package', () {
-        var target = Uri.parse('foo/bar/quux.proto');
-        var source = Uri.parse('foo/bar/a/b/baz.proto');
-        var uri = config.resolveImport(target, source, '.pb.dart');
+        final target = Uri.parse('foo/bar/quux.proto');
+        final source = Uri.parse('foo/bar/a/b/baz.proto');
+        final uri = config.resolveImport(target, source, '.pb.dart');
         expect(uri.path, '../../quux.pb.dart');
       });
 
       test('should emit package: import if in different package', () {
-        var target = Uri.parse('wibble/wobble/quux.proto');
-        var source = Uri.parse('foo/bar/baz.proto');
-        var uri = config.resolveImport(target, source, '.pb.dart');
+        final target = Uri.parse('wibble/wobble/quux.proto');
+        final source = Uri.parse('foo/bar/baz.proto');
+        final uri = config.resolveImport(target, source, '.pb.dart');
         expect(uri.scheme, 'package');
         expect(uri.path, 'wibble.wobble/quux.pb.dart');
       });
 
       test('should emit package: import if in subdir of different package', () {
-        var target = Uri.parse('wibble/wobble/foo/bar/quux.proto');
-        var source = Uri.parse('foo/bar/baz.proto');
-        var uri = config.resolveImport(target, source, '.pb.dart');
+        final target = Uri.parse('wibble/wobble/foo/bar/quux.proto');
+        final source = Uri.parse('foo/bar/baz.proto');
+        final uri = config.resolveImport(target, source, '.pb.dart');
         expect(uri.scheme, 'package');
         expect(uri.path, 'wibble.wobble/foo/bar/quux.pb.dart');
       });
 
       test('should throw if target is in unknown package', () {
-        var target = Uri.parse('flob/flub/quux.proto');
-        var source = Uri.parse('foo/bar/baz.proto');
+        final target = Uri.parse('flob/flub/quux.proto');
+        final source = Uri.parse('foo/bar/baz.proto');
         expect(() => config.resolveImport(target, source, '.pb.dart'),
             throwsA(startsWith('ERROR: cannot generate import for')));
       });

--- a/protoc_plugin/test/client_generator_test.dart
+++ b/protoc_plugin/test/client_generator_test.dart
@@ -13,21 +13,21 @@ import 'service_util.dart';
 
 void main() {
   test('testClientGenerator', () {
-    var options = GenerationOptions();
-    var fd = buildFileDescriptor(
+    final options = GenerationOptions();
+    final fd = buildFileDescriptor(
         'testpkg', 'testpkg.proto', ['SomeRequest', 'SomeReply']);
     fd.service.add(buildServiceDescriptor());
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
 
-    var fd2 = buildFileDescriptor(
+    final fd2 = buildFileDescriptor(
         'foo.bar', 'foobar.proto', ['EmptyMessage', 'AnotherReply']);
-    var fg2 = FileGenerator(fd2, options);
+    final fg2 = FileGenerator(fd2, options);
 
     link(GenerationOptions(), [fg, fg2]);
 
-    var cag = fg.clientApiGenerators[0];
+    final cag = fg.clientApiGenerators[0];
 
-    var writer = IndentingWriter();
+    final writer = IndentingWriter();
     cag.generate(writer);
     expectMatchesGoldenFile(writer.toString(), 'test/goldens/client');
   });

--- a/protoc_plugin/test/coded_buffer_test.dart
+++ b/protoc_plugin/test/coded_buffer_test.dart
@@ -8,20 +8,20 @@ import '../out/protos/entity.pb.dart';
 
 void main() {
   test('Does not reuse input buffer for bytes fields', () {
-    var message = BytesEntity()..value = [1, 2, 3];
-    var bytes = message.writeToBuffer();
-    var deserialized1 = BytesEntity()..mergeFromBuffer(bytes);
-    var deserialized2 = BytesEntity()..mergeFromBuffer(bytes);
+    final message = BytesEntity()..value = [1, 2, 3];
+    final bytes = message.writeToBuffer();
+    final deserialized1 = BytesEntity()..mergeFromBuffer(bytes);
+    final deserialized2 = BytesEntity()..mergeFromBuffer(bytes);
     deserialized1.value[0] = 100;
     expect(deserialized1.value[0], 100);
     expect(deserialized2.value[0], 1);
   });
 
   test('Does not reuse input buffer for repeated bytes fields', () {
-    var message = BytesEntity()..values.add([1, 2, 3]);
-    var bytes = message.writeToBuffer();
-    var deserialized1 = BytesEntity()..mergeFromBuffer(bytes);
-    var deserialized2 = BytesEntity()..mergeFromBuffer(bytes);
+    final message = BytesEntity()..values.add([1, 2, 3]);
+    final bytes = message.writeToBuffer();
+    final deserialized1 = BytesEntity()..mergeFromBuffer(bytes);
+    final deserialized2 = BytesEntity()..mergeFromBuffer(bytes);
     deserialized1.values.first[0] = 100;
     expect(deserialized1.values.first[0], 100);
     expect(deserialized2.values.first[0], 1);

--- a/protoc_plugin/test/const_generator_test.dart
+++ b/protoc_plugin/test/const_generator_test.dart
@@ -7,7 +7,7 @@ import 'package:protoc_plugin/indenting_writer.dart';
 import 'package:test/test.dart';
 
 String toConst(Object? val) {
-  var out = IndentingWriter();
+  final out = IndentingWriter();
   writeJsonConst(out, val);
   return out.toString();
 }

--- a/protoc_plugin/test/enum_generator_test.dart
+++ b/protoc_plugin/test/enum_generator_test.dart
@@ -12,7 +12,7 @@ import 'golden_file.dart';
 
 void main() {
   test('testEnumGenerator', () {
-    var ed = EnumDescriptorProto()
+    final ed = EnumDescriptorProto()
       ..name = 'PhoneType'
       ..value.addAll([
         EnumValueDescriptorProto()
@@ -28,9 +28,9 @@ void main() {
           ..name = 'BUSINESS'
           ..number = 2
       ]);
-    var writer = IndentingWriter(filename: 'sample.proto');
-    var fg = FileGenerator(FileDescriptorProto(), GenerationOptions());
-    var eg = EnumGenerator.topLevel(ed, fg, <String>{}, 0);
+    final writer = IndentingWriter(filename: 'sample.proto');
+    final fg = FileGenerator(FileDescriptorProto(), GenerationOptions());
+    final eg = EnumGenerator.topLevel(ed, fg, <String>{}, 0);
     eg.generate(writer);
     expectMatchesGoldenFile(writer.toString(), 'test/goldens/enum');
     expectMatchesGoldenFile(

--- a/protoc_plugin/test/extension_test.dart
+++ b/protoc_plugin/test/extension_test.dart
@@ -34,13 +34,13 @@ final withExtensions = TestAllExtensions()
 
 void main() {
   test('can set all extension types', () {
-    var message = TestAllExtensions();
+    final message = TestAllExtensions();
     setAllExtensions(message);
     assertAllExtensionsSet(message);
   });
 
   test('can modify all repeated extension types', () {
-    var message = TestAllExtensions();
+    final message = TestAllExtensions();
     setAllExtensions(message);
     modifyRepeatedExtensions(message);
     assertRepeatedExtensionsModified(message);
@@ -59,23 +59,23 @@ void main() {
 
   test('can clear an optional extension', () {
     // clearExtension() is not actually used in test_util, so try it manually.
-    var message = TestAllExtensions();
+    final message = TestAllExtensions();
     message.setExtension(Unittest.optionalInt32Extension, 1);
     message.clearExtension(Unittest.optionalInt32Extension);
     expect(message.hasExtension(Unittest.optionalInt32Extension), isFalse);
   });
 
   test('can clear a repeated extension', () {
-    var message = TestAllExtensions();
+    final message = TestAllExtensions();
     message.addExtension(Unittest.repeatedInt32Extension, 1);
     message.clearExtension(Unittest.repeatedInt32Extension);
     expect(message.getExtension(Unittest.repeatedInt32Extension).length, 0);
   });
 
   test('can clone an extension field', () {
-    var original = TestAllExtensions();
+    final original = TestAllExtensions();
     original.setExtension(Unittest.optionalInt32Extension, 1);
-    var clone = original.deepCopy();
+    final clone = original.deepCopy();
     expect(clone.hasExtension(Unittest.optionalInt32Extension), isTrue);
     expect(clone.getExtension(Unittest.optionalInt32Extension), 1);
   });
@@ -85,15 +85,15 @@ void main() {
   });
 
   test('can merge extension', () {
-    var nestedMessage = TestAllTypes_NestedMessage()..i = 42;
-    var mergeSource = TestAllExtensions()
+    final nestedMessage = TestAllTypes_NestedMessage()..i = 42;
+    final mergeSource = TestAllExtensions()
       ..setExtension(Unittest.optionalNestedMessageExtension, nestedMessage);
 
-    var nestedMessage2 = TestAllTypes_NestedMessage()..bb = 43;
-    var mergeDest = TestAllExtensions()
+    final nestedMessage2 = TestAllTypes_NestedMessage()..bb = 43;
+    final mergeDest = TestAllExtensions()
       ..setExtension(Unittest.optionalNestedMessageExtension, nestedMessage2);
 
-    var result = TestAllExtensions()
+    final result = TestAllExtensions()
       ..mergeFromMessage(mergeSource)
       ..mergeFromMessage(mergeDest);
 
@@ -102,7 +102,7 @@ void main() {
   });
 
   test("throws if field number isn't allowed for extension", () {
-    var message = TestAllTypes(); // does not allow extensions
+    final message = TestAllTypes(); // does not allow extensions
     expect(() {
       message.setExtension(Unittest.optionalInt32Extension, 0);
     },
@@ -117,7 +117,7 @@ void main() {
   });
 
   test('throws if an int32 extension is set to a bad value', () {
-    var message = TestAllExtensions();
+    final message = TestAllExtensions();
     expect(() {
       message.setExtension(Unittest.optionalInt32Extension, 'hello');
     },
@@ -127,7 +127,7 @@ void main() {
   });
 
   test('throws if an int64 extension is set to a bad value', () {
-    var message = TestAllExtensions();
+    final message = TestAllExtensions();
     expect(() {
       message.setExtension(Unittest.optionalInt64Extension, 123);
     },
@@ -137,7 +137,7 @@ void main() {
   });
 
   test('throws if a message extension is set to a bad value', () {
-    var message = TestAllExtensions();
+    final message = TestAllExtensions();
 
     // For a non-repeated message, we only check for a GeneratedMessage.
     expect(() {
@@ -155,7 +155,7 @@ void main() {
   });
 
   test('throws if an enum extension is set to a bad value', () {
-    var message = TestAllExtensions();
+    final message = TestAllExtensions();
 
     // For a non-repeated enum, we only check for a ProtobufEnum.
     expect(() {
@@ -186,7 +186,7 @@ void main() {
   });
 
   test('can extend message with enum', () {
-    var msg = Extendable();
+    final msg = Extendable();
     msg.setExtension(Enum_extension.animal, Animal.CAT);
   });
 
@@ -199,7 +199,7 @@ void main() {
   });
 
   test('to toDebugString', () {
-    var value = TestAllExtensions()
+    final value = TestAllExtensions()
       ..setExtension(Unittest.optionalInt32Extension, 1)
       ..addExtension(Unittest.repeatedStringExtension, 'hello')
       ..addExtension(Unittest.repeatedStringExtension, 'world')
@@ -208,7 +208,7 @@ void main() {
       ..setExtension(
           Unittest.optionalNestedEnumExtension, TestAllTypes_NestedEnum.BAR);
 
-    var expected = '[optionalInt32Extension]: 1\n'
+    final expected = '[optionalInt32Extension]: 1\n'
         '[optionalNestedMessageExtension]: {\n'
         '  i: 42\n'
         '}\n'
@@ -225,7 +225,7 @@ void main() {
       ..setExtension(Unittest.myExtensionString, 'bar');
     final b = withExtension.writeToBuffer();
     final withUnknownField = TestFieldOrderings.fromBuffer(b);
-    var r = ExtensionRegistry();
+    final r = ExtensionRegistry();
     Unittest.registerAllExtensions(r);
     final decodedWithExtension = TestFieldOrderings.fromBuffer(b, r);
     final noExtension = TestFieldOrderings()..myString = 'foo';
@@ -243,10 +243,10 @@ void main() {
   test(
       'ExtensionRegistry.reparseMessage will preserve already registered extensions',
       () {
-    var r1 = ExtensionRegistry();
+    final r1 = ExtensionRegistry();
     Unittest.registerAllExtensions(r1);
 
-    var r2 = ExtensionRegistry();
+    final r2 = ExtensionRegistry();
     Extend_unittest.registerAllExtensions(r2);
     final withUnknownFields =
         TestAllExtensions.fromBuffer(withExtensions.writeToBuffer());
@@ -266,7 +266,7 @@ void main() {
   test(
       'ExtensionRegistry.reparseMessage reparses extensions that were not in the original registry',
       () {
-    var r = ExtensionRegistry();
+    final r = ExtensionRegistry();
     Unittest.registerAllExtensions(r);
     Extend_unittest.registerAllExtensions(r);
 
@@ -322,7 +322,7 @@ void main() {
   });
 
   test('ExtensionRegistry.reparseMessage does not update the original', () {
-    var r = ExtensionRegistry();
+    final r = ExtensionRegistry();
     Unittest.registerAllExtensions(r);
     Extend_unittest.registerAllExtensions(r);
 

--- a/protoc_plugin/test/file_generator_test.dart
+++ b/protoc_plugin/test/file_generator_test.dart
@@ -14,7 +14,7 @@ import 'golden_file.dart';
 
 FileDescriptorProto buildFileDescriptor(
     {bool phoneNumber = true, bool topLevelEnum = false}) {
-  var fd = FileDescriptorProto()..name = 'test';
+  final fd = FileDescriptorProto()..name = 'test';
 
   if (topLevelEnum) {
     fd.enumType.add(EnumDescriptorProto()
@@ -72,7 +72,7 @@ FileDescriptorProto buildFileDescriptor(
 }
 
 FileDescriptorProto createInt64Proto() {
-  var fd = FileDescriptorProto()..name = 'test';
+  final fd = FileDescriptorProto()..name = 'test';
   fd.messageType.add(DescriptorProto()
     ..name = 'Int64'
     ..field.add(
@@ -91,20 +91,20 @@ FileDescriptorProto createInt64Proto() {
 void main() {
   test('FileGenerator outputs a .pb.dart file for a proto with one message',
       () {
-    var fd = buildFileDescriptor();
-    var options = parseGenerationOptions(
+    final fd = buildFileDescriptor();
+    final options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
         fg.generateMainFile().toString(), 'test/goldens/oneMessage.pb');
   });
 
   test('FileGenerator outputs a .pb.dart file for an Int64 message', () {
-    var fd = createInt64Proto();
-    var options = parseGenerationOptions(
+    final fd = createInt64Proto();
+    final options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
         fg.generateMainFile().toString(), 'test/goldens/int64.pb');
@@ -113,11 +113,11 @@ void main() {
   test(
       'FileGenerator outputs a .pb.dart.meta file for a proto with one message',
       () {
-    var fd = buildFileDescriptor();
-    var options = parseGenerationOptions(
+    final fd = buildFileDescriptor();
+    final options = parseGenerationOptions(
         CodeGeneratorRequest()..parameter = 'generate_kythe_info',
         CodeGeneratorResponse())!;
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(fg.generateMainFile().sourceLocationInfo.toString(),
         'test/goldens/oneMessage.pb.meta');
@@ -125,21 +125,21 @@ void main() {
 
   test('FileGenerator outputs a pbjson.dart file for a proto with one message',
       () {
-    var fd = buildFileDescriptor();
-    var options = parseGenerationOptions(
+    final fd = buildFileDescriptor();
+    final options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
         fg.generateJsonFile(), 'test/goldens/oneMessage.pbjson');
   });
 
   test('FileGenerator generates files for a top-level enum', () {
-    var fd = buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
-    var options = parseGenerationOptions(
+    final fd = buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
+    final options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
 
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
         fg.generateMainFile().toString(), 'test/goldens/topLevelEnum.pb');
@@ -148,11 +148,11 @@ void main() {
   });
 
   test('FileGenerator generates metadata files for a top-level enum', () {
-    var fd = buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
-    var options = parseGenerationOptions(
+    final fd = buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
+    final options = parseGenerationOptions(
         CodeGeneratorRequest()..parameter = 'generate_kythe_info',
         CodeGeneratorResponse())!;
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
 
     expectMatchesGoldenFile(fg.generateMainFile().sourceLocationInfo.toString(),
@@ -162,33 +162,33 @@ void main() {
   });
 
   test('FileGenerator generates a .pbjson.dart file for a top-level enum', () {
-    var fd = buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
-    var options = parseGenerationOptions(
+    final fd = buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
+    final options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
 
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
         fg.generateJsonFile(), 'test/goldens/topLevelEnum.pbjson');
   });
 
   test('FileGenerator outputs library for a .proto in a package', () {
-    var fd = buildFileDescriptor();
+    final fd = buildFileDescriptor();
     fd.package = 'pb_library';
-    var options = parseGenerationOptions(
+    final options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
 
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
 
-    var writer = IndentingWriter(filename: '');
+    final writer = IndentingWriter(filename: '');
     fg.writeMainHeader(writer);
     expectMatchesGoldenFile(
         writer.toString(), 'test/goldens/header_in_package.pb');
   });
 
   test('FileGenerator outputs a fixnum import when needed', () {
-    var fd = FileDescriptorProto()
+    final fd = FileDescriptorProto()
       ..name = 'test'
       ..messageType.add(DescriptorProto()
         ..name = 'Count'
@@ -200,40 +200,40 @@ void main() {
             ..type = FieldDescriptorProto_Type.TYPE_INT64
         ]));
 
-    var options = parseGenerationOptions(
+    final options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
 
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
 
-    var writer = IndentingWriter(filename: '');
+    final writer = IndentingWriter(filename: '');
     fg.writeMainHeader(writer);
     expectMatchesGoldenFile(
         writer.toString(), 'test/goldens/header_with_fixnum.pb');
   });
 
   test('FileGenerator outputs files for a service', () {
-    var empty = DescriptorProto()..name = 'Empty';
+    final empty = DescriptorProto()..name = 'Empty';
 
-    var sd = ServiceDescriptorProto()
+    final sd = ServiceDescriptorProto()
       ..name = 'Test'
       ..method.add(MethodDescriptorProto()
         ..name = 'Ping'
         ..inputType = '.Empty'
         ..outputType = '.Empty');
 
-    var fd = FileDescriptorProto()
+    final fd = FileDescriptorProto()
       ..name = 'test'
       ..messageType.add(empty)
       ..service.add(sd);
 
-    var options = parseGenerationOptions(
+    final options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
 
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
 
-    var writer = IndentingWriter(filename: '');
+    final writer = IndentingWriter(filename: '');
     fg.writeMainHeader(writer);
     expectMatchesGoldenFile(
         fg.generateMainFile().toString(), 'test/goldens/service.pb');
@@ -243,26 +243,26 @@ void main() {
 
   test('FileGenerator does not output legacy service stubs if gRPC is selected',
       () {
-    var empty = DescriptorProto()..name = 'Empty';
+    final empty = DescriptorProto()..name = 'Empty';
 
-    var sd = ServiceDescriptorProto()
+    final sd = ServiceDescriptorProto()
       ..name = 'Test'
       ..method.add(MethodDescriptorProto()
         ..name = 'Ping'
         ..inputType = '.Empty'
         ..outputType = '.Empty');
 
-    var fd = FileDescriptorProto()
+    final fd = FileDescriptorProto()
       ..name = 'test'
       ..messageType.add(empty)
       ..service.add(sd);
 
-    var options = GenerationOptions(useGrpc: true);
+    final options = GenerationOptions(useGrpc: true);
 
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
 
-    var writer = IndentingWriter(filename: '');
+    final writer = IndentingWriter(filename: '');
     fg.writeMainHeader(writer);
     expectMatchesGoldenFile(
         fg.generateMainFile().toString(), 'test/goldens/grpc_service.pb');
@@ -297,21 +297,21 @@ void main() {
       ..clientStreaming = true
       ..serverStreaming = true;
 
-    var sd = ServiceDescriptorProto()
+    final sd = ServiceDescriptorProto()
       ..name = 'Test'
       ..method.addAll([unary, clientStreaming, serverStreaming, bidirectional]);
 
-    var fd = FileDescriptorProto()
+    final fd = FileDescriptorProto()
       ..name = 'test'
       ..messageType.addAll([input, output])
       ..service.add(sd);
 
-    var options = GenerationOptions(useGrpc: true);
+    final options = GenerationOptions(useGrpc: true);
 
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options, [fg]);
 
-    var writer = IndentingWriter(filename: '');
+    final writer = IndentingWriter(filename: '');
     fg.writeMainHeader(writer);
     expectMatchesGoldenFile(
         fg.generateGrpcFile(), 'test/goldens/grpc_service.pbgrpc');
@@ -347,7 +347,7 @@ void main() {
     // }
 
     // Description of package1.proto.
-    var md1 = DescriptorProto()
+    final md1 = DescriptorProto()
       ..name = 'M'
       ..field.addAll([
         // optional M m = 1;
@@ -359,13 +359,13 @@ void main() {
           ..type = FieldDescriptorProto_Type.TYPE_MESSAGE
           ..typeName = '.p1.M',
       ]);
-    var fd1 = FileDescriptorProto()
+    final fd1 = FileDescriptorProto()
       ..package = 'p1'
       ..name = 'package1.proto'
       ..messageType.add(md1);
 
     // Description of package1.proto.
-    var md2 = DescriptorProto()
+    final md2 = DescriptorProto()
       ..name = 'M'
       ..field.addAll([
         // optional M m = 1;
@@ -377,13 +377,13 @@ void main() {
           ..type = FieldDescriptorProto_Type.TYPE_MESSAGE
           ..typeName = '.p2.M',
       ]);
-    var fd2 = FileDescriptorProto()
+    final fd2 = FileDescriptorProto()
       ..package = 'p2'
       ..name = 'package2.proto'
       ..messageType.add(md2);
 
     // Description of test.proto.
-    var md = DescriptorProto()
+    final md = DescriptorProto()
       ..name = 'M'
       ..field.addAll([
         // optional M m = 1;
@@ -411,15 +411,15 @@ void main() {
           ..type = FieldDescriptorProto_Type.TYPE_MESSAGE
           ..typeName = '.p2.M',
       ]);
-    var fd = FileDescriptorProto()
+    final fd = FileDescriptorProto()
       ..name = 'test.proto'
       ..messageType.add(md);
     fd.dependency.addAll(['package1.proto', 'package2.proto']);
-    var request = CodeGeneratorRequest();
-    var response = CodeGeneratorResponse();
-    var options = parseGenerationOptions(request, response)!;
+    final request = CodeGeneratorRequest();
+    final response = CodeGeneratorResponse();
+    final options = parseGenerationOptions(request, response)!;
 
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
     link(options,
         [fg, FileGenerator(fd1, options), FileGenerator(fd2, options)]);
     expectMatchesGoldenFile(

--- a/protoc_plugin/test/freeze_test.dart
+++ b/protoc_plugin/test/freeze_test.dart
@@ -16,11 +16,11 @@ void main() {
       ..nestedMessage = (Nested()..a = 3);
 
     // Create aliases to lists, maps, nested messages
-    var list = top.nestedMessageList;
-    var map = top.nestedMessageMap;
-    var msg1 = top.nestedMessageList[0];
-    var msg2 = top.nestedMessageMap[1]!;
-    var msg3 = top.nestedMessage;
+    final list = top.nestedMessageList;
+    final map = top.nestedMessageMap;
+    final msg1 = top.nestedMessageList[0];
+    final msg2 = top.nestedMessageMap[1]!;
+    final msg3 = top.nestedMessage;
 
     top.freeze();
 

--- a/protoc_plugin/test/generated_message_test.dart
+++ b/protoc_plugin/test/generated_message_test.dart
@@ -22,12 +22,12 @@ void main() {
   final throwsInvalidProtocolBufferException =
       throwsA(TypeMatcher<InvalidProtocolBufferException>());
   test('testProtosShareRepeatedArraysIfDidntChange', () {
-    var value1 = TestAllTypes()
+    final value1 = TestAllTypes()
       ..repeatedInt32.add(100)
       ..repeatedImportEnum.add(ImportEnum.IMPORT_BAR)
       ..repeatedForeignMessage.add(ForeignMessage());
 
-    var value2 = value1.deepCopy();
+    final value2 = value1.deepCopy();
 
     expect(value2.repeatedInt32, value1.repeatedInt32);
     expect(value2.repeatedImportEnum, value1.repeatedImportEnum);
@@ -64,13 +64,13 @@ void main() {
   });
 
   test('testRepeatedSetters', () {
-    var message = getAllSet();
+    final message = getAllSet();
     modifyRepeatedFields(message);
     assertRepeatedFieldsModified(message);
   });
 
   test('testRepeatedAppend', () {
-    var message = TestAllTypes()
+    final message = TestAllTypes()
       ..repeatedInt32.addAll([1, 2, 3, 4])
       ..repeatedForeignEnum.addAll([ForeignEnum.FOREIGN_BAZ])
       ..repeatedForeignMessage.addAll([ForeignMessage()..c = 12]);
@@ -82,20 +82,20 @@ void main() {
   });
 
   test('testSettingForeignMessage', () {
-    var message = TestAllTypes()
+    final message = TestAllTypes()
       ..optionalForeignMessage = (ForeignMessage()..c = 123);
 
-    var expectedMessage = TestAllTypes()
+    final expectedMessage = TestAllTypes()
       ..optionalForeignMessage = (ForeignMessage()..c = 123);
 
     expect(message, expectedMessage);
   });
 
   test('testSettingRepeatedForeignMessage', () {
-    var message = TestAllTypes()
+    final message = TestAllTypes()
       ..repeatedForeignMessage.add(ForeignMessage()..c = 456);
 
-    var expectedMessage = TestAllTypes()
+    final expectedMessage = TestAllTypes()
       ..repeatedForeignMessage.add(ForeignMessage()..c = 456);
 
     expect(message, expectedMessage);
@@ -104,7 +104,7 @@ void main() {
   test('testDefaults', () {
     assertClear(TestAllTypes());
 
-    var message = TestExtremeDefaultValues();
+    final message = TestExtremeDefaultValues();
 
     expect(message.utf8String, '\u1234');
     expect(message.infDouble, same(double.infinity));
@@ -119,7 +119,7 @@ void main() {
   });
 
   test('testClear', () {
-    var message = TestAllTypes();
+    final message = TestAllTypes();
 
     assertClear(message);
     setAllFields(message);
@@ -128,7 +128,7 @@ void main() {
   });
 
   test('test ensure method', () {
-    var message = TestAllTypes();
+    final message = TestAllTypes();
     expect(message.hasOptionalNestedMessage(), isFalse);
     expect(message.ensureOptionalNestedMessage(), TestAllTypes_NestedMessage());
     expect(message.hasOptionalNestedMessage(), isTrue);
@@ -146,26 +146,28 @@ void main() {
   });
 
   test('testEnumMap', () {
-    for (var value in ForeignEnum.values) {
+    for (final value in ForeignEnum.values) {
       expect(ForeignEnum.valueOf(value.value), value);
     }
     expect(ForeignEnum.valueOf(12345), isNull);
   });
 
   test('testParsePackedToUnpacked', () {
-    var message = TestUnpackedTypes.fromBuffer(getPackedSet().writeToBuffer());
+    final message =
+        TestUnpackedTypes.fromBuffer(getPackedSet().writeToBuffer());
     assertUnpackedFieldsSet(message);
   });
 
   test('testParseUnpackedToPacked', () {
-    var message = TestPackedTypes.fromBuffer(getUnpackedSet().writeToBuffer());
+    final message =
+        TestPackedTypes.fromBuffer(getUnpackedSet().writeToBuffer());
     assertPackedFieldsSet(message);
   });
 
   test('testIgnoreJavaMultipleFilesOption', () {
     // UNSUPPORTED getFile
     // We mostly just want to check that things compile.
-    var message = MessageWithNoOuter()
+    final message = MessageWithNoOuter()
       ..nested = (MessageWithNoOuter_NestedMessage()..i = 1)
       ..foreign.add(TestAllTypes()..optionalInt32 = 1)
       ..nestedEnum = MessageWithNoOuter_NestedEnum.BAZ
@@ -177,7 +179,7 @@ void main() {
     // expect(MessageWithNoOuter.getDescriptor().getFile(),
     //        MultipleFilesTestProto.getDescriptor());
 
-    var tagNumber = message.getTagNumber('foreignEnum')!;
+    final tagNumber = message.getTagNumber('foreignEnum')!;
     expect(message.getField(tagNumber), EnumWithNoOuter.BAR);
 
     // Not currently supported in Dart protobuf.
@@ -206,31 +208,31 @@ void main() {
   });
 
   test('testSetAllFieldsAndClone', () {
-    var message = getAllSet();
+    final message = getAllSet();
     assertAllFieldsSet(message);
     assertAllFieldsSet(message.deepCopy());
   });
 
   test('testReadWholeMessage', () {
-    var message = getAllSet();
-    List<int> rawBytes = message.writeToBuffer();
+    final message = getAllSet();
+    final List<int> rawBytes = message.writeToBuffer();
     assertAllFieldsSet(TestAllTypes.fromBuffer(rawBytes));
   });
 
   test('testReadHugeBlob', () {
     // Allocate and initialize a 1MB blob.
-    var blob = List<int>.generate(1 << 20, (i) => i % 256);
+    final blob = List<int>.generate(1 << 20, (i) => i % 256);
 
     // Make a message containing it.
-    var message = getAllSet();
+    final message = getAllSet();
     message.optionalBytes = blob;
 
-    var message2 = TestAllTypes.fromBuffer(message.writeToBuffer());
+    final message2 = TestAllTypes.fromBuffer(message.writeToBuffer());
     expect(message2.optionalBytes, message.optionalBytes);
   });
 
   test('testRecursiveMessageDefaultInstance', () {
-    var message = TestRecursiveMessage();
+    final message = TestRecursiveMessage();
     expect(message.a, isNotNull);
     expect(message, message.a);
   });
@@ -252,8 +254,8 @@ void main() {
       }
     }
 
-    List<int> data64 = makeRecursiveMessage(64).writeToBuffer();
-    List<int> data65 = makeRecursiveMessage(65).writeToBuffer();
+    final List<int> data64 = makeRecursiveMessage(64).writeToBuffer();
+    final List<int> data65 = makeRecursiveMessage(65).writeToBuffer();
 
     assertMessageDepth(TestRecursiveMessage.fromBuffer(data64), 64);
 
@@ -261,7 +263,7 @@ void main() {
       TestRecursiveMessage.fromBuffer(data65);
     }, throwsInvalidProtocolBufferException);
 
-    var input = CodedBufferReader(data64, recursionLimit: 8);
+    final input = CodedBufferReader(data64, recursionLimit: 8);
     expect(() {
       // Uncomfortable alternative to below...
       TestRecursiveMessage().mergeFromCodedBufferReader(input);
@@ -269,7 +271,7 @@ void main() {
   });
 
   test('testSizeLimit', () {
-    var input = CodedBufferReader(getAllSet().writeToBuffer(), sizeLimit: 16);
+    final input = CodedBufferReader(getAllSet().writeToBuffer(), sizeLimit: 16);
 
     expect(() {
       // Uncomfortable alternative to below...
@@ -277,9 +279,9 @@ void main() {
     }, throwsInvalidProtocolBufferException);
   });
   test('testSerialize', () {
-    var expected = getAllSet();
-    List<int> out = expected.writeToBuffer();
-    var actual = TestAllTypes.fromBuffer(out);
+    final expected = getAllSet();
+    final List<int> out = expected.writeToBuffer();
+    final actual = TestAllTypes.fromBuffer(out);
     expect(actual, expected);
   });
 
@@ -295,7 +297,7 @@ void main() {
   });
 
   test('testWriteWholeMessage', () {
-    var goldenMessage = const <int>[
+    final goldenMessage = const <int>[
       // no `dart format`
       0x08, 0x65, 0x10, 0x66, 0x18, 0x67, 0x20, 0x68, 0x28, 0xd2, 0x01, 0x30,
       0xd4, 0x01, 0x3d, 0x6b, 0x00, 0x00, 0x00, 0x41, 0x6c, 0x00, 0x00, 0x00,
@@ -343,7 +345,7 @@ void main() {
   });
 
   test('testWriteWholePackedFieldsMessage', () {
-    var goldenPackedMessage = const <int>[
+    final goldenPackedMessage = const <int>[
       // no `dart format`
       0xd2, 0x05, 0x04, 0xd9, 0x04, 0xbd, 0x05, 0xda, 0x05, 0x04, 0xda, 0x04,
       0xbe, 0x05, 0xe2, 0x05, 0x04, 0xdb, 0x04, 0xbf, 0x05, 0xea, 0x05, 0x04,
@@ -362,16 +364,16 @@ void main() {
   });
 
   test('testWriteMessageWithNegativeEnumValue', () {
-    var message = SparseEnumMessage()..sparseEnum = TestSparseEnum.SPARSE_E;
+    final message = SparseEnumMessage()..sparseEnum = TestSparseEnum.SPARSE_E;
     expect(message.sparseEnum.value < 0, isTrue,
         reason: 'enum.value should be -53452');
-    var message2 = SparseEnumMessage.fromBuffer(message.writeToBuffer());
+    final message2 = SparseEnumMessage.fromBuffer(message.writeToBuffer());
     expect(message2.sparseEnum, TestSparseEnum.SPARSE_E,
         reason: 'should resolve back to SPARSE_E');
   });
 
   test('testReservedNamesOptional', () {
-    var message = ReservedNamesOptional();
+    final message = ReservedNamesOptional();
     message.hashCode_1 = 1;
     expect(message.hashCode_1, 1);
     expect(message.hasHashCode_1(), isTrue);
@@ -412,7 +414,7 @@ void main() {
   });
 
   test('testReservedNamesRepeated', () {
-    var message = ReservedNamesRepeated();
+    final message = ReservedNamesRepeated();
     message.hashCode_1.clear();
     message.noSuchMethod_2.clear();
     message.runtimeType_3.clear();
@@ -449,7 +451,7 @@ void main() {
   });
 
   test('testReservedNamesRequired', () {
-    var message = ReservedNamesRequired();
+    final message = ReservedNamesRequired();
     message.hashCode_1 = 1;
     expect(message.hashCode_1, 1);
     expect(message.hasHashCode_1(), isTrue);
@@ -490,7 +492,7 @@ void main() {
   });
 
   test('testReservedWordsOptional', () {
-    var message = ReservedWordsOptional();
+    final message = ReservedWordsOptional();
     message.assert_1 = 1;
     message.break_2 = 1;
     message.case_3 = 1;
@@ -527,7 +529,7 @@ void main() {
   });
 
   test('testReservedWordsRepeated', () {
-    var message = ReservedWordsRepeated();
+    final message = ReservedWordsRepeated();
     message.assert_1.clear();
     message.break_2.clear();
     message.case_3.clear();
@@ -564,7 +566,7 @@ void main() {
   });
 
   test('testReservedWordsRequired', () {
-    var message = ReservedWordsRequired();
+    final message = ReservedWordsRequired();
     message.assert_1 = 1;
     message.break_2 = 1;
     message.case_3 = 1;
@@ -601,7 +603,7 @@ void main() {
   });
 
   test('testReservedWordsRequired', () {
-    var message = MessageWithReservedEnum();
+    final message = MessageWithReservedEnum();
     message.enum_1 = ReservedEnum.assert_;
     message.enum_1 = ReservedEnum.break_;
     message.enum_1 = ReservedEnum.case_;
@@ -638,7 +640,7 @@ void main() {
   });
 
   test('testReservedWordsExtension', () {
-    var message = ExtendMe();
+    final message = ExtendMe();
     message.setExtension(Reserved_names_extension.assert_1001, 1);
     message.setExtension(Reserved_names_extension.break_1002, 1);
     message.setExtension(Reserved_names_extension.case_1003, 1);
@@ -711,7 +713,7 @@ void main() {
   });
 
   test('testImportDuplicatenames', () {
-    var message = M();
+    final message = M();
     message.m1 = p1.M();
     message.m1M = p1.M_M();
     message.m2 = p2.M();
@@ -721,7 +723,7 @@ void main() {
   });
 
   test('to toDebugString', () {
-    var value1 = TestAllTypes()..optionalString = 'test 123';
+    final value1 = TestAllTypes()..optionalString = 'test 123';
     expect(value1.toString(), 'optionalString: test 123\n');
   });
 

--- a/protoc_plugin/test/golden_file.dart
+++ b/protoc_plugin/test/golden_file.dart
@@ -18,7 +18,8 @@ void expectMatchesGoldenFile(String actual, String goldenFilePath) {
   } else {
     // This enables writing the updated file when the run in otherwise hermetic
     // settings.
-    var workspaceDirectory = Platform.environment['BUILD_WORKSPACE_DIRECTORY'];
+    final workspaceDirectory =
+        Platform.environment['BUILD_WORKSPACE_DIRECTORY'];
     if (workspaceDirectory != null) {
       goldenFile = File(path.join(workspaceDirectory, goldenFilePath));
     }

--- a/protoc_plugin/test/goldens/client
+++ b/protoc_plugin/test/goldens/client
@@ -2,13 +2,11 @@ class TestApi {
   $pb.RpcClient _client;
   TestApi(this._client);
 
-  $async.Future<SomeReply> aMethod($pb.ClientContext? ctx, SomeRequest request) {
-    var emptyResponse = SomeReply();
-    return _client.invoke<SomeReply>(ctx, 'Test', 'AMethod', request, emptyResponse);
-  }
-  $async.Future<$0.AnotherReply> anotherMethod($pb.ClientContext? ctx, $0.EmptyMessage request) {
-    var emptyResponse = $0.AnotherReply();
-    return _client.invoke<$0.AnotherReply>(ctx, 'Test', 'AnotherMethod', request, emptyResponse);
-  }
+  $async.Future<SomeReply> aMethod($pb.ClientContext? ctx, SomeRequest request) =>
+    _client.invoke<SomeReply>(ctx, 'Test', 'AMethod', request, SomeReply())
+  ;
+  $async.Future<$0.AnotherReply> anotherMethod($pb.ClientContext? ctx, $0.EmptyMessage request) =>
+    _client.invoke<$0.AnotherReply>(ctx, 'Test', 'AnotherMethod', request, $0.AnotherReply())
+  ;
 }
 

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -50,10 +50,9 @@ class TestApi {
   $pb.RpcClient _client;
   TestApi(this._client);
 
-  $async.Future<Empty> ping($pb.ClientContext? ctx, Empty request) {
-    var emptyResponse = Empty();
-    return _client.invoke<Empty>(ctx, 'Test', 'Ping', request, emptyResponse);
-  }
+  $async.Future<Empty> ping($pb.ClientContext? ctx, Empty request) =>
+    _client.invoke<Empty>(ctx, 'Test', 'Ping', request, Empty())
+  ;
 }
 
 

--- a/protoc_plugin/test/hash_code_test.dart
+++ b/protoc_plugin/test/hash_code_test.dart
@@ -9,14 +9,14 @@ import '../out/protos/google/protobuf/unittest.pb.dart';
 
 void main() {
   test('testHashCodeEmptyMessage', () {
-    var m1 = TestAllTypes();
-    var m2 = TestAllTypes();
+    final m1 = TestAllTypes();
+    final m2 = TestAllTypes();
     expect(m1.hashCode, m2.hashCode);
   });
 
   test('testHashCodeOptionalInt32', () {
-    var m1 = TestAllTypes()..optionalInt32 = 42;
-    var m2 = TestAllTypes()..optionalInt32 = 42;
+    final m1 = TestAllTypes()..optionalInt32 = 42;
+    final m2 = TestAllTypes()..optionalInt32 = 42;
     expect(m1.hashCode, m2.hashCode);
 
     m1.optionalInt32 = 43;
@@ -27,8 +27,8 @@ void main() {
   });
 
   test('testHashCodeOptionalInt64', () {
-    var m1 = TestAllTypes()..optionalInt64 = Int64(42);
-    var m2 = TestAllTypes()..optionalInt64 = Int64(42);
+    final m1 = TestAllTypes()..optionalInt64 = Int64(42);
+    final m2 = TestAllTypes()..optionalInt64 = Int64(42);
     expect(m1.hashCode, m2.hashCode);
 
     m1.optionalInt64 = Int64(43);
@@ -39,8 +39,8 @@ void main() {
   });
 
   test('testHashCodeOptionalString', () {
-    var m1 = TestAllTypes()..optionalString = 'Dart';
-    var m2 = TestAllTypes()..optionalString = 'Dart';
+    final m1 = TestAllTypes()..optionalString = 'Dart';
+    final m2 = TestAllTypes()..optionalString = 'Dart';
     expect(m1.hashCode, m2.hashCode);
 
     m1.optionalString = 'JavaScript';
@@ -51,8 +51,8 @@ void main() {
   });
 
   test('testHashCodeOptionalEnum', () {
-    var m1 = TestAllTypes()..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
-    var m2 = TestAllTypes()..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
+    final m1 = TestAllTypes()..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
+    final m2 = TestAllTypes()..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
     expect(m1.hashCode, m2.hashCode);
 
     m1.optionalNestedEnum = TestAllTypes_NestedEnum.BAZ;
@@ -63,16 +63,16 @@ void main() {
   });
 
   test('testHashCodeRepeatedInt32', () {
-    var m1 = TestAllTypes();
-    var m2 = TestAllTypes();
+    final m1 = TestAllTypes();
+    final m2 = TestAllTypes();
     m1.repeatedInt32.add(42);
     m2.repeatedInt32.add(42);
     expect(m1.hashCode, m2.hashCode);
   });
 
   test('testHashCodeRepeatedInt64', () {
-    var m1 = TestAllTypes();
-    var m2 = TestAllTypes();
+    final m1 = TestAllTypes();
+    final m2 = TestAllTypes();
     m1.repeatedInt32.add(42);
     m2.repeatedInt32.add(42);
     expect(m1.hashCode, m2.hashCode);
@@ -91,8 +91,8 @@ void main() {
   });
 
   test('testHashCodeRepeatedString', () {
-    var m1 = TestAllTypes();
-    var m2 = TestAllTypes();
+    final m1 = TestAllTypes();
+    final m2 = TestAllTypes();
     m1.repeatedString.add('Dart');
     m2.repeatedString.add('Dart');
     expect(m1.hashCode, m2.hashCode);
@@ -111,8 +111,8 @@ void main() {
   });
 
   test('testHashCodeRepeatedEnum', () {
-    var m1 = TestAllTypes();
-    var m2 = TestAllTypes();
+    final m1 = TestAllTypes();
+    final m2 = TestAllTypes();
     m1.repeatedNestedEnum.add(TestAllTypes_NestedEnum.BAR);
     m2.repeatedNestedEnum.add(TestAllTypes_NestedEnum.BAR);
     expect(m1.hashCode, m2.hashCode);
@@ -125,20 +125,20 @@ void main() {
   });
 
   test('testHashCodeUnknownFields', () {
-    var m1 = TestAllTypes();
-    var m2 = TestAllTypes();
+    final m1 = TestAllTypes();
+    final m2 = TestAllTypes();
     m1.unknownFields.mergeVarintField(12345, Int64(123));
     m2.unknownFields.mergeVarintField(12345, Int64(123));
     expect(m1.hashCode, m2.hashCode);
   });
 
   test('testHashCodeCombined', () {
-    var m1 = TestAllTypes()
+    final m1 = TestAllTypes()
       ..optionalInt32 = 42
       ..optionalInt64 = Int64(42)
       ..optionalString = 'Dart'
       ..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
-    var m2 = TestAllTypes()
+    final m2 = TestAllTypes()
       ..optionalInt32 = 42
       ..optionalInt64 = Int64(42)
       ..optionalString = 'Dart'

--- a/protoc_plugin/test/indenting_writer_test.dart
+++ b/protoc_plugin/test/indenting_writer_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 void main() {
   group('IndentingWriter', () {
     test('IndentingWriter can indent a block', () {
-      var out = IndentingWriter(filename: '');
+      final out = IndentingWriter(filename: '');
       out.addBlock('class test {', '}', () {
         out.println('first;');
         out.println();
@@ -26,38 +26,38 @@ class test {
     });
 
     test('IndentingWriter annotation tracks previous output', () {
-      var out = IndentingWriter(filename: 'sample.proto');
+      final out = IndentingWriter(filename: 'sample.proto');
       out.print('13 characters');
       out.printAnnotated('sample text', [
         NamedLocation(name: 'text', fieldPathSegment: [1, 2, 3], start: 7)
       ]);
-      var expected = GeneratedCodeInfo_Annotation()
+      final expected = GeneratedCodeInfo_Annotation()
         ..path.addAll([1, 2, 3])
         ..sourceFile = 'sample.proto'
         ..begin = 20
         ..end = 24;
-      var annotation = out.sourceLocationInfo.annotation[0];
+      final annotation = out.sourceLocationInfo.annotation[0];
       expect(annotation, equals(expected));
     });
 
     test('IndentingWriter annotation counts indents correctly', () {
-      var out = IndentingWriter(filename: '');
+      final out = IndentingWriter(filename: '');
       out.addBlock('34 characters including newline {', '}', () {
         out.printlnAnnotated('sample text',
             [NamedLocation(name: 'sample', fieldPathSegment: [], start: 0)]);
       });
-      var annotation = out.sourceLocationInfo.annotation[0];
+      final annotation = out.sourceLocationInfo.annotation[0];
       // The indent is 2 characters, so these should be shifted by 2.
       expect(annotation.begin, equals(36));
       expect(annotation.end, equals(42));
     });
 
     test('IndentingWriter annotations counts multiline output correctly', () {
-      var out = IndentingWriter(filename: '');
+      final out = IndentingWriter(filename: '');
       out.print('20 characters\ntotal\n');
       out.printlnAnnotated('20 characters before this',
           [NamedLocation(name: 'ch', fieldPathSegment: [], start: 3)]);
-      var annotation = out.sourceLocationInfo.annotation[0];
+      final annotation = out.sourceLocationInfo.annotation[0];
       expect(annotation.begin, equals(23));
       expect(annotation.end, equals(25));
     });

--- a/protoc_plugin/test/json_test.dart
+++ b/protoc_plugin/test/json_test.dart
@@ -31,14 +31,14 @@ void main() {
   /// Checks that the message, once serialized to JSON, matches
   /// [testAllJsonTypes] massaged with `replaceAll(from, to)`.
   Matcher expectedJson(String from, String to) {
-    var expectedJson = testAllJsonTypes.replaceAll(from, to);
+    final expectedJson = testAllJsonTypes.replaceAll(from, to);
     return predicate(
         (GeneratedMessage message) => message.writeToJson() == expectedJson,
         'Incorrect output');
   }
 
   test('testUnsignedOutput', () {
-    var message = TestAllTypes();
+    final message = TestAllTypes();
     // These values selected because:
     // (1) large enough to set the sign bit
     // (2) don't set all of the first 10 bits under the sign bit
@@ -46,7 +46,7 @@ void main() {
     message.optionalUint64 = Int64.parseHex('f0000000ffff0000');
     message.optionalFixed64 = Int64.parseHex('f0000000ffff0001');
 
-    var expectedJsonValue =
+    final expectedJsonValue =
         '{"4":"17293822573397606400","8":"17293822573397606401"}';
     expect(message.writeToJson(), expectedJsonValue);
   });
@@ -96,7 +96,7 @@ void main() {
 
   test('testBase64Decode', () {
     String optionalBytes(String from, String to) {
-      var json = testAllJsonTypes.replaceAll(from, to);
+      final json = testAllJsonTypes.replaceAll(from, to);
       return String.fromCharCodes(TestAllTypes.fromJson(json).optionalBytes);
     }
 
@@ -118,9 +118,9 @@ void main() {
   });
 
   test('testParseUnsigned', () {
-    var parsed = TestAllTypes.fromJson(
+    final parsed = TestAllTypes.fromJson(
         '{"4":"17293822573397606400","8":"17293822573397606401"}');
-    var expected = TestAllTypes();
+    final expected = TestAllTypes();
     expected.optionalUint64 = Int64.parseHex('f0000000ffff0000');
     expected.optionalFixed64 = Int64.parseHex('f0000000ffff0001');
 
@@ -130,37 +130,37 @@ void main() {
   group('testConvertDouble', () {
     test('WithDecimal', () {
       final json = '{"12":1.2}';
-      var proto = TestAllTypes()..optionalDouble = 1.2;
+      final proto = TestAllTypes()..optionalDouble = 1.2;
       expect(TestAllTypes.fromJson(json), proto);
       expect(proto.writeToJson(), json);
     });
 
     test('WholeNumber', () {
       final json = '{"12":5}';
-      var proto = TestAllTypes()..optionalDouble = 5.0;
+      final proto = TestAllTypes()..optionalDouble = 5.0;
       expect(TestAllTypes.fromJson(json), proto);
       expect(proto.writeToJson(), json);
     });
 
     test('Infinity', () {
       final json = '{"12":"Infinity"}';
-      var proto = TestAllTypes()..optionalDouble = double.infinity;
+      final proto = TestAllTypes()..optionalDouble = double.infinity;
       expect(TestAllTypes.fromJson(json), proto);
       expect(proto.writeToJson(), json);
     });
 
     test('NegativeInfinity', () {
       final json = '{"12":"-Infinity"}';
-      var proto = TestAllTypes()..optionalDouble = double.negativeInfinity;
+      final proto = TestAllTypes()..optionalDouble = double.negativeInfinity;
       expect(TestAllTypes.fromJson(json), proto);
       expect(proto.writeToJson(), json);
     });
   });
 
   test('testParseUnsignedLegacy', () {
-    var parsed = TestAllTypes.fromJson(
+    final parsed = TestAllTypes.fromJson(
         '{"4":"-1152921500311945216","8":"-1152921500311945215"}');
-    var expected = TestAllTypes();
+    final expected = TestAllTypes();
     expected.optionalUint64 = Int64.parseHex('f0000000ffff0000');
     expected.optionalFixed64 = Int64.parseHex('f0000000ffff0001');
 
@@ -183,14 +183,14 @@ void main() {
   });
 
   test('testExtensionsParse', () {
-    var registry = getExtensionRegistry();
+    final registry = getExtensionRegistry();
     expect(TestAllExtensions.fromJson(testAllJsonTypes, registry),
         getAllExtensionsSet());
   });
 
   test('testUnknownEnumValueInOptionalField', () {
     // optional NestedEnum optional_nested_enum = 21;
-    var message = TestAllTypes.fromJson('{"21": 4}');
+    final message = TestAllTypes.fromJson('{"21": 4}');
     // 4 is an unknown value.
     expect(message.optionalNestedEnum, equals(TestAllTypes_NestedEnum.FOO));
   });

--- a/protoc_plugin/test/leading_underscores_test.dart
+++ b/protoc_plugin/test/leading_underscores_test.dart
@@ -9,7 +9,7 @@ import '../out/protos/_leading_underscores.pb.dart';
 
 void main() {
   test('can set, read and clear all fields and refer to types', () {
-    var message = A_();
+    final message = A_();
     message.setExtension(Leading_underscores_.p, Int64(99));
     expect(message.getExtension(Leading_underscores_.p), Int64(99));
     message.f = 'foo';
@@ -22,7 +22,7 @@ void main() {
     expect(message.hasF_2(), false);
     expect(message.f, '');
     expect(message.f_2, '');
-    var messageA = A();
+    final messageA = A();
     messageA.b = message;
     messageA.b_6 = message;
     expect(messageA.b_6, message);
@@ -57,7 +57,7 @@ void main() {
     messageA.setExtension(Leading_underscores_.q, Int64(100));
     expect(messageA.getExtension(Leading_underscores_.q), Int64(100));
 
-    var a = A__()..foo = 'hi';
+    final a = A__()..foo = 'hi';
     expect(a.foo, 'hi');
   });
 }

--- a/protoc_plugin/test/map_field_test.dart
+++ b/protoc_plugin/test/map_field_test.dart
@@ -122,7 +122,7 @@ void main() {
   }
 
   test('set and clear values', () {
-    var testMap = TestMap();
+    final testMap = TestMap();
     expectEmpty(testMap);
 
     setValues(testMap);
@@ -133,7 +133,7 @@ void main() {
   });
 
   test('update map values', () {
-    var testMap = TestMap();
+    final testMap = TestMap();
     setValues(testMap);
     updateValues(testMap);
     expectMapValuesUpdated(testMap);
@@ -174,13 +174,13 @@ void main() {
   test(
       'PbMap` is equal to another PbMap with equal key/value pairs in any order',
       () {
-    var t = TestMap()
+    final t = TestMap()
       ..int32ToStringField[2] = 'test2'
       ..int32ToStringField[1] = 'test';
-    var t2 = TestMap()
+    final t2 = TestMap()
       ..int32ToStringField[1] = 'test'
       ..int32ToStringField[2] = 'test2';
-    var t3 = TestMap()..int32ToStringField[1] = 'test';
+    final t3 = TestMap()..int32ToStringField[1] = 'test';
 
     final m = t.int32ToStringField;
     final m2 = t2.int32ToStringField;
@@ -232,10 +232,10 @@ void main() {
   });
 
   test('parse duplicate keys', () {
-    var testMap = TestMap()..int32ToStringField[1] = 'foo';
-    var testMap2 = TestMap()..int32ToStringField[1] = 'bar';
+    final testMap = TestMap()..int32ToStringField[1] = 'foo';
+    final testMap2 = TestMap()..int32ToStringField[1] = 'bar';
 
-    var merge = TestMap.fromBuffer(
+    final merge = TestMap.fromBuffer(
         [...testMap.writeToBuffer(), ...testMap2.writeToBuffer()]);
 
     // When parsing from the wire, if there are duplicate map keys the last key
@@ -245,28 +245,28 @@ void main() {
   });
 
   test('Deep merge from other message', () {
-    var i1 = Inner()..innerMap['a'] = 'a';
-    var i2 = Inner()..innerMap['b'] = 'b';
+    final i1 = Inner()..innerMap['a'] = 'a';
+    final i2 = Inner()..innerMap['b'] = 'b';
 
-    var o1 = Outer()..i = i1;
-    var o2 = Outer()..i = i2;
+    final o1 = Outer()..i = i1;
+    final o2 = Outer()..i = i2;
 
     o1.mergeFromMessage(o2);
     expect(o1.i.innerMap.length, 2);
   });
 
   test('retain explicit default values of sub-messages', () {
-    var testMap = TestMap()..int32ToMessageField[1] = TestMap_MessageValue();
+    final testMap = TestMap()..int32ToMessageField[1] = TestMap_MessageValue();
     expect(testMap.int32ToMessageField[1]!.secondValue, 42);
 
-    var testMap2 = TestMap()..int32ToMessageField[2] = TestMap_MessageValue();
+    final testMap2 = TestMap()..int32ToMessageField[2] = TestMap_MessageValue();
 
     testMap.mergeFromBuffer(testMap2.writeToBuffer());
     expect(testMap.int32ToMessageField[2]!.secondValue, 42);
   });
 
   test('Freeze message with map field', () {
-    var testMap = TestMap();
+    final testMap = TestMap();
     setValues(testMap);
     testMap.freeze();
 
@@ -281,7 +281,7 @@ void main() {
   });
 
   test('Values for different keys are not merged together when decoding', () {
-    var testMap = TestMap();
+    final testMap = TestMap();
     testMap.int32ToMessageField[1] = (TestMap_MessageValue()..value = 11);
     testMap.int32ToMessageField[2] = (TestMap_MessageValue()..secondValue = 12);
 
@@ -358,14 +358,14 @@ void main() {
   test('getField and \$_getMap are in sync', () {
     final msg1 = TestMap();
     expect(msg1.hasField(1), false);
-    var map1 = msg1.getField(1) as Map<int, int>;
+    final map1 = msg1.getField(1) as Map<int, int>;
     expect(msg1.hasField(1), true);
     map1[1] = 2;
     expect(msg1.int32ToInt32Field[1], 2);
 
     final msg2 = TestMap();
     expect(msg2.hasField(1), false);
-    var map2 = msg2.$_getMap(0) as Map<int, int>;
+    final map2 = msg2.$_getMap(0) as Map<int, int>;
     expect(msg2.hasField(1), true);
     map2[1] = 2;
     expect(msg2.int32ToInt32Field[1], 2);

--- a/protoc_plugin/test/map_test.dart
+++ b/protoc_plugin/test/map_test.dart
@@ -20,14 +20,14 @@ void main() {
   });
 
   test('operator [] returns null for unrecognized keys', () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     expect(rec['noSuchField'], null);
     expect(rec[1234], null);
     expect(rec[null], null);
   });
 
   test('operator [] returns default value when not set', () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     expect(rec['num'], 0);
     expect(rec['nums'], []);
     expect(rec['str'], '');
@@ -35,20 +35,20 @@ void main() {
   });
 
   test('operator [] returns new value when set', () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     rec.num = 42;
     expect(rec['num'], 42);
     rec.nums.add(123);
     expect(rec['nums'], [123]);
     rec.str = 'hello';
     expect(rec['str'], 'hello');
-    var msg = pb.NonMap();
+    final msg = pb.NonMap();
     rec.msg = msg;
     expect(rec['msg'], same(msg));
   });
 
   test('operator []= throws exception for invalid key', () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     expect(() {
       rec['unknown'] = 123;
     },
@@ -58,14 +58,14 @@ void main() {
 
   test('operator []= throws exception for repeated field', () {
     // Copying the values would be confusing.
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     expect(() {
       rec['nums'] = [1, 2];
     }, throwsArgumentError);
   });
 
   test('operator []= throws exception for invalid value type', () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     expect(() {
       rec['num'] = 'hello';
     }, throwsArgumentError);
@@ -75,7 +75,7 @@ void main() {
   });
 
   test('operator []= sets the field', () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     rec['num'] = 123;
     expect(rec.num, 123);
     rec['str'] = 'hello';
@@ -83,12 +83,12 @@ void main() {
   });
 
   test('keys returns each field name (even when unset)', () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     expect(Set.from(rec.keys), {'msg', 'num', 'nums', 'str'});
   });
 
   test('containsKey returns true for fields that exist (even when unset)', () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     expect(rec.containsKey('unknown'), false);
     expect(rec.containsKey('str'), true);
     expect(rec.containsKey('num'), true);
@@ -97,14 +97,14 @@ void main() {
   });
 
   test('length is constant', () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     expect(rec.length, 4);
     rec.str = 'hello';
     expect(rec.length, 4);
   });
 
   test("remove isn't supported", () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     rec.str = 'hello';
     expect(() {
       rec.remove('str');
@@ -116,7 +116,7 @@ void main() {
 
   test('clear sets each field to its default value (unlike a regular Map)', () {
     // We have little choice here since the clear() method already existed.
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     rec.str = 'hello';
     rec.num = 123;
     rec.nums.add(456);
@@ -128,7 +128,7 @@ void main() {
   });
 
   test('addAll sets each field to a new value', () {
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     rec.addAll({'str': 'hello', 'num': 123});
     expect(rec['str'], 'hello');
     expect(rec['num'], 123);
@@ -136,7 +136,7 @@ void main() {
 
   test("addAll doesn't work for repeated fields", () {
     // It would be confusing to copy the values.
-    var rec = pb.Rec();
+    final rec = pb.Rec();
     expect(() {
       rec.addAll({
         'nums': [1, 2, 3]

--- a/protoc_plugin/test/message_generator_test.dart
+++ b/protoc_plugin/test/message_generator_test.dart
@@ -73,13 +73,13 @@ void main() {
       ..enumType.add(ed);
   });
   test('testMessageGenerator', () {
-    var options = parseGenerationOptions(
+    final options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
 
-    var fg = FileGenerator(fd, options);
-    var mg = MessageGenerator.topLevel(md, fg, {}, null, <String>{}, 0);
+    final fg = FileGenerator(fd, options);
+    final mg = MessageGenerator.topLevel(md, fg, {}, null, <String>{}, 0);
 
-    var ctx = GenerationContext(options);
+    final ctx = GenerationContext(options);
     mg.register(ctx);
     mg.resolve(ctx);
 
@@ -98,20 +98,20 @@ void main() {
   });
 
   test('testMetadataIndices', () {
-    var options = parseGenerationOptions(
+    final options = parseGenerationOptions(
         CodeGeneratorRequest(), CodeGeneratorResponse())!;
-    var fg = FileGenerator(fd, options);
-    var mg = MessageGenerator.topLevel(md, fg, {}, null, <String>{}, 0);
+    final fg = FileGenerator(fd, options);
+    final mg = MessageGenerator.topLevel(md, fg, {}, null, <String>{}, 0);
 
-    var ctx = GenerationContext(options);
+    final ctx = GenerationContext(options);
     mg.register(ctx);
     mg.resolve(ctx);
 
-    var writer = IndentingWriter(filename: '');
+    final writer = IndentingWriter(filename: '');
     mg.generate(writer);
 
-    var eq = ListEquality();
-    var fieldStringsMap = HashMap(
+    final eq = ListEquality();
+    final fieldStringsMap = HashMap(
         equals: eq.equals, hashCode: eq.hash, isValidKey: eq.isValidKey);
     fieldStringsMap[[4, 0]] = ['PhoneNumber'];
     fieldStringsMap[[4, 0, 2, 0]] = ['type', 'hasType', 'clearType'];
@@ -123,12 +123,12 @@ void main() {
       'clearDeprecatedField'
     ];
 
-    var generatedContents = writer.toString();
-    var metadata = writer.sourceLocationInfo;
-    for (var annotation in metadata.annotation) {
-      var annotatedName =
+    final generatedContents = writer.toString();
+    final metadata = writer.sourceLocationInfo;
+    for (final annotation in metadata.annotation) {
+      final annotatedName =
           generatedContents.substring(annotation.begin, annotation.end);
-      var expectedStrings = fieldStringsMap[annotation.path];
+      final expectedStrings = fieldStringsMap[annotation.path];
       if (expectedStrings == null) {
         fail('The field path ${annotation.path} '
             'did not match any expected field path.');

--- a/protoc_plugin/test/message_test.dart
+++ b/protoc_plugin/test/message_test.dart
@@ -13,22 +13,22 @@ import '../out/protos/google/protobuf/unittest.pbjson.dart';
 import 'test_util.dart';
 
 void main() {
-  var testRequiredUninitialized = TestRequired();
+  final testRequiredUninitialized = TestRequired();
 
-  var testRequiredInitialized = TestRequired()
+  final testRequiredInitialized = TestRequired()
     ..a = 1
     ..b = 2
     ..c = 3;
 
   test('testMergeFrom', () {
-    var mergeSource = TestAllTypes()
+    final mergeSource = TestAllTypes()
       ..optionalInt32 = 1
       ..optionalString = 'foo'
       ..optionalForeignMessage = ForeignMessage()
       ..optionalNestedMessage = (TestAllTypes_NestedMessage()..i = 42)
       ..repeatedString.add('bar');
 
-    var mergeDest = TestAllTypes()
+    final mergeDest = TestAllTypes()
       ..optionalInt64 = make64(2)
       ..optionalString = 'baz'
       ..optionalForeignMessage = ForeignMessage()
@@ -36,7 +36,7 @@ void main() {
       ..optionalNestedMessage = (TestAllTypes_NestedMessage()..bb = 43)
       ..repeatedString.add('qux');
 
-    var mergeResultExpected = '''
+    final mergeResultExpected = '''
 optionalInt32: 1
 optionalInt64: 2
 optionalString: baz
@@ -51,7 +51,7 @@ repeatedString: bar
 repeatedString: qux
 ''';
 
-    var result = TestAllTypes()
+    final result = TestAllTypes()
       ..mergeFromMessage(mergeSource)
       ..mergeFromMessage(mergeDest);
 
@@ -59,7 +59,7 @@ repeatedString: qux
   });
 
   test('testRequired', () {
-    var message = TestRequired();
+    final message = TestRequired();
 
     expect(message.isInitialized(), isFalse, reason: 'no required fields set');
     message.a = 1;
@@ -73,7 +73,7 @@ repeatedString: qux
   });
 
   test('testRequiredForeign', () {
-    var message = TestRequiredForeign();
+    final message = TestRequiredForeign();
     expect(message.isInitialized(), isTrue);
 
     message.optionalMessage = testRequiredUninitialized;
@@ -90,7 +90,7 @@ repeatedString: qux
   });
 
   test('testRequiredExtension', () {
-    var message = TestAllExtensions();
+    final message = TestAllExtensions();
     expect(message.isInitialized(), isTrue);
 
     message.setExtension(TestRequired.single, testRequiredUninitialized);
@@ -117,13 +117,13 @@ repeatedString: qux
 
   test('testBuildPartial', () {
     // We're mostly testing that no exception is thrown.
-    var message = TestRequired();
+    final message = TestRequired();
     expect(message.isInitialized(), isFalse);
   });
 
   test('testNestedUninitializedException', () {
     try {
-      var message = TestRequiredForeign();
+      final message = TestRequiredForeign();
       message.optionalMessage = testRequiredUninitialized;
       message.repeatedMessage.add(testRequiredUninitialized);
       message.repeatedMessage.add(testRequiredUninitialized);
@@ -150,7 +150,7 @@ repeatedString: qux
 
   test('testBuildNestedPartial', () {
     // We're mostly testing that no exception is thrown.
-    var message = TestRequiredForeign();
+    final message = TestRequiredForeign();
     message.optionalMessage = testRequiredUninitialized;
     message.repeatedMessage.add(testRequiredUninitialized);
     message.repeatedMessage.add(testRequiredUninitialized);
@@ -167,11 +167,11 @@ repeatedString: qux
   });
 
   test('testParseNestedUnititialized', () {
-    var message = TestRequiredForeign();
+    final message = TestRequiredForeign();
     message.optionalMessage = testRequiredUninitialized;
     message.repeatedMessage.add(testRequiredUninitialized);
     message.repeatedMessage.add(testRequiredUninitialized);
-    List<int> buffer = message.writeToBuffer();
+    final List<int> buffer = message.writeToBuffer();
 
     try {
       (TestRequiredForeign.fromBuffer(buffer)).check();
@@ -197,7 +197,7 @@ repeatedString: qux
 
   test('testClearField', () {
     int fieldNo;
-    var message = TestAllTypes();
+    final message = TestAllTypes();
 
     // Singular field with no default.
     fieldNo = 1;
@@ -243,7 +243,7 @@ repeatedString: qux
   });
 
   test('Can read JSON constant into DescriptorProto', () {
-    var d = DescriptorProto()..mergeFromJsonMap(TestAllTypes$json);
+    final d = DescriptorProto()..mergeFromJsonMap(TestAllTypes$json);
     expect(d.name, 'TestAllTypes');
     expect(d.field[0].name, 'optional_int32');
     expect(d.nestedType[0].name, 'NestedMessage');

--- a/protoc_plugin/test/mirror_util.dart
+++ b/protoc_plugin/test/mirror_util.dart
@@ -7,23 +7,23 @@ import 'dart:mirrors';
 /// Returns the names of the public properties and non-static methods of a
 /// class. Also visits its superclasses, recursively.
 Set<String> findMemberNames(String importName, Symbol classSymbol) {
-  var lib = currentMirrorSystem().libraries[Uri.parse(importName)]!;
+  final lib = currentMirrorSystem().libraries[Uri.parse(importName)]!;
   var cls = lib.declarations[classSymbol] as ClassMirror?;
 
-  var result = <String>{};
+  final result = <String>{};
 
   void addNames(ClassMirror cls) {
-    var prefixToRemove = '${MirrorSystem.getName(cls.simpleName)}.';
+    final prefixToRemove = '${MirrorSystem.getName(cls.simpleName)}.';
 
     String chooseName(Symbol sym) {
-      var name = MirrorSystem.getName(sym);
+      final name = MirrorSystem.getName(sym);
       if (name.startsWith(prefixToRemove)) {
         return name.substring(prefixToRemove.length);
       }
       return name;
     }
 
-    for (var decl in cls.declarations.values) {
+    for (final decl in cls.declarations.values) {
       if (!decl.isPrivate &&
           decl is! VariableMirror &&
           decl is! TypeVariableMirror &&

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -21,7 +21,7 @@ class _ToStringMatcher extends CustomMatcher {
 
 void main() {
   test('Can access a field that was renamed using dart_name option', () {
-    var msg = pb.DartName();
+    final msg = pb.DartName();
     expect(msg.hasRenamedField(), false);
     msg.renamedField = 'test';
     expect(msg.hasRenamedField(), true);
@@ -31,13 +31,13 @@ void main() {
   });
 
   test('Can access a filed started with underscore and digit', () {
-    var msg = pb.UnderscoreDigitName();
+    final msg = pb.UnderscoreDigitName();
     msg.x3d = 'one';
     expect(msg.getField(1), 'one');
   });
 
   test('Can swap field names using dart_name option', () {
-    var msg = pb.SwapNames();
+    final msg = pb.SwapNames();
     msg.first = 'one';
     msg.second = 'two';
     expect(msg.getField(1), 'two');
@@ -45,7 +45,7 @@ void main() {
   });
 
   test("Can take another field's name using dart_name option", () {
-    var msg = pb.TakeExistingName();
+    final msg = pb.TakeExistingName();
     msg.first = 'one';
     expect(msg.getField(2), 'one');
     msg.first_1 = 'renamed';
@@ -53,7 +53,7 @@ void main() {
   });
 
   test('Throws exception for dart_name option containing a space', () {
-    var descriptor = DescriptorProto()
+    final descriptor = DescriptorProto()
       ..name = 'Example'
       ..field.add(stringField('first', 1, 'hello world'));
     expect(() {
@@ -64,7 +64,7 @@ void main() {
   });
 
   test('Throws exception for dart_name option set to reserved word', () {
-    var descriptor = DescriptorProto()
+    final descriptor = DescriptorProto()
       ..name = 'Example'
       ..field.add(stringField('first', 1, 'class'));
     expect(() {
@@ -75,7 +75,7 @@ void main() {
   });
 
   test('Throws exception for duplicate dart_name options', () {
-    var descriptor = DescriptorProto()
+    final descriptor = DescriptorProto()
       ..name = 'Example'
       ..field.addAll([
         stringField('first', 1, 'renamed'),
@@ -150,20 +150,20 @@ void main() {
   });
 
   test('oneof names no disambiguation', () {
-    var oneofDescriptor = oneofField('foo');
-    var descriptor = DescriptorProto()
+    final oneofDescriptor = oneofField('foo');
+    final descriptor = DescriptorProto()
       ..name = 'Parent'
       ..field.addAll([stringFieldOneof('first', 1, 0)])
       ..oneofDecl.add(oneofDescriptor);
 
-    var usedTopLevelNames = <String>{};
-    var memberNames =
+    final usedTopLevelNames = <String>{};
+    final memberNames =
         names.messageMemberNames(descriptor, 'Parent', usedTopLevelNames);
 
     expect(usedTopLevelNames.length, 1);
     expect(usedTopLevelNames, {'Parent_Foo'});
     expect(memberNames.oneofNames.length, 1);
-    var oneof = memberNames.oneofNames[0];
+    final oneof = memberNames.oneofNames[0];
     expect(oneof.descriptor, oneofDescriptor);
     expect(oneof.index, 0);
     expect(oneof.oneofEnumName, 'Parent_Foo');
@@ -173,21 +173,21 @@ void main() {
   });
 
   test('oneof names disambiguate method names', () {
-    var oneofDescriptor = oneofField('foo');
-    var descriptor = DescriptorProto()
+    final oneofDescriptor = oneofField('foo');
+    final descriptor = DescriptorProto()
       ..name = 'Parent'
       ..field.addAll([stringFieldOneof('first', 1, 0)])
       ..oneofDecl.add(oneofDescriptor);
 
-    var usedTopLevelNames = <String>{};
-    var memberNames = names.messageMemberNames(
+    final usedTopLevelNames = <String>{};
+    final memberNames = names.messageMemberNames(
         descriptor, 'Parent', usedTopLevelNames,
         reserved: ['clearFoo']);
 
     expect(usedTopLevelNames.length, 1);
     expect(usedTopLevelNames, {'Parent_Foo'});
     expect(memberNames.oneofNames.length, 1);
-    var oneof = memberNames.oneofNames[0];
+    final oneof = memberNames.oneofNames[0];
     expect(oneof.descriptor, oneofDescriptor);
     expect(oneof.index, 0);
     expect(oneof.oneofEnumName, 'Parent_Foo');
@@ -197,20 +197,20 @@ void main() {
   });
 
   test('oneof names disambiguate top level name', () {
-    var oneofDescriptor = oneofField('foo');
-    var descriptor = DescriptorProto()
+    final oneofDescriptor = oneofField('foo');
+    final descriptor = DescriptorProto()
       ..name = 'Parent'
       ..field.addAll([stringFieldOneof('first', 1, 0)])
       ..oneofDecl.add(oneofDescriptor);
 
-    var usedTopLevelNames = {'Parent_Foo'};
-    var memberNames =
+    final usedTopLevelNames = {'Parent_Foo'};
+    final memberNames =
         names.messageMemberNames(descriptor, 'Parent', usedTopLevelNames);
 
     expect(usedTopLevelNames.length, 2);
     expect(usedTopLevelNames, {'Parent_Foo', 'Parent_Foo_'});
     expect(memberNames.oneofNames.length, 1);
-    var oneof = memberNames.oneofNames[0];
+    final oneof = memberNames.oneofNames[0];
     expect(oneof.descriptor, oneofDescriptor);
     expect(oneof.index, 0);
     expect(oneof.oneofEnumName, 'Parent_Foo_');

--- a/protoc_plugin/test/omit_field_names_test.dart
+++ b/protoc_plugin/test/omit_field_names_test.dart
@@ -11,7 +11,7 @@ String constant() => 'SHOULD_BE_PRESENT';
 
 Future<void> main() async {
   test('field name available depending on environment', () {
-    var proto = TestAllTypes()..optionalForeignMessage = ForeignMessage();
+    final proto = TestAllTypes()..optionalForeignMessage = ForeignMessage();
 
     expect(
         proto.toString(),

--- a/protoc_plugin/test/oneof_test.dart
+++ b/protoc_plugin/test/oneof_test.dart
@@ -9,12 +9,12 @@ import '../out/protos/oneof.pb.dart';
 
 void main() {
   test('empty oneof', () {
-    var foo = Foo();
+    final foo = Foo();
     expectOneofNotSet(foo);
   });
 
   test('set oneof', () {
-    var foo = Foo();
+    final foo = Foo();
     foo.first = 'oneof';
     expectFirstSet(foo);
 
@@ -83,7 +83,7 @@ void main() {
   });
 
   test('set and clear oneof', () {
-    var foo = Foo()..first = 'oneof';
+    final foo = Foo()..first = 'oneof';
     expectFirstSet(foo);
 
     foo.clearOneofField();
@@ -117,10 +117,10 @@ void main() {
     var foo = Foo()..first = 'oneof';
     expectFirstSet(foo);
 
-    var foo2 = Foo()..second = 1;
+    final foo2 = Foo()..second = 1;
     expectSecondSet(foo2);
 
-    var concat = [...foo.writeToBuffer(), ...foo2.writeToBuffer()];
+    final concat = [...foo.writeToBuffer(), ...foo2.writeToBuffer()];
     foo = Foo.fromBuffer(concat);
     expectSecondSet(foo);
   });
@@ -129,10 +129,10 @@ void main() {
     var foo = Foo()..first = 'oneof';
     expectFirstSet(foo);
 
-    var foo2 = Foo()..second = 1;
+    final foo2 = Foo()..second = 1;
     expectSecondSet(foo2);
 
-    var jsonConcat =
+    final jsonConcat =
         '${foo2.writeToJson().substring(0, foo2.writeToJson().length - 1)}, '
         '${foo.writeToJson().substring(1)}';
     foo = Foo.fromJson(jsonConcat);
@@ -140,7 +140,7 @@ void main() {
   });
 
   test('set and clear second oneof field', () {
-    var foo = Foo();
+    final foo = Foo();
     expectOneofNotSet(foo);
 
     foo.red = 'r';
@@ -159,22 +159,22 @@ void main() {
   });
 
   test('copyWith preserves oneof state', () {
-    var foo = Foo();
+    final foo = Foo();
     expectOneofNotSet(foo);
     // `ignore` below to work around https://github.com/dart-lang/sdk/issues/48879
-    var copy1 =
+    final copy1 =
         foo.deepCopy().freeze().rebuild((_) {}) as Foo; // ignore: unused_result
     expectOneofNotSet(copy1);
     foo.first = 'oneof';
     expectFirstSet(foo);
     // `ignore` below to work around https://github.com/dart-lang/sdk/issues/48879
-    var copy2 =
+    final copy2 =
         foo.deepCopy().freeze().rebuild((_) {}) as Foo; // ignore: unused_result
     expectFirstSet(copy2);
   });
 
   test('oneof semantics is preserved when using ensure method', () {
-    var foo = Foo();
+    final foo = Foo();
     foo.first = 'oneof';
     expectFirstSet(foo);
     foo.ensureIndex();

--- a/protoc_plugin/test/proto3_json_test.dart
+++ b/protoc_plugin/test/proto3_json_test.dart
@@ -140,7 +140,7 @@ void main() {
     });
 
     test('testUnsignedOutput', () {
-      var message = TestAllTypes();
+      final message = TestAllTypes();
       // These values are selected because they are large enough to set the sign bit.
       message.optionalUint64 = Int64.parseHex('f0000000ffff0000');
       message.optionalFixed64 = Int64.parseHex('f0000000ffff0001');
@@ -153,7 +153,7 @@ void main() {
 
     test('doubles', () {
       void testValue(double value, Object expected) {
-        var message = TestAllTypes()
+        final message = TestAllTypes()
           ..defaultFloat = value
           ..defaultDouble = value;
         expect(
@@ -170,7 +170,7 @@ void main() {
     });
 
     test('map value', () {
-      var message = TestMap()
+      final message = TestMap()
         ..int32ToInt32Field[32] = 32
         ..int32ToStringField[0] = 'foo'
         ..int32ToStringField[1] = 'bar'
@@ -725,7 +725,7 @@ void main() {
     });
 
     test('map value', () {
-      var expected = TestMap()
+      final expected = TestMap()
         ..int32ToInt32Field[32] = 32
         ..int32ToStringField[0] = 'foo'
         ..int32ToStringField[1] = 'bar'
@@ -1256,14 +1256,14 @@ void main() {
   group('Convert Double', () {
     test('With Decimal', () {
       final json = {'optionalDouble': 1.2};
-      var proto = TestAllTypes()..optionalDouble = 1.2;
+      final proto = TestAllTypes()..optionalDouble = 1.2;
       expect(TestAllTypes()..mergeFromProto3Json(json), proto);
       expect(proto.toProto3Json(), json);
     });
 
     test('Whole Number', () {
       final json = {'optionalDouble': 5};
-      var proto = TestAllTypes()..optionalDouble = 5.0;
+      final proto = TestAllTypes()..optionalDouble = 5.0;
       expect(TestAllTypes()..mergeFromProto3Json(json), proto);
       expect(proto.toProto3Json(), json);
       expect(jsonEncode(proto.toProto3Json()), '{"optionalDouble":5}');
@@ -1271,14 +1271,14 @@ void main() {
 
     test('Infinity', () {
       final json = {'optionalDouble': 'Infinity'};
-      var proto = TestAllTypes()..optionalDouble = double.infinity;
+      final proto = TestAllTypes()..optionalDouble = double.infinity;
       expect(TestAllTypes()..mergeFromProto3Json(json), proto);
       expect(proto.toProto3Json(), json);
     });
 
     test('Negative Infinity', () {
       final json = {'optionalDouble': '-Infinity'};
-      var proto = TestAllTypes()..optionalDouble = double.negativeInfinity;
+      final proto = TestAllTypes()..optionalDouble = double.negativeInfinity;
       expect(TestAllTypes()..mergeFromProto3Json(json), proto);
       expect(proto.toProto3Json(), json);
     });

--- a/protoc_plugin/test/proto3_optional_test.dart
+++ b/protoc_plugin/test/proto3_optional_test.dart
@@ -10,7 +10,7 @@ import '../out/protos/proto3_optional.pb.dart';
 
 void main() {
   test('optional fields have presence', () {
-    var f = Foo();
+    final f = Foo();
     expect(f.hasOptionalSubmessage(), isFalse);
     f.optionalSubmessage = Submessage();
     expect(f.hasOptionalSubmessage(), isTrue);

--- a/protoc_plugin/test/protoc_options_test.dart
+++ b/protoc_plugin/test/protoc_options_test.dart
@@ -9,10 +9,10 @@ import 'package:test/test.dart';
 void main() {
   test('testValidGeneratorOptions', () {
     void checkValid(String? parameter) {
-      var request = CodeGeneratorRequest();
+      final request = CodeGeneratorRequest();
       if (parameter != null) request.parameter = parameter;
-      var response = CodeGeneratorResponse();
-      var options = parseGenerationOptions(request, response);
+      final response = CodeGeneratorResponse();
+      final options = parseGenerationOptions(request, response);
       expect(options, TypeMatcher<GenerationOptions>());
       expect(response.error, '');
     }
@@ -26,10 +26,10 @@ void main() {
 
   test('testInvalidGeneratorOptions', () {
     void checkInvalid(String parameter) {
-      var request = CodeGeneratorRequest();
+      final request = CodeGeneratorRequest();
       request.parameter = parameter;
-      var response = CodeGeneratorResponse();
-      var options = parseGenerationOptions(request, response);
+      final response = CodeGeneratorResponse();
+      final options = parseGenerationOptions(request, response);
       expect(options, isNull);
     }
 

--- a/protoc_plugin/test/repeated_field_test.dart
+++ b/protoc_plugin/test/repeated_field_test.dart
@@ -9,7 +9,7 @@ import '../out/protos/google/protobuf/unittest.pb.dart';
 
 void main() {
   test('check properties are initialized for repeated fields', () {
-    var msg = TestAllTypes();
+    final msg = TestAllTypes();
     expect(
         (msg.info_.byName['repeatedNestedMessage']
                 as FieldInfo<TestAllTypes_NestedMessage>)

--- a/protoc_plugin/test/reserved_names_test.dart
+++ b/protoc_plugin/test/reserved_names_test.dart
@@ -20,26 +20,26 @@ import 'mirror_util.dart' show findMemberNames;
 
 void main() {
   test('GeneratedMessage reserved names are up to date', () {
-    var actual = Set<String>.from(GeneratedMessage_reservedNames);
-    var expected =
+    final actual = Set<String>.from(GeneratedMessage_reservedNames);
+    final expected =
         findMemberNames('package:protobuf/protobuf.dart', #GeneratedMessage);
 
     expect(actual.toList()..sort(), equals(expected.toList()..sort()));
   });
 
   test('ProtobufEnum reserved names are up to date', () {
-    var actual = Set<String>.from(ProtobufEnum_reservedNames);
-    var expected =
+    final actual = Set<String>.from(ProtobufEnum_reservedNames);
+    final expected =
         findMemberNames('package:protobuf/protobuf.dart', #ProtobufEnum);
 
     expect(actual.toList()..sort(), equals(expected.toList()..sort()));
   });
 
   test("ReadonlyMessageMixin doesn't add any reserved names", () {
-    var mixinNames = findMemberNames(
+    final mixinNames = findMemberNames(
         'package:protobuf/protobuf.dart', #ReadonlyMessageMixin);
-    var reservedNames = Set<String>.from(GeneratedMessage_reservedNames);
-    for (var name in mixinNames) {
+    final reservedNames = Set<String>.from(GeneratedMessage_reservedNames);
+    for (final name in mixinNames) {
       if (name == 'ReadonlyMessageMixin' || name == 'unknownFields') continue;
       if (!reservedNames.contains(name)) {
         fail('name from ReadonlyMessageMixin is not reserved: $name');
@@ -48,10 +48,10 @@ void main() {
   });
 
   test('PbMapMixin reserved names are up to date', () {
-    var meta = findMixin('PbMapMixin')!;
-    var actual = Set<String>.from(meta.findReservedNames());
+    final meta = findMixin('PbMapMixin')!;
+    final actual = Set<String>.from(meta.findReservedNames());
 
-    var expected = findMemberNames(meta.importFrom, #PbMapMixin)
+    final expected = findMemberNames(meta.importFrom, #PbMapMixin)
       ..addAll(findMemberNames('dart:collection', #MapMixin))
       ..removeAll(GeneratedMessage_reservedNames);
 
@@ -60,10 +60,10 @@ void main() {
   });
 
   test('PbEventMixin reserved names are up to date', () {
-    var meta = findMixin('PbEventMixin')!;
-    var actual = Set<String>.from(meta.findReservedNames());
+    final meta = findMixin('PbEventMixin')!;
+    final actual = Set<String>.from(meta.findReservedNames());
 
-    var expected = findMemberNames(meta.importFrom, #PbEventMixin)
+    final expected = findMemberNames(meta.importFrom, #PbEventMixin)
       ..removeAll(GeneratedMessage_reservedNames);
 
     expect(actual.toList()..sort(), equals(expected.toList()..sort()));

--- a/protoc_plugin/test/service_generator_test.dart
+++ b/protoc_plugin/test/service_generator_test.dart
@@ -13,19 +13,19 @@ import 'service_util.dart';
 
 void main() {
   test('testServiceGenerator', () {
-    var options = GenerationOptions();
-    var fd = buildFileDescriptor(
+    final options = GenerationOptions();
+    final fd = buildFileDescriptor(
         'testpkg', 'testpkg.proto', ['SomeRequest', 'SomeReply']);
     fd.service.add(buildServiceDescriptor());
-    var fg = FileGenerator(fd, options);
+    final fg = FileGenerator(fd, options);
 
-    var fd2 = buildFileDescriptor(
+    final fd2 = buildFileDescriptor(
         'foo.bar', 'foobar.proto', ['EmptyMessage', 'AnotherReply']);
-    var fg2 = FileGenerator(fd2, options);
+    final fg2 = FileGenerator(fd2, options);
 
     link(GenerationOptions(), [fg, fg2]);
 
-    var serviceWriter = IndentingWriter();
+    final serviceWriter = IndentingWriter();
     fg.serviceGenerators[0].generate(serviceWriter);
     expectMatchesGoldenFile(
         serviceWriter.toString(), 'test/goldens/serviceGenerator');

--- a/protoc_plugin/test/service_test.dart
+++ b/protoc_plugin/test/service_test.dart
@@ -11,7 +11,7 @@ class SearchService extends pb.SearchServiceBase {
   @override
   Future<pb.SearchResponse> search(
       ServerContext ctx, pb.SearchRequest request) async {
-    var out = pb.SearchResponse();
+    final out = pb.SearchResponse();
     if (request.query == 'hello' || request.query == 'world') {
       out.result.add('hello, world!');
     }
@@ -21,9 +21,9 @@ class SearchService extends pb.SearchServiceBase {
   @override
   Future<pb2.SearchResponse> search2(
       ServerContext ctx, pb2.SearchRequest request) async {
-    var out = pb2.SearchResponse();
+    final out = pb2.SearchResponse();
     if (request.query == '2') {
-      var result = pb3.SearchResult()
+      final result = pb3.SearchResult()
         ..url = 'http://example.com/'
         ..snippet = 'hello world (2)!';
       out.results.add(result);
@@ -39,10 +39,10 @@ class FakeJsonServer {
   Future<String> messageHandler(
       String serviceName, String methodName, String requestJson) async {
     if (serviceName == 'SearchService') {
-      var request = searchService.createRequest(methodName);
+      final request = searchService.createRequest(methodName);
       request.mergeFromJson(requestJson);
-      var ctx = ServerContext();
-      var reply = await searchService.handleCall(ctx, methodName, request);
+      final ctx = ServerContext();
+      final reply = await searchService.handleCall(ctx, methodName, request);
       return reply.writeToJson();
     } else {
       throw 'unknown service: $serviceName';
@@ -62,8 +62,8 @@ class FakeJsonClient implements RpcClient {
       String methodName,
       GeneratedMessage request,
       T response) async {
-    var requestJson = request.writeToJson();
-    var replyJson =
+    final requestJson = request.writeToJson();
+    final replyJson =
         await server.messageHandler(serviceName, methodName, requestJson);
     response.mergeFromJson(replyJson);
     return response;
@@ -71,33 +71,34 @@ class FakeJsonClient implements RpcClient {
 }
 
 void main() {
-  var service = SearchService();
-  var server = FakeJsonServer(service);
-  var api = pb.SearchServiceApi(FakeJsonClient(server));
+  final service = SearchService();
+  final server = FakeJsonServer(service);
+  final api = pb.SearchServiceApi(FakeJsonClient(server));
 
   test('end to end RPC using JSON', () async {
-    var request = pb.SearchRequest()..query = 'hello';
-    var reply = await api.search(ClientContext(), request);
+    final request = pb.SearchRequest()..query = 'hello';
+    final reply = await api.search(ClientContext(), request);
     expect(reply.result, ['hello, world!']);
   });
 
   test('end to end RPC using message from a different package', () async {
-    var request = pb2.SearchRequest()..query = '2';
-    var reply = await api.search2(ClientContext(), request);
+    final request = pb2.SearchRequest()..query = '2';
+    final reply = await api.search2(ClientContext(), request);
     expect(reply.results.length, 1);
     expect(reply.results[0].url, 'http://example.com/');
     expect(reply.results[0].snippet, 'hello world (2)!');
   });
 
   test('can read service descriptor from JSON', () {
-    var descriptor = ServiceDescriptorProto()..mergeFromJsonMap(service.$json);
+    final descriptor = ServiceDescriptorProto()
+      ..mergeFromJsonMap(service.$json);
     expect(descriptor.name, 'SearchService');
-    var methodNames = descriptor.method.map((m) => m.name).toList();
+    final methodNames = descriptor.method.map((m) => m.name).toList();
     expect(methodNames, ['Search', 'Search2']);
   });
 
   test('can read message descriptors from JSON', () {
-    var map = service.$messageJson;
+    final map = service.$messageJson;
     expect(map.keys, [
       '.service.SearchRequest',
       '.service.SearchResponse',
@@ -107,8 +108,8 @@ void main() {
     ]);
 
     String readMessageName(fqname) {
-      var json = map[fqname]!;
-      var descriptor = DescriptorProto()..mergeFromJsonMap(json);
+      final json = map[fqname]!;
+      final descriptor = DescriptorProto()..mergeFromJsonMap(json);
       return descriptor.name;
     }
 

--- a/protoc_plugin/test/service_util.dart
+++ b/protoc_plugin/test/service_util.dart
@@ -5,7 +5,7 @@
 import 'package:protoc_plugin/src/generated/descriptor.pb.dart';
 
 ServiceDescriptorProto buildServiceDescriptor() {
-  var sd = ServiceDescriptorProto()
+  final sd = ServiceDescriptorProto()
     ..name = 'Test'
     ..method.addAll([
       MethodDescriptorProto()
@@ -22,11 +22,11 @@ ServiceDescriptorProto buildServiceDescriptor() {
 
 FileDescriptorProto buildFileDescriptor(
     String package, String fileUri, List<String> messages) {
-  var fd = FileDescriptorProto()
+  final fd = FileDescriptorProto()
     ..package = package
     ..name = fileUri;
-  for (var name in messages) {
-    var md = DescriptorProto()..name = name;
+  for (final name in messages) {
+    final md = DescriptorProto()..name = name;
 
     fd.messageType.add(md);
   }

--- a/protoc_plugin/test/test_util.dart
+++ b/protoc_plugin/test/test_util.dart
@@ -1265,7 +1265,7 @@ void assertUnpackedFieldsSet(TestUnpackedTypes message) {
 }
 
 TestAllExtensions getAllExtensionsSet() {
-  var message = TestAllExtensions();
+  final message = TestAllExtensions();
   setAllExtensions(message);
   return message;
 }
@@ -1273,31 +1273,31 @@ TestAllExtensions getAllExtensionsSet() {
 // Get a [TestAllTypes] with all fields set as they would
 // be by [setAllFields(TestAllTypes)].
 TestAllTypes getAllSet() {
-  var message = TestAllTypes();
+  final message = TestAllTypes();
   setAllFields(message);
   return message;
 }
 
 ExtensionRegistry getExtensionRegistry() {
-  var registry = ExtensionRegistry();
+  final registry = ExtensionRegistry();
   registerAllExtensions(registry);
   return registry /*.getUnmodifiable()*/;
 }
 
 TestPackedExtensions getPackedExtensionsSet() {
-  var message = TestPackedExtensions();
+  final message = TestPackedExtensions();
   setPackedExtensions(message);
   return message;
 }
 
 TestPackedTypes getPackedSet() {
-  var message = TestPackedTypes();
+  final message = TestPackedTypes();
   setPackedFields(message);
   return message;
 }
 
 TestUnpackedTypes getUnpackedSet() {
-  var message = TestUnpackedTypes();
+  final message = TestUnpackedTypes();
   setUnpackedFields(message);
   return message;
 }
@@ -1367,19 +1367,19 @@ void modifyRepeatedFields(TestAllTypes message) {
   message.repeatedString[1] = '515';
   message.repeatedBytes[1] = '516'.codeUnits;
 
-  var repeatedGroup = TestAllTypes_RepeatedGroup();
+  final repeatedGroup = TestAllTypes_RepeatedGroup();
   repeatedGroup.a = 517;
   message.repeatedGroup[1] = repeatedGroup;
 
-  var optionalNestedMessage = TestAllTypes_NestedMessage();
+  final optionalNestedMessage = TestAllTypes_NestedMessage();
   optionalNestedMessage.bb = 518;
   message.repeatedNestedMessage[1] = optionalNestedMessage;
 
-  var optionalForeignMessage = ForeignMessage();
+  final optionalForeignMessage = ForeignMessage();
   optionalForeignMessage.c = 519;
   message.repeatedForeignMessage[1] = optionalForeignMessage;
 
-  var optionalImportMessage = ImportMessage();
+  final optionalImportMessage = ImportMessage();
   optionalImportMessage.d = 520;
   message.repeatedImportMessage[1] = optionalImportMessage;
 
@@ -1412,19 +1412,19 @@ void setAllExtensions(TestAllExtensions message) {
   message.setExtension(Unittest.optionalStringExtension, '115');
   message.setExtension(Unittest.optionalBytesExtension, '116'.codeUnits);
 
-  var msg = OptionalGroup_extension();
+  final msg = OptionalGroup_extension();
   msg.a = 117;
   message.setExtension(Unittest.optionalGroupExtension, msg);
 
-  var msg2 = TestAllTypes_NestedMessage();
+  final msg2 = TestAllTypes_NestedMessage();
   msg2.bb = 118;
   message.setExtension(Unittest.optionalNestedMessageExtension, msg2);
 
-  var msg3 = ForeignMessage();
+  final msg3 = ForeignMessage();
   msg3.c = 119;
   message.setExtension(Unittest.optionalForeignMessageExtension, msg3);
 
-  var msg4 = ImportMessage();
+  final msg4 = ImportMessage();
   msg4.d = 120;
   message.setExtension(Unittest.optionalImportMessageExtension, msg4);
 
@@ -1456,19 +1456,19 @@ void setAllExtensions(TestAllExtensions message) {
   message.addExtension(Unittest.repeatedStringExtension, '215');
   message.addExtension(Unittest.repeatedBytesExtension, '216'.codeUnits);
 
-  var msg5 = RepeatedGroup_extension();
+  final msg5 = RepeatedGroup_extension();
   msg5.a = 217;
   message.addExtension(Unittest.repeatedGroupExtension, msg5);
 
-  var msg6 = TestAllTypes_NestedMessage();
+  final msg6 = TestAllTypes_NestedMessage();
   msg6.bb = 218;
   message.addExtension(Unittest.repeatedNestedMessageExtension, msg6);
 
-  var msg7 = ForeignMessage();
+  final msg7 = ForeignMessage();
   msg7.c = 219;
   message.addExtension(Unittest.repeatedForeignMessageExtension, msg7);
 
-  var msg8 = ImportMessage();
+  final msg8 = ImportMessage();
   msg8.d = 220;
   message.addExtension(Unittest.repeatedImportMessageExtension, msg8);
 
@@ -1499,19 +1499,19 @@ void setAllExtensions(TestAllExtensions message) {
   message.addExtension(Unittest.repeatedStringExtension, '315');
   message.addExtension(Unittest.repeatedBytesExtension, '316'.codeUnits);
 
-  var msg9 = RepeatedGroup_extension();
+  final msg9 = RepeatedGroup_extension();
   msg9.a = 317;
   message.addExtension(Unittest.repeatedGroupExtension, msg9);
 
-  var msg10 = TestAllTypes_NestedMessage();
+  final msg10 = TestAllTypes_NestedMessage();
   msg10.bb = 318;
   message.addExtension(Unittest.repeatedNestedMessageExtension, msg10);
 
-  var msg11 = ForeignMessage();
+  final msg11 = ForeignMessage();
   msg11.c = 319;
   message.addExtension(Unittest.repeatedForeignMessageExtension, msg11);
 
-  var msg12 = ImportMessage();
+  final msg12 = ImportMessage();
   msg12.d = 320;
   message.addExtension(Unittest.repeatedImportMessageExtension, msg12);
 
@@ -1573,19 +1573,19 @@ void setAllFields(TestAllTypes message) {
   message.optionalString = '115';
   message.optionalBytes = '116'.codeUnits;
 
-  var optionalGroup = TestAllTypes_OptionalGroup();
+  final optionalGroup = TestAllTypes_OptionalGroup();
   optionalGroup.a = 117;
   message.optionalGroup = optionalGroup;
 
-  var optionalNestedMessage = TestAllTypes_NestedMessage();
+  final optionalNestedMessage = TestAllTypes_NestedMessage();
   optionalNestedMessage.bb = 118;
   message.optionalNestedMessage = optionalNestedMessage;
 
-  var optionalForeignMessage = ForeignMessage();
+  final optionalForeignMessage = ForeignMessage();
   optionalForeignMessage.c = 119;
   message.optionalForeignMessage = optionalForeignMessage;
 
-  var optionalImportMessage = ImportMessage();
+  final optionalImportMessage = ImportMessage();
   optionalImportMessage.d = 120;
   message.optionalImportMessage = optionalImportMessage;
 

--- a/protoc_plugin/test/timestamp_test.dart
+++ b/protoc_plugin/test/timestamp_test.dart
@@ -9,15 +9,15 @@ import '../out/protos/google/protobuf/timestamp.pb.dart';
 
 void main() {
   test('timestamp -> datetime -> timestamp', () {
-    var timestamp = Timestamp()
+    final timestamp = Timestamp()
       ..seconds = Int64(1550225928)
       ..nanos = 12345000;
     expect(Timestamp.fromDateTime(timestamp.toDateTime()), timestamp);
   });
 
   test('utc datetime -> timestamp -> datetime', () {
-    var dateTime = DateTime.utc(2019, 02, 15, 10, 21, 25, 5, 5);
-    var fromProto = Timestamp.fromDateTime(dateTime).toDateTime();
+    final dateTime = DateTime.utc(2019, 02, 15, 10, 21, 25, 5, 5);
+    final fromProto = Timestamp.fromDateTime(dateTime).toDateTime();
 
     expect(fromProto.isUtc, true, reason: '$fromProto is not a UTC time.');
     expect(fromProto, dateTime);
@@ -27,7 +27,7 @@ void main() {
     final secondBeforeEpoch = Timestamp()
       ..seconds = Int64(-1)
       ..nanos = 1000000;
-    var dateTime = DateTime.fromMillisecondsSinceEpoch(-999, isUtc: true);
+    final dateTime = DateTime.fromMillisecondsSinceEpoch(-999, isUtc: true);
 
     expect(secondBeforeEpoch.toDateTime().millisecondsSinceEpoch,
         dateTime.millisecondsSinceEpoch);
@@ -37,8 +37,8 @@ void main() {
   });
 
   test('local datetime -> timestamp -> datetime', () {
-    var dateTime = DateTime(2019, 02, 15, 10, 21, 25, 5, 5);
-    var fromProto = Timestamp.fromDateTime(dateTime).toDateTime();
+    final dateTime = DateTime(2019, 02, 15, 10, 21, 25, 5, 5);
+    final fromProto = Timestamp.fromDateTime(dateTime).toDateTime();
 
     expect(fromProto.isUtc, true, reason: '$fromProto is not a UTC time.');
     expect(fromProto, dateTime.toUtc());

--- a/protoc_plugin/test/to_builder_test.dart
+++ b/protoc_plugin/test/to_builder_test.dart
@@ -13,7 +13,7 @@ import '../out/protos/google/protobuf/unittest.pb.dart';
 
 void main() {
   group('frozen and tobuilder', () {
-    var original = Outer()
+    final original = Outer()
       ..inner = (Inner()..value = 'foo')
       ..inners.add(Inner()..value = 'repeatedInner')
       ..setExtension(FooExt.inner, Inner()..value = 'extension')
@@ -136,7 +136,7 @@ void main() {
 
     test('can add fields to a builder with unknown fields', () {
       emptyMessage.freeze();
-      var builder = emptyMessage.toBuilder() as TestEmptyMessage;
+      final builder = emptyMessage.toBuilder() as TestEmptyMessage;
 
       builder.unknownFields
           .addField(2, UnknownFieldSetField()..fixed32s.add(42));
@@ -145,7 +145,7 @@ void main() {
 
     test('cannot mutate already added UnknownFieldSetField on builder', () {
       emptyMessage.freeze();
-      var builder = emptyMessage.toBuilder() as TestEmptyMessage;
+      final builder = emptyMessage.toBuilder() as TestEmptyMessage;
 
       expect(
           () => builder.unknownFields.getField(1)!.lengthDelimited[0] =
@@ -189,7 +189,7 @@ void main() {
 
     test('cannot merge message into a frozen UnknownFieldSet', () {
       emptyMessage.freeze();
-      var other = emptyMessage.deepCopy();
+      final other = emptyMessage.deepCopy();
 
       expect(() => emptyMessage.mergeFromBuffer(other.writeToBuffer()),
           throwsA(TypeMatcher<UnsupportedError>()));

--- a/protoc_plugin/test/unknown_field_set_test.dart
+++ b/protoc_plugin/test/unknown_field_set_test.dart
@@ -9,13 +9,13 @@ import '../out/protos/google/protobuf/unittest.pb.dart';
 import 'test_util.dart';
 
 void main() {
-  var testAllTypes = getAllSet();
-  List<int> allFieldsData = testAllTypes.writeToBuffer();
-  var emptyMessage = TestEmptyMessage.fromBuffer(allFieldsData);
-  var unknownFields = emptyMessage.unknownFields;
+  final testAllTypes = getAllSet();
+  final List<int> allFieldsData = testAllTypes.writeToBuffer();
+  final emptyMessage = TestEmptyMessage.fromBuffer(allFieldsData);
+  final unknownFields = emptyMessage.unknownFields;
 
   UnknownFieldSetField getField(String name) {
-    var tagNumber = testAllTypes.getTagNumber(name)!;
+    final tagNumber = testAllTypes.getTagNumber(name)!;
     assert(unknownFields.hasField(tagNumber));
     return unknownFields.getField(tagNumber)!;
   }
@@ -42,37 +42,37 @@ void main() {
     expect(set, set);
 
     // Object should be equal to a copy of itself.
-    var copy = set.clone();
+    final copy = set.clone();
     expect(copy, set);
     expect(set, copy);
   }
 
   test('testVarint', () {
-    var optionalInt32 = getField('optionalInt32');
+    final optionalInt32 = getField('optionalInt32');
     expect(optionalInt32.varints[0], expect64(testAllTypes.optionalInt32));
   });
 
   test('testFixed32', () {
-    var optionalFixed32 = getField('optionalFixed32');
+    final optionalFixed32 = getField('optionalFixed32');
     expect(optionalFixed32.fixed32s[0], testAllTypes.optionalFixed32);
   });
 
   test('testFixed64', () {
-    var optionalFixed64 = getField('optionalFixed64');
+    final optionalFixed64 = getField('optionalFixed64');
     expect(optionalFixed64.fixed64s[0], testAllTypes.optionalFixed64);
   });
 
   test('testLengthDelimited', () {
-    var optionalBytes = getField('optionalBytes');
+    final optionalBytes = getField('optionalBytes');
     expect(optionalBytes.lengthDelimited[0], testAllTypes.optionalBytes);
   });
 
   test('testGroup', () {
-    var tagNumberA = TestAllTypes_OptionalGroup().getTagNumber('a')!;
+    final tagNumberA = TestAllTypes_OptionalGroup().getTagNumber('a')!;
 
-    var optionalGroupField = getField('optionalgroup');
+    final optionalGroupField = getField('optionalgroup');
     expect(optionalGroupField.groups.length, 1);
-    var group = optionalGroupField.groups[0];
+    final group = optionalGroupField.groups[0];
     expect(group.hasField(tagNumberA), isTrue);
     expect(group.getField(tagNumberA)!.varints[0],
         expect64(testAllTypes.optionalGroup.a));
@@ -83,25 +83,25 @@ void main() {
   });
 
   test('testCopyFrom', () {
-    var message = emptyMessage.deepCopy();
+    final message = emptyMessage.deepCopy();
     expect(message.toString(), emptyMessage.toString());
     expect(emptyMessage.toString().isEmpty, isFalse);
   });
 
   test('testMergeFrom', () {
     // Source.
-    var sourceFieldSet = UnknownFieldSet()
+    final sourceFieldSet = UnknownFieldSet()
       ..addField(2, UnknownFieldSetField()..addVarint(make64(2)))
       ..addField(3, UnknownFieldSetField()..addVarint(make64(3)));
 
-    var source = TestEmptyMessage()..mergeUnknownFields(sourceFieldSet);
+    final source = TestEmptyMessage()..mergeUnknownFields(sourceFieldSet);
 
     // Destination.
-    var destinationFieldSet = UnknownFieldSet()
+    final destinationFieldSet = UnknownFieldSet()
       ..addField(1, UnknownFieldSetField()..addVarint(make64(1)))
       ..addField(3, UnknownFieldSetField()..addVarint(make64(4)));
 
-    var destination = TestEmptyMessage()
+    final destination = TestEmptyMessage()
       ..mergeUnknownFields(destinationFieldSet)
       ..mergeFromMessage(source);
 
@@ -114,7 +114,7 @@ void main() {
   });
 
   test('testClear', () {
-    var fsb = unknownFields.clone()..clear();
+    final fsb = unknownFields.clone()..clear();
     expect(fsb.asMap(), isEmpty);
   });
 
@@ -123,25 +123,25 @@ void main() {
   });
 
   test('testClearMessage', () {
-    var message = emptyMessage.deepCopy();
+    final message = emptyMessage.deepCopy();
     message.clear();
     expect(message.writeToBuffer(), isEmpty);
   });
 
   test('testParseKnownAndUnknown', () {
     // Test mixing known and unknown fields when parsing.
-    var fields = unknownFields.clone()
+    final fields = unknownFields.clone()
       ..addField(123456, UnknownFieldSetField()..addVarint(make64(654321)));
 
-    var writer = CodedBufferWriter();
+    final writer = CodedBufferWriter();
     fields.writeToCodedBufferWriter(writer);
 
-    var destination = TestAllTypes.fromBuffer(writer.toBuffer());
+    final destination = TestAllTypes.fromBuffer(writer.toBuffer());
 
     assertAllFieldsSet(destination);
     expect(destination.unknownFields.asMap().length, 1);
 
-    var field = destination.unknownFields.getField(123456)!;
+    final field = destination.unknownFields.getField(123456)!;
     expect(field.varints.length, 1);
     expect(field.varints[0], expect64(654321));
   });
@@ -150,11 +150,11 @@ void main() {
   // numbers as allFieldsData except that each field is some other wire
   // type.
   List<int> getBizarroData() {
-    var bizarroFields = UnknownFieldSet();
+    final bizarroFields = UnknownFieldSet();
 
-    var varintField = UnknownFieldSetField()..addVarint(make64(1));
+    final varintField = UnknownFieldSetField()..addVarint(make64(1));
 
-    var fixed32Field = UnknownFieldSetField()..addFixed32(1);
+    final fixed32Field = UnknownFieldSetField()..addFixed32(1);
 
     unknownFields.asMap().forEach((int tag, UnknownFieldSetField value) {
       if (value.varints.isEmpty) {
@@ -165,7 +165,7 @@ void main() {
         bizarroFields.addField(tag, fixed32Field);
       }
     });
-    var writer = CodedBufferWriter();
+    final writer = CodedBufferWriter();
     bizarroFields.writeToCodedBufferWriter(writer);
     return writer.toBuffer();
   }
@@ -173,9 +173,9 @@ void main() {
   test('testWrongTypeTreatedAsUnknown', () {
     // Test that fields of the wrong wire type are treated like unknown fields
     // when parsing.
-    var bizarroData = getBizarroData();
-    var allTypesMessage = TestAllTypes.fromBuffer(bizarroData);
-    var emptyMessage_ = TestEmptyMessage.fromBuffer(bizarroData);
+    final bizarroData = getBizarroData();
+    final allTypesMessage = TestAllTypes.fromBuffer(bizarroData);
+    final emptyMessage_ = TestEmptyMessage.fromBuffer(bizarroData);
     // All fields should have been interpreted as unknown, so the debug strings
     // should be the same.
     expect(allTypesMessage.toString(), emptyMessage_.toString());
@@ -184,7 +184,7 @@ void main() {
   test('testUnknownExtensions', () {
     // Make sure fields are properly parsed to the UnknownFieldSet even when
     // they are declared as extension numbers.
-    var message = TestEmptyMessageWithExtensions.fromBuffer(allFieldsData);
+    final message = TestEmptyMessageWithExtensions.fromBuffer(allFieldsData);
 
     expect(message.unknownFields.asMap().length, unknownFields.asMap().length);
     expect(message.writeToBuffer(), allFieldsData);
@@ -194,9 +194,9 @@ void main() {
     // Test that fields of the wrong wire type are treated like unknown fields
     // when parsing extensions.
 
-    var bizarroData = getBizarroData();
-    var allExtensionsMessage = TestAllExtensions.fromBuffer(bizarroData);
-    var emptyMessage_ = TestEmptyMessage.fromBuffer(bizarroData);
+    final bizarroData = getBizarroData();
+    final allExtensionsMessage = TestAllExtensions.fromBuffer(bizarroData);
+    final emptyMessage_ = TestEmptyMessage.fromBuffer(bizarroData);
 
     // All fields should have been interpreted as unknown, so the debug strings
     // should be the same.
@@ -204,12 +204,12 @@ void main() {
   });
 
   test('testParseUnknownEnumValue', () {
-    var singularFieldNum = testAllTypes.getTagNumber('optionalNestedEnum')!;
-    var repeatedFieldNum = testAllTypes.getTagNumber('repeatedNestedEnum')!;
+    final singularFieldNum = testAllTypes.getTagNumber('optionalNestedEnum')!;
+    final repeatedFieldNum = testAllTypes.getTagNumber('repeatedNestedEnum')!;
     expect(singularFieldNum, isNotNull);
     expect(repeatedFieldNum, isNotNull);
 
-    var fieldSet = UnknownFieldSet()
+    final fieldSet = UnknownFieldSet()
       ..addField(
           singularFieldNum,
           UnknownFieldSetField()
@@ -223,10 +223,10 @@ void main() {
             ..addVarint(make64(TestAllTypes_NestedEnum.BAZ.value))
             ..addVarint(make64(6)));
 
-    var writer = CodedBufferWriter();
+    final writer = CodedBufferWriter();
     fieldSet.writeToCodedBufferWriter(writer);
     {
-      var message = TestAllTypes.fromBuffer(writer.toBuffer());
+      final message = TestAllTypes.fromBuffer(writer.toBuffer());
       expect(message.optionalNestedEnum, TestAllTypes_NestedEnum.BAR);
       expect(message.repeatedNestedEnum,
           [TestAllTypes_NestedEnum.FOO, TestAllTypes_NestedEnum.BAZ]);
@@ -241,7 +241,7 @@ void main() {
       expect(repeatedVarints[1], expect64(6));
     }
     {
-      var message = TestAllExtensions.fromBuffer(
+      final message = TestAllExtensions.fromBuffer(
           writer.toBuffer(), getExtensionRegistry());
       expect(message.getExtension(Unittest.optionalNestedEnumExtension),
           TestAllTypes_NestedEnum.BAR);
@@ -261,33 +261,33 @@ void main() {
   });
 
   test('testLargeVarint', () {
-    var unknownFieldSet = UnknownFieldSet()
+    final unknownFieldSet = UnknownFieldSet()
       ..addField(
           1, UnknownFieldSetField()..addVarint(make64(0x7FFFFFFF, 0xFFFFFFFF)));
-    var writer = CodedBufferWriter();
+    final writer = CodedBufferWriter();
     unknownFieldSet.writeToCodedBufferWriter(writer);
 
-    var parsed = UnknownFieldSet()
+    final parsed = UnknownFieldSet()
       ..mergeFromCodedBufferReader(CodedBufferReader(writer.toBuffer()));
-    var field = parsed.getField(1)!;
+    final field = parsed.getField(1)!;
     expect(field.varints.length, 1);
     expect(field.varints[0], expect64(0x7FFFFFFF, 0xFFFFFFFFF));
   });
 
   test('testEquals', () {
-    var a = UnknownFieldSet()
+    final a = UnknownFieldSet()
       ..addField(1, UnknownFieldSetField()..addFixed32(1));
 
-    var b = UnknownFieldSet()
+    final b = UnknownFieldSet()
       ..addField(1, UnknownFieldSetField()..addFixed64(make64(1)));
 
-    var c = UnknownFieldSet()
+    final c = UnknownFieldSet()
       ..addField(1, UnknownFieldSetField()..addVarint(make64(1)));
 
-    var d = UnknownFieldSet()
+    final d = UnknownFieldSet()
       ..addField(1, UnknownFieldSetField()..addLengthDelimited([]));
 
-    var e = UnknownFieldSet()
+    final e = UnknownFieldSet()
       ..addField(1, UnknownFieldSetField()..addGroup(unknownFields));
 
     checkEqualsIsConsistent(a);
@@ -307,9 +307,9 @@ void main() {
     checkNotEqual(c, e);
     checkNotEqual(d, e);
 
-    var f1 = UnknownFieldSet()
+    final f1 = UnknownFieldSet()
       ..addField(1, UnknownFieldSetField()..addLengthDelimited([1, 2]));
-    var f2 = UnknownFieldSet()
+    final f2 = UnknownFieldSet()
       ..addField(1, UnknownFieldSetField()..addLengthDelimited([2, 1]));
 
     checkEqualsIsConsistent(f1);

--- a/protoc_plugin/test/validate_fail_test.dart
+++ b/protoc_plugin/test/validate_fail_test.dart
@@ -8,7 +8,7 @@ import '../out/protos/google/protobuf/unittest.pb.dart';
 
 void main() {
   test('testValidationFailureMessages', () {
-    var builder = TestAllTypes();
+    final builder = TestAllTypes();
 
     expect(() {
       builder.optionalInt32 = -2147483649;

--- a/protoc_plugin/test/wire_format_test.dart
+++ b/protoc_plugin/test/wire_format_test.dart
@@ -32,16 +32,16 @@ void main() {
     // TestAllTypes and TestAllExtensions should have compatible wire formats,
     // so if we serialize a TestAllTypes then parse it as TestAllExtensions
     // it should work.
-    List<int> rawBytes = getAllSet().writeToBuffer();
-    var registry = getExtensionRegistry();
+    final List<int> rawBytes = getAllSet().writeToBuffer();
+    final registry = getExtensionRegistry();
 
     assertAllExtensionsSet(TestAllExtensions.fromBuffer(rawBytes, registry));
   });
 
   test('testParsePackedExtensions', () {
     // Ensure that packed extensions can be properly parsed.
-    List<int> rawBytes = getPackedExtensionsSet().writeToBuffer();
-    var registry = getExtensionRegistry();
+    final List<int> rawBytes = getPackedExtensionsSet().writeToBuffer();
+    final registry = getExtensionRegistry();
 
     assertPackedExtensionsSet(
         TestPackedExtensions.fromBuffer(rawBytes, registry));
@@ -54,18 +54,19 @@ void main() {
   test('testParseMultipleExtensionRanges', () {
     // Make sure we can parse a message that contains multiple extensions
     // ranges.
-    var source = TestFieldOrderings()
+    final source = TestFieldOrderings()
       ..myInt = make64(1)
       ..myString = 'foo'
       ..myFloat = 1.0
       ..setExtension(Unittest.myExtensionInt, 23)
       ..setExtension(Unittest.myExtensionString, 'bar');
 
-    var registry = ExtensionRegistry()
+    final registry = ExtensionRegistry()
       ..add(Unittest.myExtensionInt)
       ..add(Unittest.myExtensionString);
 
-    var dest = TestFieldOrderings.fromBuffer(source.writeToBuffer(), registry);
+    final dest =
+        TestFieldOrderings.fromBuffer(source.writeToBuffer(), registry);
 
     expect(dest, source);
   });


### PR DESCRIPTION
This enables lints `prefer_final_in_for_each` and `prefer_final_locals` and fixes lints errors.

These lints were previously enabled in internal version in the following CLs:

- cl/523340795: updated protoc_plugin source
- cl/523340868: updated protoc_plugin tests
- cl/523340813: updated protobuf source
- cl/523952148: updated protobuf tests

Majority of the changes are generated by `dart fix --apply`. Manual changes were done in two places:

- `dart fix` does not fix lints in `<type> <var> = <expr>;` syntax, it looks like it only replaces `var` with `final` and does not add `final` before a type. A few lint errors were fixed manually for this.

- protoc_plugin/lib/src/client_generator.dart updated manually to fix the lints in generated code. The difference in generated code can be seen in changes in `protoc_plugin/test/goldens`.