### PR TITLE
Ignore non-items in message sets

### DIFF
--- a/protobuf/lib/src/protobuf/message_set.dart
+++ b/protobuf/lib/src/protobuf/message_set.dart
@@ -58,7 +58,6 @@ abstract class $_MessageSet extends GeneratedMessage {
     outer:
     while (true) {
       final tag = input.readTag();
-      final wireType = getTagWireType(tag);
       final tagNumber = getTagFieldNumber(tag);
 
       if (tag == 0) {
@@ -66,8 +65,11 @@ abstract class $_MessageSet extends GeneratedMessage {
       }
 
       if (tagNumber != _messageSetItemsTag) {
-        throw UnsupportedError(
-            'Invalid message set (type = $wireType, tag = $tagNumber)');
+        if (!input.skipField(tag)) {
+          break; // End of group.
+        } else {
+          continue;
+        }
       }
 
       // Parse an item. An item is a message with two fields:


### PR DESCRIPTION
This removes the remaining runtime error case in message set parser: when parsing a message set message we expect tag 1 for the items. Ignore other tags.

With this message set parser no longer fails in runtime. Anything unexpected is ignored.

Reference: https://github.com/protocolbuffers/protobuf/blob/a95eb31ac45eed38a586a11cfb9c93faf765bafa/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java#L780-L788