### PR TITLE
Generate actuall `enums`

### DIFF
--- a/protoc_plugin/Makefile
+++ b/protoc_plugin/Makefile
@@ -111,7 +111,7 @@ update-pregenerated: $(PLUGIN_PATH) $(PREGENERATED_SRCS)
 protos: $(PLUGIN_PATH) $(TEST_PROTO_LIBS)
 
 run-tests: protos
-	dart test
+	dart test && dart -Dprotobuf.omit_enum_names=true test
 
 update-goldens: protos
 	rm -rf test/goldens

--- a/protoc_plugin/lib/src/enum_generator.dart
+++ b/protoc_plugin/lib/src/enum_generator.dart
@@ -110,10 +110,10 @@ class EnumGenerator extends ProtobufContainer {
       out.println('@$coreImportPrefix.Deprecated(\'This enum is deprecated\')');
     }
     out.addAnnotatedBlock(
-        'class $classname extends $protobufImportPrefix.ProtobufEnum {',
+        'enum $classname implements $protobufImportPrefix.ProtobufEnum {',
         '}\n', [
       NamedLocation(
-          name: classname, fieldPathSegment: fieldPath, start: 'class '.length)
+          name: classname, fieldPathSegment: fieldPath, start: 'enum '.length)
     ], () {
       // -----------------------------------------------------------------
       // Define enum types.
@@ -137,16 +137,14 @@ class EnumGenerator extends ProtobufContainer {
               '@$coreImportPrefix.Deprecated(\'This enum value is deprecated\')');
         }
 
-        out.printlnAnnotated(
-            'static const $classname $name = '
-            '$classname._(${val.number}, $conditionalValName);',
-            [
-              NamedLocation(
-                  name: name,
-                  fieldPathSegment: fieldPathSegment,
-                  start: 'static const $classname '.length)
-            ]);
+        out.printlnAnnotated('$name(${val.number}, $conditionalValName),', [
+          NamedLocation(
+              name: name, fieldPathSegment: fieldPathSegment, start: 0)
+        ]);
+        out.println();
       }
+      out.println(';');
+
       if (_aliases.isNotEmpty) {
         out.println();
         for (var i = 0; i < _aliases.length; i++) {
@@ -164,27 +162,29 @@ class EnumGenerator extends ProtobufContainer {
               ]);
         }
       }
-      out.println();
 
-      out.println('static const $coreImportPrefix.List<$classname> values ='
-          ' <$classname> [');
-      for (final val in _canonicalValues) {
-        final name = dartNames[val.name];
-        out.println('  $name,');
-      }
-      out.println('];');
       out.println();
-
       out.println(
           'static final $coreImportPrefix.Map<$coreImportPrefix.int, $classname> _byValue ='
           ' $protobufImportPrefix.ProtobufEnum.initByValue(values);');
       out.println('static $classname? valueOf($coreImportPrefix.int value) =>'
           ' _byValue[value];');
-      out.println();
 
+      out.println();
+      out.println('@$coreImportPrefix.override');
+      out.println('final $coreImportPrefix.int value;');
+      out.println();
+      out.println('@$coreImportPrefix.override');
+      out.println('final $coreImportPrefix.String name;');
+      out.println();
+      out.println('const $classname(this.value, this.name);');
+      out.println();
       out.println(
-          'const $classname._($coreImportPrefix.int v, $coreImportPrefix.String n) '
-          ': super(v, n);');
+          "/// Returns this enum's [name] or the [value] if names are not"
+          ' represented.');
+      out.println('@$coreImportPrefix.override');
+      out.println("$coreImportPrefix.String toString() => name == '' ? "
+          'value.toString() : name;');
     });
   }
 

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -644,7 +644,6 @@ class FileGenerator extends ProtobufContainer {
 //  Generated code. Do not modify.
 //  source: ${descriptor.name}
 //
-// @dart = 2.12
 ''');
     ignorelines.forEach(out.println);
     out.println('');

--- a/protoc_plugin/lib/src/generated/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/generated/dart_options.pb.dart
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: dart_options.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes
@@ -12,6 +11,8 @@
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 /// A mixin that can be used in the 'with' clause of the generated Dart class
 /// for a proto message.
@@ -171,7 +172,7 @@ class Imports extends $pb.GeneratedMessage {
   ///  so the generated code may contain errors. Therefore, running dartanalyzer
   ///  on the generated file is a good idea.
   @$pb.TagNumber(1)
-  $core.List<DartMixin> get mixins => $_getList(0);
+  $pb.PbList<DartMixin> get mixins => $_getList(0);
 }
 
 class Dart_options {

--- a/protoc_plugin/lib/src/generated/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pb.dart
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: descriptor.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes
@@ -15,6 +14,8 @@ import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 import 'descriptor.pbenum.dart';
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 export 'descriptor.pbenum.dart';
 
@@ -71,7 +72,7 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
   static FileDescriptorSet? _defaultInstance;
 
   @$pb.TagNumber(1)
-  $core.List<FileDescriptorProto> get file => $_getList(0);
+  $pb.PbList<FileDescriptorProto> get file => $_getList(0);
 }
 
 /// Describes a complete .proto file.
@@ -216,20 +217,20 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
 
   /// Names of files imported by this file.
   @$pb.TagNumber(3)
-  $core.List<$core.String> get dependency => $_getList(2);
+  $pb.PbList<$core.String> get dependency => $_getList(2);
 
   /// All top-level definitions in this file.
   @$pb.TagNumber(4)
-  $core.List<DescriptorProto> get messageType => $_getList(3);
+  $pb.PbList<DescriptorProto> get messageType => $_getList(3);
 
   @$pb.TagNumber(5)
-  $core.List<EnumDescriptorProto> get enumType => $_getList(4);
+  $pb.PbList<EnumDescriptorProto> get enumType => $_getList(4);
 
   @$pb.TagNumber(6)
-  $core.List<ServiceDescriptorProto> get service => $_getList(5);
+  $pb.PbList<ServiceDescriptorProto> get service => $_getList(5);
 
   @$pb.TagNumber(7)
-  $core.List<FieldDescriptorProto> get extension => $_getList(6);
+  $pb.PbList<FieldDescriptorProto> get extension => $_getList(6);
 
   @$pb.TagNumber(8)
   FileOptions get options => $_getN(7);
@@ -265,12 +266,12 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
 
   /// Indexes of the public imported files in the dependency list above.
   @$pb.TagNumber(10)
-  $core.List<$core.int> get publicDependency => $_getList(9);
+  $pb.PbList<$core.int> get publicDependency => $_getList(9);
 
   /// Indexes of the weak imported files in the dependency list.
   /// For Google-internal migration only. Do not use.
   @$pb.TagNumber(11)
-  $core.List<$core.int> get weakDependency => $_getList(10);
+  $pb.PbList<$core.int> get weakDependency => $_getList(10);
 
   /// The syntax of the proto file.
   /// The supported values are "proto2" and "proto3".
@@ -597,19 +598,19 @@ class DescriptorProto extends $pb.GeneratedMessage {
   void clearName() => $_clearField(1);
 
   @$pb.TagNumber(2)
-  $core.List<FieldDescriptorProto> get field => $_getList(1);
+  $pb.PbList<FieldDescriptorProto> get field => $_getList(1);
 
   @$pb.TagNumber(3)
-  $core.List<DescriptorProto> get nestedType => $_getList(2);
+  $pb.PbList<DescriptorProto> get nestedType => $_getList(2);
 
   @$pb.TagNumber(4)
-  $core.List<EnumDescriptorProto> get enumType => $_getList(3);
+  $pb.PbList<EnumDescriptorProto> get enumType => $_getList(3);
 
   @$pb.TagNumber(5)
-  $core.List<DescriptorProto_ExtensionRange> get extensionRange => $_getList(4);
+  $pb.PbList<DescriptorProto_ExtensionRange> get extensionRange => $_getList(4);
 
   @$pb.TagNumber(6)
-  $core.List<FieldDescriptorProto> get extension => $_getList(5);
+  $pb.PbList<FieldDescriptorProto> get extension => $_getList(5);
 
   @$pb.TagNumber(7)
   MessageOptions get options => $_getN(6);
@@ -626,15 +627,15 @@ class DescriptorProto extends $pb.GeneratedMessage {
   MessageOptions ensureOptions() => $_ensure(6);
 
   @$pb.TagNumber(8)
-  $core.List<OneofDescriptorProto> get oneofDecl => $_getList(7);
+  $pb.PbList<OneofDescriptorProto> get oneofDecl => $_getList(7);
 
   @$pb.TagNumber(9)
-  $core.List<DescriptorProto_ReservedRange> get reservedRange => $_getList(8);
+  $pb.PbList<DescriptorProto_ReservedRange> get reservedRange => $_getList(8);
 
   /// Reserved field names, which may not be used by fields in the same message.
   /// A given name may only be reserved once.
   @$pb.TagNumber(10)
-  $core.List<$core.String> get reservedName => $_getList(9);
+  $pb.PbList<$core.String> get reservedName => $_getList(9);
 }
 
 class ExtensionRangeOptions extends $pb.GeneratedMessage {
@@ -692,7 +693,7 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
 
   /// The parser stores options it doesn't recognize here. See above.
   @$pb.TagNumber(999)
-  $core.List<UninterpretedOption> get uninterpretedOption => $_getList(0);
+  $pb.PbList<UninterpretedOption> get uninterpretedOption => $_getList(0);
 }
 
 /// Describes a field within a message.
@@ -1241,7 +1242,7 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
   void clearName() => $_clearField(1);
 
   @$pb.TagNumber(2)
-  $core.List<EnumValueDescriptorProto> get value => $_getList(1);
+  $pb.PbList<EnumValueDescriptorProto> get value => $_getList(1);
 
   @$pb.TagNumber(3)
   EnumOptions get options => $_getN(2);
@@ -1261,13 +1262,13 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
   /// by enum values in the same enum declaration. Reserved ranges may not
   /// overlap.
   @$pb.TagNumber(4)
-  $core.List<EnumDescriptorProto_EnumReservedRange> get reservedRange =>
+  $pb.PbList<EnumDescriptorProto_EnumReservedRange> get reservedRange =>
       $_getList(3);
 
   /// Reserved enum value names, which may not be reused. A given name may only
   /// be reserved once.
   @$pb.TagNumber(5)
-  $core.List<$core.String> get reservedName => $_getList(4);
+  $pb.PbList<$core.String> get reservedName => $_getList(4);
 }
 
 /// Describes a value within an enum.
@@ -1448,7 +1449,7 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
   void clearName() => $_clearField(1);
 
   @$pb.TagNumber(2)
-  $core.List<MethodDescriptorProto> get method => $_getList(1);
+  $pb.PbList<MethodDescriptorProto> get method => $_getList(1);
 
   @$pb.TagNumber(3)
   ServiceOptions get options => $_getN(2);
@@ -2087,7 +2088,7 @@ class FileOptions extends $pb.GeneratedMessage {
   /// The parser stores options it doesn't recognize here.
   /// See the documentation for the "Options" section above.
   @$pb.TagNumber(999)
-  $core.List<UninterpretedOption> get uninterpretedOption => $_getList(20);
+  $pb.PbList<UninterpretedOption> get uninterpretedOption => $_getList(20);
 }
 
 class MessageOptions extends $pb.GeneratedMessage {
@@ -2257,7 +2258,7 @@ class MessageOptions extends $pb.GeneratedMessage {
 
   /// The parser stores options it doesn't recognize here. See above.
   @$pb.TagNumber(999)
-  $core.List<UninterpretedOption> get uninterpretedOption => $_getList(4);
+  $pb.PbList<UninterpretedOption> get uninterpretedOption => $_getList(4);
 }
 
 class FieldOptions extends $pb.GeneratedMessage {
@@ -2476,7 +2477,7 @@ class FieldOptions extends $pb.GeneratedMessage {
 
   /// The parser stores options it doesn't recognize here. See above.
   @$pb.TagNumber(999)
-  $core.List<UninterpretedOption> get uninterpretedOption => $_getList(6);
+  $pb.PbList<UninterpretedOption> get uninterpretedOption => $_getList(6);
 }
 
 class OneofOptions extends $pb.GeneratedMessage {
@@ -2532,7 +2533,7 @@ class OneofOptions extends $pb.GeneratedMessage {
 
   /// The parser stores options it doesn't recognize here. See above.
   @$pb.TagNumber(999)
-  $core.List<UninterpretedOption> get uninterpretedOption => $_getList(0);
+  $pb.PbList<UninterpretedOption> get uninterpretedOption => $_getList(0);
 }
 
 class EnumOptions extends $pb.GeneratedMessage {
@@ -2627,7 +2628,7 @@ class EnumOptions extends $pb.GeneratedMessage {
 
   /// The parser stores options it doesn't recognize here. See above.
   @$pb.TagNumber(999)
-  $core.List<UninterpretedOption> get uninterpretedOption => $_getList(2);
+  $pb.PbList<UninterpretedOption> get uninterpretedOption => $_getList(2);
 }
 
 class EnumValueOptions extends $pb.GeneratedMessage {
@@ -2704,7 +2705,7 @@ class EnumValueOptions extends $pb.GeneratedMessage {
 
   /// The parser stores options it doesn't recognize here. See above.
   @$pb.TagNumber(999)
-  $core.List<UninterpretedOption> get uninterpretedOption => $_getList(1);
+  $pb.PbList<UninterpretedOption> get uninterpretedOption => $_getList(1);
 }
 
 class ServiceOptions extends $pb.GeneratedMessage {
@@ -2781,7 +2782,7 @@ class ServiceOptions extends $pb.GeneratedMessage {
 
   /// The parser stores options it doesn't recognize here. See above.
   @$pb.TagNumber(999)
-  $core.List<UninterpretedOption> get uninterpretedOption => $_getList(1);
+  $pb.PbList<UninterpretedOption> get uninterpretedOption => $_getList(1);
 }
 
 class MethodOptions extends $pb.GeneratedMessage {
@@ -2879,7 +2880,7 @@ class MethodOptions extends $pb.GeneratedMessage {
 
   /// The parser stores options it doesn't recognize here. See above.
   @$pb.TagNumber(999)
-  $core.List<UninterpretedOption> get uninterpretedOption => $_getList(2);
+  $pb.PbList<UninterpretedOption> get uninterpretedOption => $_getList(2);
 }
 
 /// The name of the uninterpreted option.  Each string represents a segment in
@@ -3061,7 +3062,7 @@ class UninterpretedOption extends $pb.GeneratedMessage {
   static UninterpretedOption? _defaultInstance;
 
   @$pb.TagNumber(2)
-  $core.List<UninterpretedOption_NamePart> get name => $_getList(0);
+  $pb.PbList<UninterpretedOption_NamePart> get name => $_getList(0);
 
   /// The value of the uninterpreted option, in whatever type the tokenizer
   /// identified it as during parsing. Exactly one of these should be set.
@@ -3233,7 +3234,7 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
   ///  this path refers to the whole field declaration (from the beginning
   ///  of the label to the terminating semicolon).
   @$pb.TagNumber(1)
-  $core.List<$core.int> get path => $_getList(0);
+  $pb.PbList<$core.int> get path => $_getList(0);
 
   /// Always has exactly three or four elements: start line, start column,
   /// end line (optional, otherwise assumed same as start line), end column.
@@ -3241,7 +3242,7 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
   /// and column numbers are zero-based -- typically you will want to add
   /// 1 to each before displaying to a user.
   @$pb.TagNumber(2)
-  $core.List<$core.int> get span => $_getList(1);
+  $pb.PbList<$core.int> get span => $_getList(1);
 
   ///  If this SourceCodeInfo represents a complete declaration, these are any
   ///  comments appearing before and after the declaration which appear to be
@@ -3315,7 +3316,7 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
   void clearTrailingComments() => $_clearField(4);
 
   @$pb.TagNumber(6)
-  $core.List<$core.String> get leadingDetachedComments => $_getList(4);
+  $pb.PbList<$core.String> get leadingDetachedComments => $_getList(4);
 }
 
 /// Encapsulates information about the original source file from which a
@@ -3415,7 +3416,7 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
   ///    ignore those that it doesn't understand, as more types of locations could
   ///    be recorded in the future.
   @$pb.TagNumber(1)
-  $core.List<SourceCodeInfo_Location> get location => $_getList(0);
+  $pb.PbList<SourceCodeInfo_Location> get location => $_getList(0);
 }
 
 class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
@@ -3489,7 +3490,7 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
   /// Identifies the element in the original source .proto file. This field
   /// is formatted the same as SourceCodeInfo.Location.path.
   @$pb.TagNumber(1)
-  $core.List<$core.int> get path => $_getList(0);
+  $pb.PbList<$core.int> get path => $_getList(0);
 
   /// Identifies the filesystem path to the original source .proto.
   @$pb.TagNumber(2)
@@ -3591,7 +3592,7 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
   /// An Annotation connects some span of text in generated code to an element
   /// of its generating .proto file.
   @$pb.TagNumber(1)
-  $core.List<GeneratedCodeInfo_Annotation> get annotation => $_getList(0);
+  $pb.PbList<GeneratedCodeInfo_Annotation> get annotation => $_getList(0);
 }
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');

--- a/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/descriptor.pbenum.dart
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: descriptor.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes
@@ -13,188 +12,207 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-class FieldDescriptorProto_Type extends $pb.ProtobufEnum {
-  static const FieldDescriptorProto_Type TYPE_DOUBLE =
-      FieldDescriptorProto_Type._(1, _omitEnumNames ? '' : 'TYPE_DOUBLE');
-  static const FieldDescriptorProto_Type TYPE_FLOAT =
-      FieldDescriptorProto_Type._(2, _omitEnumNames ? '' : 'TYPE_FLOAT');
-  static const FieldDescriptorProto_Type TYPE_INT64 =
-      FieldDescriptorProto_Type._(3, _omitEnumNames ? '' : 'TYPE_INT64');
-  static const FieldDescriptorProto_Type TYPE_UINT64 =
-      FieldDescriptorProto_Type._(4, _omitEnumNames ? '' : 'TYPE_UINT64');
-  static const FieldDescriptorProto_Type TYPE_INT32 =
-      FieldDescriptorProto_Type._(5, _omitEnumNames ? '' : 'TYPE_INT32');
-  static const FieldDescriptorProto_Type TYPE_FIXED64 =
-      FieldDescriptorProto_Type._(6, _omitEnumNames ? '' : 'TYPE_FIXED64');
-  static const FieldDescriptorProto_Type TYPE_FIXED32 =
-      FieldDescriptorProto_Type._(7, _omitEnumNames ? '' : 'TYPE_FIXED32');
-  static const FieldDescriptorProto_Type TYPE_BOOL =
-      FieldDescriptorProto_Type._(8, _omitEnumNames ? '' : 'TYPE_BOOL');
-  static const FieldDescriptorProto_Type TYPE_STRING =
-      FieldDescriptorProto_Type._(9, _omitEnumNames ? '' : 'TYPE_STRING');
-  static const FieldDescriptorProto_Type TYPE_GROUP =
-      FieldDescriptorProto_Type._(10, _omitEnumNames ? '' : 'TYPE_GROUP');
-  static const FieldDescriptorProto_Type TYPE_MESSAGE =
-      FieldDescriptorProto_Type._(11, _omitEnumNames ? '' : 'TYPE_MESSAGE');
-  static const FieldDescriptorProto_Type TYPE_BYTES =
-      FieldDescriptorProto_Type._(12, _omitEnumNames ? '' : 'TYPE_BYTES');
-  static const FieldDescriptorProto_Type TYPE_UINT32 =
-      FieldDescriptorProto_Type._(13, _omitEnumNames ? '' : 'TYPE_UINT32');
-  static const FieldDescriptorProto_Type TYPE_ENUM =
-      FieldDescriptorProto_Type._(14, _omitEnumNames ? '' : 'TYPE_ENUM');
-  static const FieldDescriptorProto_Type TYPE_SFIXED32 =
-      FieldDescriptorProto_Type._(15, _omitEnumNames ? '' : 'TYPE_SFIXED32');
-  static const FieldDescriptorProto_Type TYPE_SFIXED64 =
-      FieldDescriptorProto_Type._(16, _omitEnumNames ? '' : 'TYPE_SFIXED64');
-  static const FieldDescriptorProto_Type TYPE_SINT32 =
-      FieldDescriptorProto_Type._(17, _omitEnumNames ? '' : 'TYPE_SINT32');
-  static const FieldDescriptorProto_Type TYPE_SINT64 =
-      FieldDescriptorProto_Type._(18, _omitEnumNames ? '' : 'TYPE_SINT64');
+enum FieldDescriptorProto_Type implements $pb.ProtobufEnum {
+  /// 0 is reserved for errors.
+  /// Order is weird for historical reasons.
+  TYPE_DOUBLE(1, _omitEnumNames ? '' : 'TYPE_DOUBLE'),
 
-  static const $core.List<FieldDescriptorProto_Type> values =
-      <FieldDescriptorProto_Type>[
-    TYPE_DOUBLE,
-    TYPE_FLOAT,
-    TYPE_INT64,
-    TYPE_UINT64,
-    TYPE_INT32,
-    TYPE_FIXED64,
-    TYPE_FIXED32,
-    TYPE_BOOL,
-    TYPE_STRING,
-    TYPE_GROUP,
-    TYPE_MESSAGE,
-    TYPE_BYTES,
-    TYPE_UINT32,
-    TYPE_ENUM,
-    TYPE_SFIXED32,
-    TYPE_SFIXED64,
-    TYPE_SINT32,
-    TYPE_SINT64,
-  ];
+  TYPE_FLOAT(2, _omitEnumNames ? '' : 'TYPE_FLOAT'),
+
+  /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+  /// negative values are likely.
+  TYPE_INT64(3, _omitEnumNames ? '' : 'TYPE_INT64'),
+
+  TYPE_UINT64(4, _omitEnumNames ? '' : 'TYPE_UINT64'),
+
+  /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+  /// negative values are likely.
+  TYPE_INT32(5, _omitEnumNames ? '' : 'TYPE_INT32'),
+
+  TYPE_FIXED64(6, _omitEnumNames ? '' : 'TYPE_FIXED64'),
+
+  TYPE_FIXED32(7, _omitEnumNames ? '' : 'TYPE_FIXED32'),
+
+  TYPE_BOOL(8, _omitEnumNames ? '' : 'TYPE_BOOL'),
+
+  TYPE_STRING(9, _omitEnumNames ? '' : 'TYPE_STRING'),
+
+  /// Tag-delimited aggregate.
+  /// Group type is deprecated and not supported in proto3. However, Proto3
+  /// implementations should still be able to parse the group wire format and
+  /// treat group fields as unknown fields.
+  TYPE_GROUP(10, _omitEnumNames ? '' : 'TYPE_GROUP'),
+
+  TYPE_MESSAGE(11, _omitEnumNames ? '' : 'TYPE_MESSAGE'),
+
+  /// New in version 2.
+  TYPE_BYTES(12, _omitEnumNames ? '' : 'TYPE_BYTES'),
+
+  TYPE_UINT32(13, _omitEnumNames ? '' : 'TYPE_UINT32'),
+
+  TYPE_ENUM(14, _omitEnumNames ? '' : 'TYPE_ENUM'),
+
+  TYPE_SFIXED32(15, _omitEnumNames ? '' : 'TYPE_SFIXED32'),
+
+  TYPE_SFIXED64(16, _omitEnumNames ? '' : 'TYPE_SFIXED64'),
+
+  TYPE_SINT32(17, _omitEnumNames ? '' : 'TYPE_SINT32'),
+
+  TYPE_SINT64(18, _omitEnumNames ? '' : 'TYPE_SINT64'),
+  ;
 
   static final $core.Map<$core.int, FieldDescriptorProto_Type> _byValue =
       $pb.ProtobufEnum.initByValue(values);
   static FieldDescriptorProto_Type? valueOf($core.int value) => _byValue[value];
 
-  const FieldDescriptorProto_Type._($core.int v, $core.String n) : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const FieldDescriptorProto_Type(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
-class FieldDescriptorProto_Label extends $pb.ProtobufEnum {
-  static const FieldDescriptorProto_Label LABEL_OPTIONAL =
-      FieldDescriptorProto_Label._(1, _omitEnumNames ? '' : 'LABEL_OPTIONAL');
-  static const FieldDescriptorProto_Label LABEL_REQUIRED =
-      FieldDescriptorProto_Label._(2, _omitEnumNames ? '' : 'LABEL_REQUIRED');
-  static const FieldDescriptorProto_Label LABEL_REPEATED =
-      FieldDescriptorProto_Label._(3, _omitEnumNames ? '' : 'LABEL_REPEATED');
+enum FieldDescriptorProto_Label implements $pb.ProtobufEnum {
+  /// 0 is reserved for errors
+  LABEL_OPTIONAL(1, _omitEnumNames ? '' : 'LABEL_OPTIONAL'),
 
-  static const $core.List<FieldDescriptorProto_Label> values =
-      <FieldDescriptorProto_Label>[
-    LABEL_OPTIONAL,
-    LABEL_REQUIRED,
-    LABEL_REPEATED,
-  ];
+  LABEL_REQUIRED(2, _omitEnumNames ? '' : 'LABEL_REQUIRED'),
+
+  LABEL_REPEATED(3, _omitEnumNames ? '' : 'LABEL_REPEATED'),
+  ;
 
   static final $core.Map<$core.int, FieldDescriptorProto_Label> _byValue =
       $pb.ProtobufEnum.initByValue(values);
   static FieldDescriptorProto_Label? valueOf($core.int value) =>
       _byValue[value];
 
-  const FieldDescriptorProto_Label._($core.int v, $core.String n) : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const FieldDescriptorProto_Label(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
 /// Generated classes can be optimized for speed or code size.
-class FileOptions_OptimizeMode extends $pb.ProtobufEnum {
-  static const FileOptions_OptimizeMode SPEED =
-      FileOptions_OptimizeMode._(1, _omitEnumNames ? '' : 'SPEED');
-  static const FileOptions_OptimizeMode CODE_SIZE =
-      FileOptions_OptimizeMode._(2, _omitEnumNames ? '' : 'CODE_SIZE');
-  static const FileOptions_OptimizeMode LITE_RUNTIME =
-      FileOptions_OptimizeMode._(3, _omitEnumNames ? '' : 'LITE_RUNTIME');
+enum FileOptions_OptimizeMode implements $pb.ProtobufEnum {
+  SPEED(1, _omitEnumNames ? '' : 'SPEED'),
 
-  static const $core.List<FileOptions_OptimizeMode> values =
-      <FileOptions_OptimizeMode>[
-    SPEED,
-    CODE_SIZE,
-    LITE_RUNTIME,
-  ];
+  /// etc.
+  CODE_SIZE(2, _omitEnumNames ? '' : 'CODE_SIZE'),
+
+  LITE_RUNTIME(3, _omitEnumNames ? '' : 'LITE_RUNTIME'),
+  ;
 
   static final $core.Map<$core.int, FileOptions_OptimizeMode> _byValue =
       $pb.ProtobufEnum.initByValue(values);
   static FileOptions_OptimizeMode? valueOf($core.int value) => _byValue[value];
 
-  const FileOptions_OptimizeMode._($core.int v, $core.String n) : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const FileOptions_OptimizeMode(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
-class FieldOptions_CType extends $pb.ProtobufEnum {
-  static const FieldOptions_CType STRING =
-      FieldOptions_CType._(0, _omitEnumNames ? '' : 'STRING');
-  static const FieldOptions_CType CORD =
-      FieldOptions_CType._(1, _omitEnumNames ? '' : 'CORD');
-  static const FieldOptions_CType STRING_PIECE =
-      FieldOptions_CType._(2, _omitEnumNames ? '' : 'STRING_PIECE');
+enum FieldOptions_CType implements $pb.ProtobufEnum {
+  /// Default mode.
+  STRING(0, _omitEnumNames ? '' : 'STRING'),
 
-  static const $core.List<FieldOptions_CType> values = <FieldOptions_CType>[
-    STRING,
-    CORD,
-    STRING_PIECE,
-  ];
+  CORD(1, _omitEnumNames ? '' : 'CORD'),
+
+  STRING_PIECE(2, _omitEnumNames ? '' : 'STRING_PIECE'),
+  ;
 
   static final $core.Map<$core.int, FieldOptions_CType> _byValue =
       $pb.ProtobufEnum.initByValue(values);
   static FieldOptions_CType? valueOf($core.int value) => _byValue[value];
 
-  const FieldOptions_CType._($core.int v, $core.String n) : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const FieldOptions_CType(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
-class FieldOptions_JSType extends $pb.ProtobufEnum {
-  static const FieldOptions_JSType JS_NORMAL =
-      FieldOptions_JSType._(0, _omitEnumNames ? '' : 'JS_NORMAL');
-  static const FieldOptions_JSType JS_STRING =
-      FieldOptions_JSType._(1, _omitEnumNames ? '' : 'JS_STRING');
-  static const FieldOptions_JSType JS_NUMBER =
-      FieldOptions_JSType._(2, _omitEnumNames ? '' : 'JS_NUMBER');
+enum FieldOptions_JSType implements $pb.ProtobufEnum {
+  /// Use the default type.
+  JS_NORMAL(0, _omitEnumNames ? '' : 'JS_NORMAL'),
 
-  static const $core.List<FieldOptions_JSType> values = <FieldOptions_JSType>[
-    JS_NORMAL,
-    JS_STRING,
-    JS_NUMBER,
-  ];
+  /// Use JavaScript strings.
+  JS_STRING(1, _omitEnumNames ? '' : 'JS_STRING'),
+
+  /// Use JavaScript numbers.
+  JS_NUMBER(2, _omitEnumNames ? '' : 'JS_NUMBER'),
+  ;
 
   static final $core.Map<$core.int, FieldOptions_JSType> _byValue =
       $pb.ProtobufEnum.initByValue(values);
   static FieldOptions_JSType? valueOf($core.int value) => _byValue[value];
 
-  const FieldOptions_JSType._($core.int v, $core.String n) : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const FieldOptions_JSType(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
 /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
 /// or neither? HTTP based RPC implementation may choose GET verb for safe
 /// methods, and PUT verb for idempotent methods instead of the default POST.
-class MethodOptions_IdempotencyLevel extends $pb.ProtobufEnum {
-  static const MethodOptions_IdempotencyLevel IDEMPOTENCY_UNKNOWN =
-      MethodOptions_IdempotencyLevel._(
-          0, _omitEnumNames ? '' : 'IDEMPOTENCY_UNKNOWN');
-  static const MethodOptions_IdempotencyLevel NO_SIDE_EFFECTS =
-      MethodOptions_IdempotencyLevel._(
-          1, _omitEnumNames ? '' : 'NO_SIDE_EFFECTS');
-  static const MethodOptions_IdempotencyLevel IDEMPOTENT =
-      MethodOptions_IdempotencyLevel._(2, _omitEnumNames ? '' : 'IDEMPOTENT');
+enum MethodOptions_IdempotencyLevel implements $pb.ProtobufEnum {
+  IDEMPOTENCY_UNKNOWN(0, _omitEnumNames ? '' : 'IDEMPOTENCY_UNKNOWN'),
 
-  static const $core.List<MethodOptions_IdempotencyLevel> values =
-      <MethodOptions_IdempotencyLevel>[
-    IDEMPOTENCY_UNKNOWN,
-    NO_SIDE_EFFECTS,
-    IDEMPOTENT,
-  ];
+  NO_SIDE_EFFECTS(1, _omitEnumNames ? '' : 'NO_SIDE_EFFECTS'),
+
+  IDEMPOTENT(2, _omitEnumNames ? '' : 'IDEMPOTENT'),
+  ;
 
   static final $core.Map<$core.int, MethodOptions_IdempotencyLevel> _byValue =
       $pb.ProtobufEnum.initByValue(values);
   static MethodOptions_IdempotencyLevel? valueOf($core.int value) =>
       _byValue[value];
 
-  const MethodOptions_IdempotencyLevel._($core.int v, $core.String n)
-      : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const MethodOptions_IdempotencyLevel(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/protoc_plugin/lib/src/generated/plugin.pb.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pb.dart
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: plugin.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes
@@ -15,6 +14,8 @@ import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 import 'descriptor.pb.dart' as $0;
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 export 'plugin.pbenum.dart';
 
@@ -204,7 +205,7 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
   /// code generator should generate code only for these files.  Each file's
   /// descriptor will be included in proto_file, below.
   @$pb.TagNumber(1)
-  $core.List<$core.String> get fileToGenerate => $_getList(0);
+  $pb.PbList<$core.String> get fileToGenerate => $_getList(0);
 
   /// The generator parameter passed on the command-line.
   @$pb.TagNumber(2)
@@ -249,7 +250,7 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
   ///  Type names of fields and extensions in the FileDescriptorProto are always
   ///  fully qualified.
   @$pb.TagNumber(15)
-  $core.List<$0.FileDescriptorProto> get protoFile => $_getList(3);
+  $pb.PbList<$0.FileDescriptorProto> get protoFile => $_getList(3);
 }
 
 /// Represents a single generated file.
@@ -525,7 +526,7 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
   void clearSupportedFeatures() => $_clearField(2);
 
   @$pb.TagNumber(15)
-  $core.List<CodeGeneratorResponse_File> get file => $_getList(2);
+  $pb.PbList<CodeGeneratorResponse_File> get file => $_getList(2);
 }
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');

--- a/protoc_plugin/lib/src/generated/plugin.pbenum.dart
+++ b/protoc_plugin/lib/src/generated/plugin.pbenum.dart
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: plugin.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes
@@ -14,26 +13,28 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 /// Sync with code_generator.h.
-class CodeGeneratorResponse_Feature extends $pb.ProtobufEnum {
-  static const CodeGeneratorResponse_Feature FEATURE_NONE =
-      CodeGeneratorResponse_Feature._(0, _omitEnumNames ? '' : 'FEATURE_NONE');
-  static const CodeGeneratorResponse_Feature FEATURE_PROTO3_OPTIONAL =
-      CodeGeneratorResponse_Feature._(
-          1, _omitEnumNames ? '' : 'FEATURE_PROTO3_OPTIONAL');
+enum CodeGeneratorResponse_Feature implements $pb.ProtobufEnum {
+  FEATURE_NONE(0, _omitEnumNames ? '' : 'FEATURE_NONE'),
 
-  static const $core.List<CodeGeneratorResponse_Feature> values =
-      <CodeGeneratorResponse_Feature>[
-    FEATURE_NONE,
-    FEATURE_PROTO3_OPTIONAL,
-  ];
+  FEATURE_PROTO3_OPTIONAL(1, _omitEnumNames ? '' : 'FEATURE_PROTO3_OPTIONAL'),
+  ;
 
   static final $core.Map<$core.int, CodeGeneratorResponse_Feature> _byValue =
       $pb.ProtobufEnum.initByValue(values);
   static CodeGeneratorResponse_Feature? valueOf($core.int value) =>
       _byValue[value];
 
-  const CodeGeneratorResponse_Feature._($core.int v, $core.String n)
-      : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const CodeGeneratorResponse_Feature(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/protoc_plugin/test/goldens/deprecations
+++ b/protoc_plugin/test/goldens/deprecations
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: deprecations.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/deprecations.pbenum
+++ b/protoc_plugin/test/goldens/deprecations.pbenum
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: deprecations.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes
@@ -14,21 +13,28 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 @$core.Deprecated('This enum is deprecated')
-class A extends $pb.ProtobufEnum {
+enum A implements $pb.ProtobufEnum {
   @$core.Deprecated('This enum value is deprecated')
-  static const A A1 = A._(0, _omitEnumNames ? '' : 'A1');
-  static const A A2 = A._(1, _omitEnumNames ? '' : 'A2');
+  A1(0, _omitEnumNames ? '' : 'A1'),
 
-  static const $core.List<A> values = <A>[
-    A1,
-    A2,
-  ];
+  A2(1, _omitEnumNames ? '' : 'A2'),
+  ;
 
   static final $core.Map<$core.int, A> _byValue =
       $pb.ProtobufEnum.initByValue(values);
   static A? valueOf($core.int value) => _byValue[value];
 
-  const A._($core.int v, $core.String n) : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const A(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/protoc_plugin/test/goldens/doc_comments
+++ b/protoc_plugin/test/goldens/doc_comments
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: doc_comments.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/doc_comments.pbenum
+++ b/protoc_plugin/test/goldens/doc_comments.pbenum
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: doc_comments.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes
@@ -14,23 +13,29 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 /// This is an enum.
-class A extends $pb.ProtobufEnum {
+enum A implements $pb.ProtobufEnum {
   /// This is an enum variant.
-  static const A A1 = A._(0, _omitEnumNames ? '' : 'A1');
+  A1(0, _omitEnumNames ? '' : 'A1'),
 
   /// This is another enum variant.
-  static const A A2 = A._(1, _omitEnumNames ? '' : 'A2');
-
-  static const $core.List<A> values = <A>[
-    A1,
-    A2,
-  ];
+  A2(1, _omitEnumNames ? '' : 'A2'),
+  ;
 
   static final $core.Map<$core.int, A> _byValue =
       $pb.ProtobufEnum.initByValue(values);
   static A? valueOf($core.int value) => _byValue[value];
 
-  const A._($core.int v, $core.String n) : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const A(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/protoc_plugin/test/goldens/enum
+++ b/protoc_plugin/test/goldens/enum
@@ -1,20 +1,28 @@
-class PhoneType extends $pb.ProtobufEnum {
-  static const PhoneType MOBILE = PhoneType._(0, _omitEnumNames ? '' : 'MOBILE');
-  static const PhoneType HOME = PhoneType._(1, _omitEnumNames ? '' : 'HOME');
-  static const PhoneType WORK = PhoneType._(2, _omitEnumNames ? '' : 'WORK');
+enum PhoneType implements $pb.ProtobufEnum {
+  MOBILE(0, _omitEnumNames ? '' : 'MOBILE'),
+
+  HOME(1, _omitEnumNames ? '' : 'HOME'),
+
+  WORK(2, _omitEnumNames ? '' : 'WORK'),
+
+  ;
 
   static const PhoneType BUSINESS = WORK;
-
-  static const $core.List<PhoneType> values = <PhoneType> [
-    MOBILE,
-    HOME,
-    WORK,
-  ];
 
   static final $core.Map<$core.int, PhoneType> _byValue = $pb.ProtobufEnum.initByValue(values);
   static PhoneType? valueOf($core.int value) => _byValue[value];
 
-  const PhoneType._($core.int v, $core.String n) : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const PhoneType(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
 

--- a/protoc_plugin/test/goldens/enum.meta
+++ b/protoc_plugin/test/goldens/enum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: sample.proto
-  begin: 6
-  end: 15
+  begin: 5
+  end: 14
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: sample.proto
-  begin: 68
-  end: 74
+  begin: 47
+  end: 53
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: sample.proto
-  begin: 150
-  end: 154
+  begin: 93
+  end: 97
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: sample.proto
-  begin: 228
-  end: 232
+  begin: 135
+  end: 139
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: sample.proto
-  begin: 307
-  end: 315
+  begin: 205
+  end: 213
 }

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/imports.pbjson
+++ b/protoc_plugin/test/goldens/imports.pbjson
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/messageGeneratorEnums
+++ b/protoc_plugin/test/goldens/messageGeneratorEnums
@@ -1,20 +1,28 @@
-class PhoneNumber_PhoneType extends $pb.ProtobufEnum {
-  static const PhoneNumber_PhoneType MOBILE = PhoneNumber_PhoneType._(0, _omitEnumNames ? '' : 'MOBILE');
-  static const PhoneNumber_PhoneType HOME = PhoneNumber_PhoneType._(1, _omitEnumNames ? '' : 'HOME');
-  static const PhoneNumber_PhoneType WORK = PhoneNumber_PhoneType._(2, _omitEnumNames ? '' : 'WORK');
+enum PhoneNumber_PhoneType implements $pb.ProtobufEnum {
+  MOBILE(0, _omitEnumNames ? '' : 'MOBILE'),
+
+  HOME(1, _omitEnumNames ? '' : 'HOME'),
+
+  WORK(2, _omitEnumNames ? '' : 'WORK'),
+
+  ;
 
   static const PhoneNumber_PhoneType BUSINESS = WORK;
-
-  static const $core.List<PhoneNumber_PhoneType> values = <PhoneNumber_PhoneType> [
-    MOBILE,
-    HOME,
-    WORK,
-  ];
 
   static final $core.Map<$core.int, PhoneNumber_PhoneType> _byValue = $pb.ProtobufEnum.initByValue(values);
   static PhoneNumber_PhoneType? valueOf($core.int value) => _byValue[value];
 
-  const PhoneNumber_PhoneType._($core.int v, $core.String n) : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const PhoneNumber_PhoneType(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
 

--- a/protoc_plugin/test/goldens/messageGeneratorEnums.meta
+++ b/protoc_plugin/test/goldens/messageGeneratorEnums.meta
@@ -4,8 +4,8 @@ annotation: {
   path: 4
   path: 0
   sourceFile: 
-  begin: 6
-  end: 27
+  begin: 5
+  end: 26
 }
 annotation: {
   path: 4
@@ -15,8 +15,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 92
-  end: 98
+  begin: 59
+  end: 65
 }
 annotation: {
   path: 4
@@ -26,8 +26,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 198
-  end: 202
+  begin: 105
+  end: 109
 }
 annotation: {
   path: 4
@@ -37,8 +37,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 300
-  end: 304
+  begin: 147
+  end: 151
 }
 annotation: {
   path: 4
@@ -48,6 +48,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 403
-  end: 411
+  begin: 229
+  end: 237
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 526
-  end: 537
+  begin: 510
+  end: 521
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 608
-  end: 619
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2328
-  end: 2334
+  begin: 592
+  end: 603
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2376
-  end: 2382
+  begin: 2312
+  end: 2318
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2455
-  end: 2464
+  begin: 2360
+  end: 2366
 }
 annotation: {
   path: 4
@@ -45,17 +36,17 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2507
-  end: 2518
+  begin: 2439
+  end: 2448
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: test
-  begin: 2578
-  end: 2582
+  begin: 2491
+  end: 2502
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2624
-  end: 2628
+  begin: 2562
+  end: 2566
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2703
-  end: 2710
+  begin: 2608
+  end: 2612
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2753
-  end: 2762
+  begin: 2687
+  end: 2694
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2737
+  end: 2746
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2825
-  end: 2829
+  begin: 2809
+  end: 2813
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2876
-  end: 2880
+  begin: 2860
+  end: 2864
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2953
-  end: 2960
+  begin: 2937
+  end: 2944
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3003
-  end: 3012
+  begin: 2987
+  end: 2996
 }

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: testpkg.proto
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes
@@ -13,23 +12,31 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-class PhoneType extends $pb.ProtobufEnum {
-  static const PhoneType MOBILE = PhoneType._(0, _omitEnumNames ? '' : 'MOBILE');
-  static const PhoneType HOME = PhoneType._(1, _omitEnumNames ? '' : 'HOME');
-  static const PhoneType WORK = PhoneType._(2, _omitEnumNames ? '' : 'WORK');
+enum PhoneType implements $pb.ProtobufEnum {
+  MOBILE(0, _omitEnumNames ? '' : 'MOBILE'),
+
+  HOME(1, _omitEnumNames ? '' : 'HOME'),
+
+  WORK(2, _omitEnumNames ? '' : 'WORK'),
+
+  ;
 
   static const PhoneType BUSINESS = WORK;
-
-  static const $core.List<PhoneType> values = <PhoneType> [
-    MOBILE,
-    HOME,
-    WORK,
-  ];
 
   static final $core.Map<$core.int, PhoneType> _byValue = $pb.ProtobufEnum.initByValue(values);
   static PhoneType? valueOf($core.int value) => _byValue[value];
 
-  const PhoneType._($core.int v, $core.String n) : super(v, n);
+  @$core.override
+  final $core.int value;
+
+  @$core.override
+  final $core.String name;
+
+  const PhoneType(this.value, this.name);
+
+  /// Returns this enum's [name] or the [value] if names are not represented.
+  @$core.override
+  $core.String toString() => name == '' ? value.toString() : name;
 }
 
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 445
-  end: 454
+  begin: 428
+  end: 437
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 507
-  end: 513
+  begin: 470
+  end: 476
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 589
-  end: 593
+  begin: 516
+  end: 520
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 667
-  end: 671
+  begin: 558
+  end: 562
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 746
-  end: 754
+  begin: 628
+  end: 636
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -2,7 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes


### PR DESCRIPTION
This PR changes the enum generation to generate actual enums.

I think sooner or later this is a necessary step to take full advantage of dart`s features.

#862 Also motivates this change.

I tried to keep everything as compatible as possible. I think my implementation should be fully compatible. (Except of sup-typing generated enums. But I think nobody has done this.)

I've grouped my changes into four commits to simplify reviewing this PR.

Close #862 