### PR TITLE
Keep a `ByteData` around in `CodedBufferReader` to avoid repeated `ByteData` allocs

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -16,7 +16,7 @@ class CodedBufferReader {
 
   /// [ByteData] of [_buffer], created once to be able to decode fixed-size
   /// integers and floats without having to allocate a [ByteData] every time.
-  final ByteData _byteData;
+  late final ByteData _byteData = ByteData.sublistView(_buffer);
 
   int _bufferPos = 0;
   int _currentLimit = -1;
@@ -25,18 +25,10 @@ class CodedBufferReader {
   final int _recursionLimit;
   final int _sizeLimit;
 
-  factory CodedBufferReader(List<int> buffer,
-          {int recursionLimit = DEFAULT_RECURSION_LIMIT,
-          int sizeLimit = DEFAULT_SIZE_LIMIT}) =>
-      CodedBufferReader._(
-        buffer is Uint8List ? buffer : Uint8List.fromList(buffer),
-        recursionLimit,
-        sizeLimit,
-      );
-
-  CodedBufferReader._(Uint8List buffer, int recursionLimit, int sizeLimit)
-      : _buffer = buffer,
-        _byteData = ByteData.sublistView(buffer),
+  CodedBufferReader(List<int> buffer,
+      {int recursionLimit = DEFAULT_RECURSION_LIMIT,
+      int sizeLimit = DEFAULT_SIZE_LIMIT})
+      : _buffer = buffer is Uint8List ? buffer : Uint8List.fromList(buffer),
         _recursionLimit = recursionLimit,
         _sizeLimit = math.min(sizeLimit, buffer.length) {
     _currentLimit = _sizeLimit;


### PR DESCRIPTION
In Dart, the only way to convert a list of bytes to an `int` or `double` is by using a `ByteData`.

Currently `CodedBufferReader` allocates a new `ByteData` for every fixed-size `int` or `float` decoding.

With this change we now allocate a `ByteData` once initialization and reuse it.

Benchmark results, using the same benchmark reported in #888:

|                              | Before     | After      | Diff                |
|------------------------------|------------|------------|---------------------|
| AOT                          |  26,763 us |  25,305 us | - 1,458 us, - 5.4%  |
| JIT                          |  24,573 us |  25,521 us | +   948 us, + 3.8%  |
| dart2js -O4                  | 212,000 us | 199,300 us | -12,700 us, - 5.9%  |
| dart2wasm --omit-type-checks |  89,750 us |  78,958 us | -10,792 us, -12.0%  |