### PR TITLE
Sync some g3 changes, minor refactoring

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -268,7 +268,7 @@ class CodedBufferWriter {
       value >>= 7;
     }
     _outputChunk![i++] = value;
-    _bytesTotal += (i - _bytesInChunk);
+    _bytesTotal += i - _bytesInChunk;
     _bytesInChunk = i;
   }
 
@@ -283,7 +283,7 @@ class CodedBufferWriter {
       hi >>= 7;
     }
     _outputChunk![i++] = lo;
-    _bytesTotal += (i - _bytesInChunk);
+    _bytesTotal += i - _bytesInChunk;
     _bytesInChunk = i;
   }
 

--- a/protobuf/lib/src/protobuf/mixins/event_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/event_mixin.dart
@@ -12,7 +12,7 @@ import '../../../protobuf.dart' show GeneratedMessage, FieldInfo, EventPlugin;
 ///
 /// This mixin is enabled via an option in dart_options.proto in
 /// dart-protoc-plugin.
-abstract class PbEventMixin {
+mixin PbEventMixin {
   final eventPlugin = EventBuffer();
 
   /// A stream of changes to fields in the GeneratedMessage.

--- a/protobuf/lib/src/protobuf/mixins/map_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/map_mixin.dart
@@ -10,7 +10,7 @@ import '../../../protobuf.dart' show BuilderInfo;
 ///
 /// Since PbMapMixin is built in, this is done automatically, so this mixin can
 /// be enabled by specifying only a dart_options.mixin option.
-abstract class PbMapMixin {
+mixin PbMapMixin {
   // GeneratedMessage properties and methods used by this mixin.
 
   BuilderInfo get info_;

--- a/protobuf/lib/src/protobuf/mixins/well_known.dart
+++ b/protobuf/lib/src/protobuf/mixins/well_known.dart
@@ -9,7 +9,7 @@ import 'package:fixnum/fixnum.dart';
 import '../../../protobuf.dart';
 import '../json_parsing_context.dart';
 
-abstract class AnyMixin implements GeneratedMessage {
+mixin AnyMixin implements GeneratedMessage {
   String get typeUrl;
   set typeUrl(String value);
   List<int> get value;
@@ -138,7 +138,7 @@ String _typeNameFromUrl(String typeUrl) {
   return index < 0 ? '' : typeUrl.substring(index + 1);
 }
 
-abstract class TimestampMixin {
+mixin TimestampMixin {
   static final RegExp finalGroupsOfThreeZeroes = RegExp(r'(?:000)*$');
 
   Int64 get seconds;
@@ -256,7 +256,7 @@ abstract class TimestampMixin {
   }
 }
 
-abstract class DurationMixin {
+mixin DurationMixin {
   Int64 get seconds;
   set seconds(Int64 value);
 
@@ -303,7 +303,7 @@ abstract class DurationMixin {
   }
 }
 
-abstract class StructMixin implements GeneratedMessage {
+mixin StructMixin implements GeneratedMessage {
   Map<String, ValueMixin> get fields;
   static const _fieldsFieldTagNumber = 1;
 
@@ -345,7 +345,7 @@ abstract class StructMixin implements GeneratedMessage {
   }
 }
 
-abstract class ValueMixin implements GeneratedMessage {
+mixin ValueMixin implements GeneratedMessage {
   bool hasNullValue();
   ProtobufEnum get nullValue;
   set nullValue(covariant ProtobufEnum value);
@@ -421,7 +421,7 @@ abstract class ValueMixin implements GeneratedMessage {
   }
 }
 
-abstract class ListValueMixin implements GeneratedMessage {
+mixin ListValueMixin implements GeneratedMessage {
   List<ValueMixin> get values;
 
   // From google/protobuf/struct.proto:
@@ -455,7 +455,7 @@ abstract class ListValueMixin implements GeneratedMessage {
   }
 }
 
-abstract class FieldMaskMixin {
+mixin FieldMaskMixin {
   List<String> get paths;
 
   // From google/protobuf/field_mask.proto:
@@ -507,7 +507,7 @@ abstract class FieldMaskMixin {
   }
 }
 
-abstract class DoubleValueMixin {
+mixin DoubleValueMixin {
   double get value;
   set value(double value);
 
@@ -533,7 +533,7 @@ abstract class DoubleValueMixin {
   }
 }
 
-abstract class FloatValueMixin {
+mixin FloatValueMixin {
   double get value;
   set value(double value);
 
@@ -559,7 +559,7 @@ abstract class FloatValueMixin {
   }
 }
 
-abstract class Int64ValueMixin {
+mixin Int64ValueMixin {
   Int64 get value;
   set value(Int64 value);
 
@@ -587,7 +587,7 @@ abstract class Int64ValueMixin {
   }
 }
 
-abstract class UInt64ValueMixin {
+mixin UInt64ValueMixin {
   Int64 get value;
   set value(Int64 value);
 
@@ -616,7 +616,7 @@ abstract class UInt64ValueMixin {
   }
 }
 
-abstract class Int32ValueMixin {
+mixin Int32ValueMixin {
   int get value;
   set value(int value);
 
@@ -642,7 +642,7 @@ abstract class Int32ValueMixin {
   }
 }
 
-abstract class UInt32ValueMixin {
+mixin UInt32ValueMixin {
   int get value;
   set value(int value);
   static Object toProto3JsonHelper(
@@ -667,7 +667,7 @@ abstract class UInt32ValueMixin {
   }
 }
 
-abstract class BoolValueMixin {
+mixin BoolValueMixin {
   bool get value;
   set value(bool value);
 
@@ -688,7 +688,7 @@ abstract class BoolValueMixin {
   }
 }
 
-abstract class StringValueMixin {
+mixin StringValueMixin {
   String get value;
   set value(String value);
 
@@ -709,7 +709,7 @@ abstract class StringValueMixin {
   }
 }
 
-abstract class BytesValueMixin {
+mixin BytesValueMixin {
   List<int> get value;
   set value(List<int> value);
 

--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -188,7 +188,7 @@ Iterable<String> defaultSuffixes() sync* {
   yield '_';
   var i = 0;
   while (true) {
-    yield ('_$i');
+    yield '_$i';
     i++;
   }
 }

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -156,8 +156,8 @@ class FileGenerator extends ProtobufContainer {
     final defaultMixin =
         declaredMixins[defaultMixinName] ?? findMixin(defaultMixinName);
     if (defaultMixin == null && defaultMixinName.isNotEmpty) {
-      throw ('Option default_mixin on file ${descriptor.name}: Unknown mixin '
-          '$defaultMixinName');
+      throw 'Option default_mixin on file ${descriptor.name}: Unknown mixin '
+          '$defaultMixinName';
     }
 
     // Load and register all enum and message types.

--- a/protoc_plugin/test/message_test.dart
+++ b/protoc_plugin/test/message_test.dart
@@ -159,7 +159,7 @@ repeatedString: qux
 
   test('testParseUnititialized', () {
     try {
-      (TestRequired.fromBuffer([])).check();
+      TestRequired.fromBuffer([]).check();
       fail('Should have thrown an exception.');
     } on StateError catch (e) {
       expect(e.message, 'Message missing required fields: a, b, c');

--- a/protoc_plugin/test/reserved_names_test.dart
+++ b/protoc_plugin/test/reserved_names_test.dart
@@ -66,6 +66,7 @@ void main() {
     final expected = findMemberNames(meta.importFrom, #PbEventMixin)
       ..removeAll(GeneratedMessage_reservedNames);
 
-    expect(actual.toList()..sort(), equals(expected.toList()..sort()));
+    expect(
+        actual.toList()..sort(), containsAllInOrder(expected.toList()..sort()));
   });
 }


### PR DESCRIPTION
- Remove redundant parentheses

- Make mixins `mixin` (from `abstract class`).

  This fixes internal errors as we use `with` syntax in `event_test.dart`, `map_mixin_test.dart`. and `with` with non-mixing classes is not allowed internally.

  Same change is done internally in cl/533984005.