### PR TITLE
Replace removed `dart:typed_data` type in test code

### DIFF
--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -2,11 +2,11 @@ name: protobuf
 version: 4.0.0-dev
 description: >-
   Runtime library for protocol buffers support. Use with package:protoc_plugin
-  to generate dart code for your '.proto' files.
+  to generate Dart code for your '.proto' files.
 repository: https://github.com/google/protobuf.dart/tree/master/protobuf
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
   collection: ^1.15.0

--- a/protobuf/test/coded_buffer_reader_test.dart
+++ b/protobuf/test/coded_buffer_reader_test.dart
@@ -84,11 +84,7 @@ void main() {
     });
 
     test('unmodifiable-uint8-list-view', () {
-      // TODO: Use `Uint8List.asUnmodifiableView` instead of
-      // `UnmodifiableUint8ListView` when it's available in the oldest
-      // supported SDK version.
-      // ignore: deprecated_member_use
-      testWithList(UnmodifiableUint8ListView(Uint8List.fromList(inputBuffer)));
+      testWithList(Uint8List.fromList(inputBuffer).asUnmodifiableView());
     });
 
     test('uint8-list-view', () {


### PR DESCRIPTION
`Unmodifiable...View` types were deprecated in favor of `asModifiableView`s members introduced in SDK 3.3.0.

These types are now removed, so the protobuf package tests can't be built with the most recent SDK.

Bump the SDK dependency to 3.3.0 (the version introduced `asModifiableView`) and replace the removed type with `asModifiableView` in the test.