### PR TITLE
Annotate deepCopy with @useResult

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -15,7 +15,12 @@
 * **Breaking:** `CodedBufferWriter.writeRawBytes` now takes a `Uint8List`
   argument (instead of `TypedData`).
 
+* `GeneratedMessageGenericExtensions.deepCopy` is now annotated with
+  `@useResult` and will generate a warning when its result is not used.
+  ([#896])
+
 [#738]: https://github.com/google/protobuf.dart/issues/738
+[#896]: https://github.com/google/protobuf.dart/issues/896
 
 ## 3.1.0
 

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -576,5 +576,7 @@ extension GeneratedMessageGenericExtensions<T extends GeneratedMessage> on T {
   }
 
   /// Returns a writable deep copy of this message.
+  @UseResult('[GeneratedMessageGenericExtensions.deepCopy] '
+      'does not update the message, returns a new message')
   T deepCopy() => info_.createEmptyInstance!() as T..mergeFromMessage(this);
 }


### PR DESCRIPTION
Fixes #896.