### PR TITLE
Make wrapped lists in PbList monomorphic

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -19,8 +19,15 @@
   `@useResult` and will generate a warning when its result is not used.
   ([#896])
 
+* **Breaking:** `PbMap.unmodifiable` now takes a key and value field types as
+  argument, instead of another `PbMap`.
+
+  To migrate, use `PbMap.unmodifiable(map.keyFieldType, map.valueFieldType)`
+  instead of `PbMap.unmodifiable(map)`. ([#902])
+
 [#738]: https://github.com/google/protobuf.dart/issues/738
 [#896]: https://github.com/google/protobuf.dart/issues/896
+[#902]: https://github.com/google/protobuf.dart/issues/902
 
 ## 3.1.0
 

--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -19,8 +19,8 @@
   `@useResult` and will generate a warning when its result is not used.
   ([#896])
 
-* **Breaking:** `PbMap.unmodifiable` now takes a key and value field types as
-  argument, instead of another `PbMap`.
+* **Breaking:** `PbMap.unmodifiable` now takes key and value field types as
+  arguments, instead of another `PbMap`.
 
   To migrate, use `PbMap.unmodifiable(map.keyFieldType, map.valueFieldType)`
   instead of `PbMap.unmodifiable(map)`. ([#902])

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -395,8 +395,7 @@ class _FieldSet {
     assert(fi.isMapField);
 
     if (_isReadOnly) {
-      return PbMap<K, V>.unmodifiable(
-          PbMap<K, V>(fi.keyFieldType, fi.valueFieldType));
+      return PbMap<K, V>.unmodifiable(fi.keyFieldType, fi.valueFieldType);
     }
 
     final map = fi._createMapField();

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -11,7 +11,14 @@ typedef CheckFunc<E> = void Function(E? x);
 
 /// A [ListBase] implementation used for protobuf `repeated` fields.
 class PbList<E> extends ListBase<E> {
+  /// The actual list storing the elements.
+  ///
+  /// We want only one [List] implementation class to be stored here to make
+  /// sure the list operations are monomorphic and can be inlined. To make this
+  /// explicit we use the `<E>[]` syntax when initializing this field (instead
+  /// of factory methods like `List.from`).
   final List<E> _wrappedList;
+
   final CheckFunc<E> _check;
 
   bool _isReadOnly = false;
@@ -23,12 +30,14 @@ class PbList<E> extends ListBase<E> {
         _check = check;
 
   PbList.unmodifiable()
-      : _wrappedList = const [],
+      : _wrappedList = <E>[],
         _check = _checkNotNull,
         _isReadOnly = true;
 
-  PbList.from(List from)
-      : _wrappedList = List<E>.from(from),
+  PbList.from(List<E> from)
+      // Use `<E>[]` to allocate the list, see [_wrappedList] documentation.
+      // ignore: prefer_spread_collections
+      : _wrappedList = <E>[]..addAll(from),
         _check = _checkNotNull;
 
   @override

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -22,8 +22,7 @@ class PbList<E> extends ListBase<E> {
   /// A growable list, to be used in `unmodifiable` constructor to avoid
   /// allocating a list every time.
   ///
-  /// We can't use `const <E>[]` as it makes the `_wrappedList` field
-  /// polymorphic.
+  /// We can't use `const []` as it makes the `_wrappedList` field polymorphic.
   static final _emptyList = <Never>[];
 
   final CheckFunc<E> _check;

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -31,8 +31,7 @@ class PbMap<K, V> extends MapBase<K, V> {
 
   /// The map instance to be used in `PbMap.unmodifiable`.
   ///
-  /// We can't use `const <K, V>{}` as it makes the `_wrappedMap` field
-  /// polymorphic.
+  /// We can't use `const {}` as it makes the `_wrappedMap` field polymorphic.
   static final _emptyMap = <Never, Never>{};
 
   bool _isReadOnly = false;

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -21,23 +21,14 @@ class PbMap<K, V> extends MapBase<K, V> {
   static const int _keyFieldNumber = 1;
   static const int _valueFieldNumber = 2;
 
-  /// The actual map storing the elements.
-  ///
-  /// We want only one [Map] implementation class to be stored here to make
-  /// sure the map operations are monomorphic and can be inlined. To make this
-  /// explicit we use the `<K, V>{}` syntax when initializing this field
-  /// (instead of factory methods like `Map.unmodifiable`).
-  final Map<K, V> _wrappedMap;
+  final Map<K, V> _wrappedMap = <K, V>{};
 
   bool _isReadonly = false;
 
-  PbMap(this.keyFieldType, this.valueFieldType) : _wrappedMap = <K, V>{};
+  PbMap(this.keyFieldType, this.valueFieldType);
 
-  PbMap.unmodifiable(PbMap<K, V> other)
-      : keyFieldType = other.keyFieldType,
-        valueFieldType = other.valueFieldType,
-        _wrappedMap = <K, V>{}..addAll(other._wrappedMap),
-        _isReadonly = true;
+  PbMap.unmodifiable(this.keyFieldType, this.valueFieldType)
+      : _isReadonly = true;
 
   @override
   V? operator [](Object? key) => _wrappedMap[key];

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -21,16 +21,22 @@ class PbMap<K, V> extends MapBase<K, V> {
   static const int _keyFieldNumber = 1;
   static const int _valueFieldNumber = 2;
 
+  /// The actual map storing the elements.
+  ///
+  /// We want only one [Map] implementation class to be stored here to make
+  /// sure the map operations are monomorphic and can be inlined. To make this
+  /// explicit we use the `<K, V>{}` syntax when initializing this field
+  /// (instead of factory methods like `Map.unmodifiable`).
   final Map<K, V> _wrappedMap;
 
   bool _isReadonly = false;
 
   PbMap(this.keyFieldType, this.valueFieldType) : _wrappedMap = <K, V>{};
 
-  PbMap.unmodifiable(PbMap other)
+  PbMap.unmodifiable(PbMap<K, V> other)
       : keyFieldType = other.keyFieldType,
         valueFieldType = other.valueFieldType,
-        _wrappedMap = Map.unmodifiable(other._wrappedMap),
+        _wrappedMap = <K, V>{}..addAll(other._wrappedMap),
         _isReadonly = true;
 
   @override


### PR DESCRIPTION
In `PbList`, the list field becomes monomorphic growable list (from the list base class). This makes `add` calls monomorphic and inlinable, and avoids double mutability checks (once in `PbList.add`, again in `_wrappedList.add`).

Also simplifies immutable `PbMap` allocations.

`PbMap._isReadonly` is renamed to `_isReadOnly` for consistency with `PbList._isReadOnly`.