### PR TITLE
Change the method of IntList equals from toString to ListEquality.equals. In my case, codegen 15x faster

### DIFF
--- a/protoc_plugin/lib/src/shared.dart
+++ b/protoc_plugin/lib/src/shared.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 import 'dart:io';
+import 'package:collection/collection.dart';
 
 import '../protoc.dart';
 
@@ -23,8 +24,9 @@ extension FileDescriptorProtoExt on FileGenerator {
   /// The output can contain multiple lines. None of the lines will have
   /// trailing whitespace.
   String? commentBlock(List<int> path) {
+    final eq = ListEquality().equals;
     final bits = descriptor.sourceCodeInfo.location
-        .where((element) => element.path.toString() == path.toString())
+        .where((element) => eq(element.path, path))
         .toList();
 
     if (bits.length == 1) {


### PR DESCRIPTION
I have a 6000-line proto file, and it takes one minute to generate Dart code using the Dart proto plugin. After changing to the ListEquality.equals method, it only takes 4.6 seconds. If I completely remove the commentBlock call and compile it into an AOT (Ahead-of-Time) artifact, it only takes 200ms.

> ❯ time protoc --dart_out=./dart/lib1 test.proto
> protoc --dart_out=./dart/lib1 test.proto  62.60s user 0.75s system 100% cpu 1:03.31 total
> ❯ time protoc --dart_out=./dart/lib1 --plugin=protobuf.dart/protoc_plugin/bin/protoc-gen-dart test.proto
> protoc --dart_out=./dart/lib1  test.proto  4.61s user 0.32s system 125% cpu 3.918 total