### PR TITLE
Ignore the UnmodifiableUint8ListView deprecation warning

### DIFF
--- a/protobuf/test/coded_buffer_reader_test.dart
+++ b/protobuf/test/coded_buffer_reader_test.dart
@@ -85,8 +85,8 @@ void main() {
 
     test('unmodifiable-uint8-list-view', () {
       // TODO: Use `Uint8List.asUnmodifiableView` instead of
-      // `UnmodifiableUint8ListView` when it's available in the minimum
-      // supported version.
+      // `UnmodifiableUint8ListView` when it's available in the oldest
+      // supported SDK version.
       // ignore: deprecated_member_use
       testWithList(UnmodifiableUint8ListView(Uint8List.fromList(inputBuffer)));
     });

--- a/protobuf/test/coded_buffer_reader_test.dart
+++ b/protobuf/test/coded_buffer_reader_test.dart
@@ -84,6 +84,10 @@ void main() {
     });
 
     test('unmodifiable-uint8-list-view', () {
+      // TODO: Use `Uint8List.asUnmodifiableView` instead of
+      // `UnmodifiableUint8ListView` when it's available in the minimum
+      // supported version.
+      // ignore: deprecated_member_use
       testWithList(UnmodifiableUint8ListView(Uint8List.fromList(inputBuffer)));
     });
 


### PR DESCRIPTION
We can't fix it until the minimum supported SDK version has the replacement. Ignore the warning for now.