### PR TITLE
Avoid allocating temporary views in when decoding strings in `CodedBufferReader`

### DIFF
--- a/protobuf/lib/protobuf.dart
+++ b/protobuf/lib/protobuf.dart
@@ -9,7 +9,13 @@ library;
 
 import 'dart:collection' show ListBase, MapBase;
 import 'dart:convert'
-    show Utf8Codec, base64Decode, base64Encode, jsonDecode, jsonEncode;
+    show
+        Utf8Decoder,
+        Utf8Encoder,
+        base64Decode,
+        base64Encode,
+        jsonDecode,
+        jsonEncode;
 import 'dart:math' as math;
 import 'dart:typed_data' show ByteData, Endian, TypedData, Uint8List;
 
@@ -58,5 +64,3 @@ Int64 parseLongInt(String text) {
   if (text.startsWith('-0x')) return -Int64.parseHex(text.substring(3));
   return Int64.parseInt(text);
 }
-
-const _utf8 = Utf8Codec(allowMalformed: true);

--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -152,7 +152,7 @@ class CodedBufferReader {
     final length = readInt32();
     final stringPos = _bufferPos;
     _checkLimit(length);
-    return Utf8Decoder(allowMalformed: true)
+    return const Utf8Decoder(allowMalformed: true)
         .convert(_buffer, stringPos, stringPos + length);
   }
 

--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -148,7 +148,14 @@ class CodedBufferReader {
         _buffer.buffer, _buffer.offsetInBytes + _bufferPos - length, length);
   }
 
-  String readString() => _utf8.decode(readBytesAsView());
+  String readString() {
+    final length = readInt32();
+    final stringPos = _bufferPos;
+    _checkLimit(length);
+    return Utf8Decoder(allowMalformed: true)
+        .convert(_buffer, stringPos, stringPos + length);
+  }
+
   double readFloat() => _readByteData(4).getFloat32(0, Endian.little);
   double readDouble() => _readByteData(8).getFloat64(0, Endian.little);
 
@@ -180,7 +187,8 @@ class CodedBufferReader {
         readFixed64();
         return true;
       case WIRETYPE_LENGTH_DELIMITED:
-        readBytesAsView();
+        final length = readInt32();
+        _checkLimit(length);
         return true;
       case WIRETYPE_FIXED32:
         readFixed32();

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -341,7 +341,7 @@ class CodedBufferWriter {
             value is Uint8List ? value : Uint8List.fromList(value));
         break;
       case PbFieldType._STRING_BIT:
-        _writeBytesNoTag(_utf8.encoder.convert(value));
+        _writeBytesNoTag(const Utf8Encoder().convert(value));
         break;
       case PbFieldType._DOUBLE_BIT:
         _writeDouble(value);


### PR DESCRIPTION
Benchmark results from the same internal benchmark reported in previous PRs/commits:

|                              | Before     | After      | Diff                |
|------------------------------|------------|------------|---------------------|
| AOT                          |  31,025 us |  27,597 us | - 3,428 us, -11.0%  |
| JIT                          |  34,829 us |  26,846 us | - 7,983 us, -22.9%  |
| dart2js -O4                  | 300,571 us | 248,300 us | -52,271 us, -17.3%  |
| dart2wasm --omit-type-checks | 130,812 us | 107,850 us | -22,962 us, -17.5%  |