### PR TITLE
Use `setRange` when copying output chunks to the final buffer in `CodedBufferWriter`

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -152,21 +152,11 @@ class CodedBufferWriter {
             final leftInChunk = bytesInChunk - chunkPos;
             final bytesToCopyFromChunk =
                 leftInChunk > bytesToCopy ? bytesToCopy : leftInChunk;
-            final endPos = chunkPos + bytesToCopyFromChunk;
-
-            if (bytesToCopyFromChunk <= 20) {
-              while (chunkPos < endPos) {
-                buffer[outPos++] = chunk[chunkPos++];
-              }
-              bytesToCopy -= bytesToCopyFromChunk;
-            } else {
-              final chunkSlice = Uint8List.sublistView(chunk, chunkPos, endPos);
-              buffer.setRange(
-                  outPos, outPos + bytesToCopyFromChunk, chunkSlice);
-              chunkPos += bytesToCopyFromChunk;
-              outPos += bytesToCopyFromChunk;
-              bytesToCopy -= bytesToCopyFromChunk;
-            }
+            buffer.setRange(
+                outPos, outPos + bytesToCopyFromChunk, chunk, chunkPos);
+            chunkPos += bytesToCopyFromChunk;
+            outPos += bytesToCopyFromChunk;
+            bytesToCopy -= bytesToCopyFromChunk;
 
             // Move to the next chunk if the current one is exhausted.
             if (chunkPos == bytesInChunk) {


### PR DESCRIPTION
Similar to #885, this optimizes some more buffer copying to `memcpy`.

Results from the same benchmark in #885:

|                              | Before     | After      | Diff                |
|------------------------------|------------|------------|---------------------|
| AOT                          | 114,713 us | 109,838 us | - 4,875 us, -4.2%   |
| JIT                          |  91,960 us |  92,887 us | +   927 us, +1.0%   |
| dart2js -O4                  | 259,125 us | 257,000 us | - 2,125 us, -0.8%   |
| dart2wasm --omit-type-checks | 196,909 us | 182,333 us | -14,576 us, -7.4%   |

AOT and JIT tested on x64.