### PR TITLE
Avoid adding empty splices in `CodedBufferWriter`

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -337,11 +337,22 @@ class CodedBufferWriter {
         _writeVarint32(value ? 1 : 0);
         break;
       case PbFieldType._BYTES_BIT:
-        _writeBytesNoTag(
-            value is Uint8List ? value : Uint8List.fromList(value));
+        final List<int> bytes = value;
+        if (bytes is Uint8List) {
+          _writeBytesNoTag(bytes);
+        } else if (bytes.isEmpty) {
+          writeInt32NoTag(0);
+        } else {
+          _writeBytesNoTag(Uint8List.fromList(value));
+        }
         break;
       case PbFieldType._STRING_BIT:
-        _writeBytesNoTag(_utf8.encoder.convert(value));
+        final String string = value;
+        if (string.isEmpty) {
+          writeInt32NoTag(0);
+        } else {
+          _writeBytesNoTag(_utf8.encoder.convert(string));
+        }
         break;
       case PbFieldType._DOUBLE_BIT:
         _writeDouble(value);

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -223,9 +223,11 @@ class CodedBufferWriter {
   /// Add TypedData splice - these bytes would be directly copied into the
   /// output buffer by [writeTo].
   void writeRawBytes(TypedData value) {
+    final length = value.lengthInBytes;
+    if (length == 0) return;
     _commitSplice();
     _splices.add(value);
-    _bytesTotal += value.lengthInBytes;
+    _bytesTotal += length;
   }
 
   /// Start writing a length-delimited data.

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -346,15 +346,15 @@ class CodedBufferWriter {
         if (bytes is Uint8List) {
           _writeBytesNoTag(bytes);
         } else if (bytes.isEmpty) {
-          writeInt32NoTag(0);
+          _writeEmptyBytes();
         } else {
-          _writeBytesNoTag(Uint8List.fromList(value));
+          _writeBytesNoTag(Uint8List.fromList(bytes));
         }
         break;
       case PbFieldType._STRING_BIT:
         final String string = value;
         if (string.isEmpty) {
-          writeInt32NoTag(0);
+          _writeEmptyBytes();
         } else {
           _writeBytesNoTag(const Utf8Encoder().convert(string));
         }
@@ -416,6 +416,10 @@ class CodedBufferWriter {
   void _writeBytesNoTag(Uint8List value) {
     writeInt32NoTag(value.length);
     writeRawBytes(value);
+  }
+
+  void _writeEmptyBytes() {
+    writeInt32NoTag(0);
   }
 
   void _writeTag(int fieldNumber, int wireFormat) {


### PR DESCRIPTION
By avoiding allocating empty `Uint8List`s this saves a few percent in dart2js -O4 in the benchmark reported in #885.

|                              | Before     | After      | Diff                |
|------------------------------|------------|------------|---------------------|
| AOT                          | 122,917 us | 122,741 us |                     |
| JIT                          |  93,376 us |  94,880 us |                     |
| dart2js -O4                  | 271,111 us | 258,250 us | -12,861 us, -4.7%   |
| dart2wasm --omit-type-checks | 196,454 us | 195,300 us |                     |

Number of splices in the benchmark before this change: 21,123
After: 20,857