### PR TITLE
Avoid redundant ByteData allocation when decoding sfixed64

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -126,9 +126,11 @@ class CodedBufferReader {
   int readFixed32() => _readByteData(4).getUint32(0, Endian.little);
   Int64 readFixed64() => readSfixed64();
   int readSfixed32() => _readByteData(4).getInt32(0, Endian.little);
+
   Int64 readSfixed64() {
-    final data = _readByteData(8);
-    final view = Uint8List.view(data.buffer, data.offsetInBytes, 8);
+    final pos = _bufferPos;
+    _checkLimit(8);
+    final view = Uint8List.sublistView(_buffer, pos, pos + 8);
     return Int64.fromBytes(view);
   }
 


### PR DESCRIPTION
Ideally `Int64.fromBytes` would provide a `skip` argument (similar to
`Utf8Decoder.convert`) to avoid allocating intermediate views completely, but
for now we just remove the intermediate `ByteData`.

