### PR TITLE
Optimize repeated field decoding

### DIFF
--- a/benchmarks/bin/repeated_field.dart
+++ b/benchmarks/bin/repeated_field.dart
@@ -1,0 +1,45 @@
+import 'dart:typed_data';
+
+import 'package:fixnum/fixnum.dart';
+import 'package:protobuf_benchmarks/benchmark_base.dart';
+import 'package:protobuf_benchmarks/generated/f12.pb.dart' as f12;
+import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
+
+class RepeatedBenchmark extends BenchmarkBase {
+  final Uint8List _buffer;
+
+  RepeatedBenchmark(super.name, GoogleMessage2 message)
+      : _buffer = message.writeToBuffer();
+
+  @override
+  void run() => GoogleMessage2.fromBuffer(_buffer);
+}
+
+class RepeatedEnumBenchmark extends BenchmarkBase {
+  final Uint8List _buffer;
+
+  RepeatedEnumBenchmark(super.name, f12.A58 message)
+      : _buffer = message.writeToBuffer();
+
+  @override
+  void run() => f12.A58.fromBuffer(_buffer);
+}
+
+void main() {
+  const kSize = 500000;
+
+  RepeatedBenchmark(
+    'repeated_int64',
+    GoogleMessage2(field130: List<Int64>.generate(kSize, Int64.new)),
+  ).report();
+
+  RepeatedBenchmark(
+    'repeated_string',
+    GoogleMessage2(field128: List<String>.generate(kSize, (i) => i.toString())),
+  ).report();
+
+  RepeatedEnumBenchmark(
+    'repeated_enum',
+    f12.A58(a306: List<f12.A322>.generate(kSize, (_) => f12.A322.A324)),
+  ).report();
+}

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -323,10 +323,13 @@ class BuilderInfo {
 
   ProtobufEnum? _decodeEnum(
       int tagNumber, ExtensionRegistry? registry, int rawValue) {
-    var f = valueOfFunc(tagNumber);
-    if (f == null && registry != null) {
-      f = registry.getExtension(qualifiedMessageName, tagNumber)!.valueOf;
+    final f = valueOfFunc(tagNumber);
+    if (f != null) {
+      return f(rawValue);
     }
-    return f!(rawValue);
+    return registry
+        ?.getExtension(qualifiedMessageName, tagNumber)
+        ?.valueOf
+        ?.call(rawValue);
   }
 }

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -33,19 +33,8 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
     CodedBufferReader input, ExtensionRegistry registry) {
   ArgumentError.checkNotNull(registry);
   fs._ensureWritable();
-
-  // Micro-optimization: cache the storage lookup for repeated fields.
-  var prevTag = -1;
-  List? cachedList;
-
   while (true) {
     final tag = input.readTag();
-    // If the current field's tag is different from previous, invalidate cache.
-    if (tag != prevTag) {
-      cachedList = null;
-      prevTag = tag;
-    }
-
     if (tag == 0) return;
     final wireType = tag & 0x7;
     final tagNumber = tag >> 3;
@@ -139,7 +128,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_BOOL:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readBool()));
         } else {
@@ -147,15 +136,15 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_BYTES:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         list.add(input.readBytes());
         break;
       case PbFieldType._REPEATED_STRING:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         list.add(input.readString());
         break;
       case PbFieldType._REPEATED_FLOAT:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readFloat()));
         } else {
@@ -163,7 +152,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_DOUBLE:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readDouble()));
         } else {
@@ -171,18 +160,18 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_ENUM:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         _readPackableToListEnum(
             list, meta, fs, input, wireType, tagNumber, registry);
         break;
       case PbFieldType._REPEATED_GROUP:
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readGroup(tagNumber, subMessage, registry);
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         list.add(subMessage);
         break;
       case PbFieldType._REPEATED_INT32:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readInt32()));
         } else {
@@ -190,7 +179,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_INT64:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readInt64()));
         } else {
@@ -198,7 +187,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_SINT32:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readSint32()));
         } else {
@@ -206,7 +195,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_SINT64:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readSint64()));
         } else {
@@ -214,7 +203,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_UINT32:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readUint32()));
         } else {
@@ -222,7 +211,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_UINT64:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readUint64()));
         } else {
@@ -230,7 +219,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_FIXED32:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readFixed32()));
         } else {
@@ -238,7 +227,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_FIXED64:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readFixed64()));
         } else {
@@ -246,7 +235,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_SFIXED32:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readSfixed32()));
         } else {
@@ -254,7 +243,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_SFIXED64:
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           _readPacked(input, () => list.add(input.readSfixed64()));
         } else {
@@ -264,7 +253,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_MESSAGE:
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readMessage(subMessage, registry);
-        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        final list = fs._ensureRepeatedField(meta, fi);
         list.add(subMessage);
         break;
       case PbFieldType._MAP:

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -208,9 +208,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_SINT64:
         final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readSint32()));
+          _readPacked(input, () => list.add(input.readSint64()));
         } else {
-          list.add(input.readSint32());
+          list.add(input.readSint64());
         }
         break;
       case PbFieldType._REPEATED_UINT32:

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -300,25 +300,23 @@ void _readPackableToListEnum(
     // Packed.
     input._withLimit(input.readInt32(), () {
       while (!input.isAtEnd()) {
-        final rawValue = input.readEnum();
-        final value = meta._decodeEnum(tagNumber, registry, rawValue);
-        if (value == null) {
-          final unknown = fs._ensureUnknownFields();
-          unknown.mergeVarintField(tagNumber, Int64(rawValue));
-        } else {
-          list.add(value);
-        }
+        _readRepeatedEnum(list, meta, fs, input, tagNumber, registry);
       }
     });
   } else {
     // Not packed.
-    final rawValue = input.readEnum();
-    final value = meta._decodeEnum(tagNumber, registry, rawValue);
-    if (value == null) {
-      final unknown = fs._ensureUnknownFields();
-      unknown.mergeVarintField(tagNumber, Int64(rawValue));
-    } else {
-      list.add(value);
-    }
+    _readRepeatedEnum(list, meta, fs, input, tagNumber, registry);
+  }
+}
+
+void _readRepeatedEnum(List list, BuilderInfo meta, _FieldSet fs,
+    CodedBufferReader input, int tagNumber, ExtensionRegistry registry) {
+  final rawValue = input.readEnum();
+  final value = meta._decodeEnum(tagNumber, registry, rawValue);
+  if (value == null) {
+    final unknown = fs._ensureUnknownFields();
+    unknown.mergeVarintField(tagNumber, Int64(rawValue));
+  } else {
+    list.add(value);
   }
 }

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -33,8 +33,19 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
     CodedBufferReader input, ExtensionRegistry registry) {
   ArgumentError.checkNotNull(registry);
   fs._ensureWritable();
+
+  // Micro-optimization: cache the storage lookup for repeated fields.
+  var prevTag = -1;
+  List? cachedList;
+
   while (true) {
     final tag = input.readTag();
+    // If the current field's tag is different from previous, invalidate cache.
+    if (tag != prevTag) {
+      cachedList = null;
+      prevTag = tag;
+    }
+
     if (tag == 0) return;
     final wireType = tag & 0x7;
     final tagNumber = tag >> 3;
@@ -128,63 +139,133 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         }
         break;
       case PbFieldType._REPEATED_BOOL:
-        _readPackable(meta, fs, input, wireType, fi, input.readBool);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readBool()));
+        } else {
+          list.add(input.readBool());
+        }
         break;
       case PbFieldType._REPEATED_BYTES:
-        fs._ensureRepeatedField(meta, fi).add(input.readBytes());
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        list.add(input.readBytes());
         break;
       case PbFieldType._REPEATED_STRING:
-        fs._ensureRepeatedField(meta, fi).add(input.readString());
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        list.add(input.readString());
         break;
       case PbFieldType._REPEATED_FLOAT:
-        _readPackable(meta, fs, input, wireType, fi, input.readFloat);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readFloat()));
+        } else {
+          list.add(input.readFloat());
+        }
         break;
       case PbFieldType._REPEATED_DOUBLE:
-        _readPackable(meta, fs, input, wireType, fi, input.readDouble);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readDouble()));
+        } else {
+          list.add(input.readDouble());
+        }
         break;
       case PbFieldType._REPEATED_ENUM:
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
         _readPackableToListEnum(
-            meta, fs, input, wireType, fi, tagNumber, registry);
+            list, meta, fs, input, wireType, tagNumber, registry);
         break;
       case PbFieldType._REPEATED_GROUP:
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readGroup(tagNumber, subMessage, registry);
-        fs._ensureRepeatedField(meta, fi).add(subMessage);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        list.add(subMessage);
         break;
       case PbFieldType._REPEATED_INT32:
-        _readPackable(meta, fs, input, wireType, fi, input.readInt32);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readInt32()));
+        } else {
+          list.add(input.readInt32());
+        }
         break;
       case PbFieldType._REPEATED_INT64:
-        _readPackable(meta, fs, input, wireType, fi, input.readInt64);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readInt64()));
+        } else {
+          list.add(input.readInt64());
+        }
         break;
       case PbFieldType._REPEATED_SINT32:
-        _readPackable(meta, fs, input, wireType, fi, input.readSint32);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readSint32()));
+        } else {
+          list.add(input.readSint32());
+        }
         break;
       case PbFieldType._REPEATED_SINT64:
-        _readPackable(meta, fs, input, wireType, fi, input.readSint64);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readSint32()));
+        } else {
+          list.add(input.readSint32());
+        }
         break;
       case PbFieldType._REPEATED_UINT32:
-        _readPackable(meta, fs, input, wireType, fi, input.readUint32);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readUint32()));
+        } else {
+          list.add(input.readUint32());
+        }
         break;
       case PbFieldType._REPEATED_UINT64:
-        _readPackable(meta, fs, input, wireType, fi, input.readUint64);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readUint64()));
+        } else {
+          list.add(input.readUint64());
+        }
         break;
       case PbFieldType._REPEATED_FIXED32:
-        _readPackable(meta, fs, input, wireType, fi, input.readFixed32);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readFixed32()));
+        } else {
+          list.add(input.readFixed32());
+        }
         break;
       case PbFieldType._REPEATED_FIXED64:
-        _readPackable(meta, fs, input, wireType, fi, input.readFixed64);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readFixed64()));
+        } else {
+          list.add(input.readFixed64());
+        }
         break;
       case PbFieldType._REPEATED_SFIXED32:
-        _readPackable(meta, fs, input, wireType, fi, input.readSfixed32);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readSfixed32()));
+        } else {
+          list.add(input.readSfixed32());
+        }
         break;
       case PbFieldType._REPEATED_SFIXED64:
-        _readPackable(meta, fs, input, wireType, fi, input.readSfixed64);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+          _readPacked(input, () => list.add(input.readSfixed64()));
+        } else {
+          list.add(input.readSfixed64());
+        }
         break;
       case PbFieldType._REPEATED_MESSAGE:
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readMessage(subMessage, registry);
-        fs._ensureRepeatedField(meta, fi).add(subMessage);
+        final list = cachedList ??= fs._ensureRepeatedField(meta, fi);
+        list.add(subMessage);
         break;
       case PbFieldType._MAP:
         final mapFieldInfo = fi as MapFieldInfo;
@@ -199,21 +280,38 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
   }
 }
 
-void _readPackable(BuilderInfo meta, _FieldSet fs, CodedBufferReader input,
-    int wireType, FieldInfo fi, Function() readFunc) {
-  void readToList(List list) => list.add(readFunc());
-  _readPackableToList(meta, fs, input, wireType, fi, readToList);
+void _readPacked(CodedBufferReader input, void Function() readFunc) {
+  input._withLimit(input.readInt32(), () {
+    while (!input.isAtEnd()) {
+      readFunc();
+    }
+  });
 }
 
 void _readPackableToListEnum(
+    List list,
     BuilderInfo meta,
     _FieldSet fs,
     CodedBufferReader input,
     int wireType,
-    FieldInfo fi,
     int tagNumber,
     ExtensionRegistry registry) {
-  void readToList(List list) {
+  if (wireType == WIRETYPE_LENGTH_DELIMITED) {
+    // Packed.
+    input._withLimit(input.readInt32(), () {
+      while (!input.isAtEnd()) {
+        final rawValue = input.readEnum();
+        final value = meta._decodeEnum(tagNumber, registry, rawValue);
+        if (value == null) {
+          final unknown = fs._ensureUnknownFields();
+          unknown.mergeVarintField(tagNumber, Int64(rawValue));
+        } else {
+          list.add(value);
+        }
+      }
+    });
+  } else {
+    // Not packed.
     final rawValue = input.readEnum();
     final value = meta._decodeEnum(tagNumber, registry, rawValue);
     if (value == null) {
@@ -222,29 +320,5 @@ void _readPackableToListEnum(
     } else {
       list.add(value);
     }
-  }
-
-  _readPackableToList(meta, fs, input, wireType, fi, readToList);
-}
-
-void _readPackableToList(
-    BuilderInfo meta,
-    _FieldSet fs,
-    CodedBufferReader input,
-    int wireType,
-    FieldInfo fi,
-    Function(List) readToList) {
-  final list = fs._ensureRepeatedField(meta, fi);
-
-  if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-    // Packed.
-    input._withLimit(input.readInt32(), () {
-      while (!input.isAtEnd()) {
-        readToList(list);
-      }
-    });
-  } else {
-    // Not packed.
-    readToList(list);
   }
 }


### PR DESCRIPTION
Avoid allocating tear-off closures when decoding repeated but non-packed fields.

Also refactors `BuilderInfo._decodeEnum`.

# Benchmarks

`repeated_int64`, `repeated_string`, and `repeated_enum` are the new benchmarks added with this PR.

`fromBuffer` is an internal benchmark that decodes a large buffer.

`fromBufferUnmodifiableInput` is the same as `fromBuffer`, but the input `Uint8List` is made unmodifiable.

## AOT

|                             | Before    | After     | Diff               |
|-----------------------------|-----------|-----------|--------------------|
| repeated_int64              | 84,549 us | 61,820 us | -22,729 us, -25.8% |
| repeated_string             | 67,183 us | 67,984 us | +801 us, +1.19%    |
| repeated_enum               | 52,335 us | 44,772 us | -7,563 us, -14.4%  |
| fromBuffer                  | 25,661 us | 25,299 us | -362 us, -1.4%     |
| fromBufferUnmodifiableInput | 26,135 us | 25,689 us | -446 us, -1.7%     |

## JS

|                             | Before     | After      | Diff               |
|-----------------------------|------------|------------|--------------------|
| repeated_int64              | 112,050 us | 109,850 us | -2,200 us, -1.9%   |
| repeated_string             | 123,050 us | 126,650 us | +3,600 us, +2.9%   |
| repeated_enum               |  43,920 us |  39,400 us | -4,520 us, -10.2%  |
| fromBuffer                  | 211,888 us | 168,250 us | -43,638 us, -20.5% |
| fromBufferUnmodifiableInput | 227,444 us | 185,454 us | -41,990 us, -18.4% |