### PR TITLE
Fix generated ignore_for_file directives

### DIFF
--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -710,6 +710,7 @@ const _fileIgnores = {
   'library_prefixes',
   'non_constant_identifier_names',
   'prefer_final_fields',
+  'unnecessary_import',
   'unnecessary_this',
   'unused_import',
 };

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -303,7 +303,7 @@ class FileGenerator extends ProtobufContainer {
   /// Writes the header and imports for the .pb.dart file.
   void writeMainHeader(IndentingWriter out,
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
-    _writeHeading(out, extraIgnores: {'unnecessary_import'});
+    _writeHeading(out);
 
     final importWriter = ImportWriter();
 
@@ -710,6 +710,6 @@ const _fileIgnores = {
   'library_prefixes',
   'non_constant_identifier_names',
   'prefer_final_fields',
-  'return_of_invalid_type',
   'unnecessary_this',
+  'unused_import',
 };

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/imports.pbjson
+++ b/protoc_plugin/test/goldens/imports.pbjson
@@ -7,5 +7,5 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 

--- a/protoc_plugin/test/goldens/imports.pbjson
+++ b/protoc_plugin/test/goldens/imports.pbjson
@@ -7,5 +7,5 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 405
-  end: 416
+  begin: 425
+  end: 436
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 487
-  end: 498
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2207
-  end: 2213
+  begin: 507
+  end: 518
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2255
-  end: 2261
+  begin: 2227
+  end: 2233
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2334
-  end: 2343
+  begin: 2275
+  end: 2281
 }
 annotation: {
   path: 4
@@ -45,17 +36,17 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2386
-  end: 2397
+  begin: 2354
+  end: 2363
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: test
-  begin: 2455
-  end: 2459
+  begin: 2406
+  end: 2417
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2501
-  end: 2505
+  begin: 2475
+  end: 2479
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2580
-  end: 2587
+  begin: 2521
+  end: 2525
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2630
-  end: 2639
+  begin: 2600
+  end: 2607
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2650
+  end: 2659
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2700
-  end: 2704
+  begin: 2720
+  end: 2724
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2751
-  end: 2755
+  begin: 2771
+  end: 2775
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2828
-  end: 2835
+  begin: 2848
+  end: 2855
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2878
-  end: 2887
+  begin: 2898
+  end: 2907
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 434
-  end: 445
+  begin: 405
+  end: 416
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 516
-  end: 527
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2236
-  end: 2242
+  begin: 487
+  end: 498
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2284
-  end: 2290
+  begin: 2207
+  end: 2213
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2363
-  end: 2372
+  begin: 2255
+  end: 2261
 }
 annotation: {
   path: 4
@@ -45,17 +36,17 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2415
-  end: 2426
+  begin: 2334
+  end: 2343
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: test
-  begin: 2484
-  end: 2488
+  begin: 2386
+  end: 2397
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2530
-  end: 2534
+  begin: 2455
+  end: 2459
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2609
-  end: 2616
+  begin: 2501
+  end: 2505
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2659
-  end: 2668
+  begin: 2580
+  end: 2587
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2630
+  end: 2639
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2729
-  end: 2733
+  begin: 2700
+  end: 2704
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2780
-  end: 2784
+  begin: 2751
+  end: 2755
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2857
-  end: 2864
+  begin: 2828
+  end: 2835
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2907
-  end: 2916
+  begin: 2878
+  end: 2887
 }

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_import, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 414
-  end: 423
+  begin: 405
+  end: 414
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 476
-  end: 482
+  begin: 467
+  end: 473
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 558
-  end: 562
+  begin: 549
+  end: 553
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 636
-  end: 640
+  begin: 627
+  end: 631
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 715
-  end: 723
+  begin: 706
+  end: 714
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 405
-  end: 414
+  begin: 425
+  end: 434
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 467
-  end: 473
+  begin: 487
+  end: 493
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 549
-  end: 553
+  begin: 569
+  end: 573
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 627
-  end: 631
+  begin: 647
+  end: 651
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 706
-  end: 714
+  begin: 726
+  end: 734
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_this, unused_import
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -7,7 +7,7 @@
 // ignore_for_file: annotate_overrides, camel_case_types
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: return_of_invalid_type, unnecessary_this
+// ignore_for_file: unnecessary_this, unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;


### PR DESCRIPTION
- Bring unnecessary_import back. (was removed with #778)

- Generate unused_import in grpc files as well.

- Don't generate return_of_invalid_type: this lint seems to be removed.

(The first two issues were found in cl/535141580)