### PR TITLE
Document why we add '$' prefix to result local in constructors

### DIFF
--- a/protoc_plugin/lib/src/message_generator.dart
+++ b/protoc_plugin/lib/src/message_generator.dart
@@ -445,6 +445,7 @@ class MessageGenerator extends ProtobufContainer {
         }
       }
       out.println('}) {');
+      // Add '$' prefix to avoid proto field name conflicts.
       out.println('  final \$result = create();');
       for (final field in _fieldList) {
         out.println('  if (${field.memberNames!.fieldName} != null) {');


### PR DESCRIPTION
We used to add a prefix before, but when I brought back the constructor
arguments I didn't include it because (1) the previous prefix was `_` which
caused lint errors (2) there were no tests or documentation on why the prefix
was needed.

Document it now so that it won't be removed again.

(I couldn't add this in #869 as I didn't have push access to the PR's repo)