### PR TITLE
Add more message set tests, fix a bug

### DIFF
--- a/protobuf/lib/src/protobuf/message_set.dart
+++ b/protobuf/lib/src/protobuf/message_set.dart
@@ -60,7 +60,7 @@ abstract class $_MessageSet extends GeneratedMessage {
       final tagNumber = getTagFieldNumber(tag);
 
       if (tag == 0) {
-        break;
+        break; // End of input.
       }
 
       if (tagNumber != _messageSetItemsTag) {
@@ -86,7 +86,7 @@ abstract class $_MessageSet extends GeneratedMessage {
         final tagNumber = getTagFieldNumber(tag);
 
         if (tag == 0) {
-          break;
+          break; // End of input.
         }
 
         if (tagNumber == _messageSetItemTypeIdTag) {

--- a/protobuf/lib/src/protobuf/message_set.dart
+++ b/protobuf/lib/src/protobuf/message_set.dart
@@ -52,10 +52,9 @@ abstract class $_MessageSet extends GeneratedMessage {
       [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
     // Parse items. The field for the items looks like:
     //
-    //   repeated Item items = 1;
+    //   repeated group Item items = 1;
     //
     // Since message sets are compatible with proto1 items can't be packed.
-    outer:
     while (true) {
       final tag = input.readTag();
       final tagNumber = getTagFieldNumber(tag);
@@ -96,7 +95,6 @@ abstract class $_MessageSet extends GeneratedMessage {
             _parseExtension(typeId, message, extensionRegistry);
             typeId = null;
             message = null;
-            continue outer;
           }
         } else if (tagNumber == _messageSetItemMessageTag) {
           message = input.readBytes();
@@ -104,12 +102,11 @@ abstract class $_MessageSet extends GeneratedMessage {
             _parseExtension(typeId, message, extensionRegistry);
             typeId = null;
             message = null;
-            continue outer;
           }
         } else {
           // Skip unknown tags.
           if (!input.skipField(tag)) {
-            break outer; // End of group.
+            break; // End of group.
           }
         }
       }

--- a/protobuf/lib/src/protobuf/message_set.dart
+++ b/protobuf/lib/src/protobuf/message_set.dart
@@ -104,7 +104,8 @@ abstract class $_MessageSet extends GeneratedMessage {
             message = null;
           }
         } else {
-          // Skip unknown tags.
+          // Skip unknown tags. If we're at the end of the group consume the
+          // EGROUP tag.
           if (!input.skipField(tag)) {
             break; // End of group.
           }

--- a/protoc_plugin/test/message_set_test.dart
+++ b/protoc_plugin/test/message_set_test.dart
@@ -10,6 +10,31 @@ import '../out/protos/google/protobuf/empty.pb.dart';
 import '../out/protos/message_set.pb.dart';
 
 void main() {
+  // Example message encoded with the C++ library. `protoc --decode_raw`
+  // output:
+  //
+  // 1 {
+  //   1 {
+  //     2: 1758024
+  //     3 {
+  //       1: 123
+  //       2: "testing"
+  //       3 {
+  //         5: 0
+  //         5: 1
+  //         5: 2
+  //       }
+  //     }
+  //   }
+  //   1 {
+  //     2: 1832098
+  //     3 {
+  //       5: 987
+  //       5: 654
+  //       5: 321
+  //     }
+  //   }
+  // }
   final encoded = [
     10, 44, 11, 16, 200, 166, 107, 26, 19, 8, 123, 18, 7, 116, 101, 115, //
     116, 105, 110, 103, 26, 6, 40, 0, 40, 1, 40, 2, 12, 11, 16, 162, 233, //

--- a/protoc_plugin/test/protos/message_set.proto
+++ b/protoc_plugin/test/protos/message_set.proto
@@ -13,13 +13,20 @@ message MessageSet {
 
 message TestMessage {
   extend MessageSet {
-    optional ExtensionMessage message_set_extension = 1758024;
+    optional ExtensionMessage1 ext1 = 1758024;
+    optional ExtensionMessage2 ext2 = 1832098;
   }
 
-  optional MessageSet info = 123;
+  optional MessageSet info = 1;
+  optional int32 i = 2;
 }
 
-message ExtensionMessage {
+message ExtensionMessage1 {
   optional int32 a = 1;
   optional string b = 2;
+  optional ExtensionMessage2 c = 3;
+}
+
+message ExtensionMessage2 {
+  repeated int32 ints = 5;
 }


### PR DESCRIPTION
When parsing an item we should consume the "end group" tag before breaking. Remove the `break` statements after parsing the extension.