### PR TITLE
Make `CodedBufferWriter.writeRawByte` argument type more accurate

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.0-dev
 
-* The following types and members are now removed:
+* **Breaking:** The following types and members are now removed:
 
   - `PbEventMixin`
   - `PbFieldChange`
@@ -11,6 +11,9 @@
   These were used to implement events, which are unused internally. To keep API
   surface small (to make it easier to change the library or migrate to another
   library) these types and members are removed. ([#738])
+
+* **Breaking:** `CodedBufferWriter.writeRawBytes` now takes a `Uint8List`
+  argument (instead of `TypedData`).
 
 [#738]: https://github.com/google/protobuf.dart/issues/738
 

--- a/protobuf/lib/protobuf.dart
+++ b/protobuf/lib/protobuf.dart
@@ -17,7 +17,7 @@ import 'dart:convert'
         jsonDecode,
         jsonEncode;
 import 'dart:math' as math;
-import 'dart:typed_data' show ByteData, Endian, TypedData, Uint8List;
+import 'dart:typed_data' show ByteData, Endian, Uint8List;
 
 import 'package:fixnum/fixnum.dart' show Int64;
 import 'package:meta/meta.dart' show UseResult;


### PR DESCRIPTION
`writeRawBytes` adds bytes to the output and it will only be fast when the argument is `Uint8List`.

Since all the users already pass `Uint8List`, update the argument type.

This allows simplifyping `_copyInto`. Because it has only one call site, we simplify it and inline it in the call site.

cl/576427817