### PR TITLE
Update getList and getMap return types

### DIFF
--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -389,7 +389,7 @@ class _FieldSet {
   /// The implementation of a generated getter for map fields.
   PbMap<K, V> _$getMap<K, V>(GeneratedMessage parentMessage, int index) {
     final value = _values[index];
-    if (value != null) return value as PbMap<K, V>;
+    if (value != null) return value;
 
     final fi = _nonExtensionInfoByIndex(index) as MapFieldInfo<K, V>;
     assert(fi.isMapField);

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -370,7 +370,7 @@ class _FieldSet {
   }
 
   /// The implementation of a generated getter for repeated fields.
-  List<T> _$getList<T>(int index) {
+  PbList<T> _$getList<T>(int index) {
     final value = _values[index];
     if (value != null) return value;
 
@@ -387,9 +387,9 @@ class _FieldSet {
   }
 
   /// The implementation of a generated getter for map fields.
-  Map<K, V> _$getMap<K, V>(GeneratedMessage parentMessage, int index) {
+  PbMap<K, V> _$getMap<K, V>(GeneratedMessage parentMessage, int index) {
     final value = _values[index];
-    if (value != null) return value as Map<K, V>;
+    if (value != null) return value as PbMap<K, V>;
 
     final fi = _nonExtensionInfoByIndex(index) as MapFieldInfo<K, V>;
     assert(fi.isMapField);

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -417,11 +417,12 @@ abstract class GeneratedMessage {
 
   /// For generated code only.
   /// @nodoc
-  List<T> $_getList<T>(int index) => _fieldSet._$getList<T>(index);
+  PbList<T> $_getList<T>(int index) => _fieldSet._$getList<T>(index);
 
   /// For generated code only.
   /// @nodoc
-  Map<K, V> $_getMap<K, V>(int index) => _fieldSet._$getMap<K, V>(this, index);
+  PbMap<K, V> $_getMap<K, V>(int index) =>
+      _fieldSet._$getMap<K, V>(this, index);
 
   /// For generated code only.
   /// @nodoc

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## 22.0.0-dev
 
 * Remove `PbEventMixin` mixin. ([#738])
+* Repeated fields now have `PbList` return type (instead of `List`), map fields
+  now have `PbMap` return type (instead of `Map`). ([#903])
+
+  This change requires protobuf-4.0.0.
 
 [#738]: https://github.com/google/protobuf.dart/issues/738
+[#903]: https://github.com/google/protobuf.dart/pull/903
 
 ## 21.1.2
 

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 22.0.0-dev
 
 * Remove `PbEventMixin` mixin. ([#738])
-* Repeated fields now have `PbList` return type (instead of `List`), map fields
-  now have `PbMap` return type (instead of `Map`). ([#903])
+* Type of repeated fields is now `PbList` (instead of `List`), type of map
+  fields is now `PbMap` (instead of `Map`). ([#903])
 
   This change requires protobuf-4.0.0.
 

--- a/protoc_plugin/lib/src/base_type.dart
+++ b/protoc_plugin/lib/src/base_type.dart
@@ -54,7 +54,7 @@ class BaseType {
           : prefixed;
 
   String getRepeatedDartType(FileGenerator fileGen) =>
-      '$coreImportPrefix.List<${getDartType(fileGen)}>';
+      '$protobufImportPrefix.PbList<${getDartType(fileGen)}>';
 
   String getRepeatedDartTypeIterable(FileGenerator fileGen) =>
       '$coreImportPrefix.Iterable<${getDartType(fileGen)}>';

--- a/protoc_plugin/lib/src/protobuf_field.dart
+++ b/protoc_plugin/lib/src/protobuf_field.dart
@@ -146,7 +146,7 @@ class ProtobufField {
       final d = baseType.generator as MessageGenerator;
       final keyType = d._fieldList[0].baseType.getDartType(parent.fileGen!);
       final valueType = d._fieldList[1].baseType.getDartType(parent.fileGen!);
-      return '$coreImportPrefix.Map<$keyType, $valueType>';
+      return '$protobufImportPrefix.PbMap<$keyType, $valueType>';
     }
     if (isRepeated) return baseType.getRepeatedDartType(parent.fileGen!);
     return baseType.getDartType(parent.fileGen!);


### PR DESCRIPTION
This improves iteration performance by making `moveNext` and `current` direct calls in kernel. #902 does not have the same effect on `moveNext` and `current` calls, this change is needed even with #902.

This change was not possible before #880 as users could override the list and map types to types that are not `PbList`s or `PbMap`s.

Note: changes in the message field types (the plugin changes in this PR) are not necessary for the kernel improvements, but it doesn't hurt to generate more precise types everywhere.