### PR TITLE
Improve packed field decoding

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -130,9 +130,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_BOOL:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readBool());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readBool());
+            }
+          });
         } else {
           list.add(input.readBool());
         }
@@ -148,9 +150,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_FLOAT:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readFloat());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readFloat());
+            }
+          });
         } else {
           list.add(input.readFloat());
         }
@@ -158,9 +162,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_DOUBLE:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readDouble());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readDouble());
+            }
+          });
         } else {
           list.add(input.readDouble());
         }
@@ -179,9 +185,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_INT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readInt32());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readInt32());
+            }
+          });
         } else {
           list.add(input.readInt32());
         }
@@ -189,9 +197,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_INT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readInt64());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readInt64());
+            }
+          });
         } else {
           list.add(input.readInt64());
         }
@@ -199,9 +209,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_SINT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readSint32());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readSint32());
+            }
+          });
         } else {
           list.add(input.readSint32());
         }
@@ -209,9 +221,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_SINT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readSint64());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readSint64());
+            }
+          });
         } else {
           list.add(input.readSint64());
         }
@@ -219,9 +233,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_UINT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readUint32());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readUint32());
+            }
+          });
         } else {
           list.add(input.readUint32());
         }
@@ -229,9 +245,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_UINT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readUint64());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readUint64());
+            }
+          });
         } else {
           list.add(input.readUint64());
         }
@@ -239,9 +257,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_FIXED32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readFixed32());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readFixed32());
+            }
+          });
         } else {
           list.add(input.readFixed32());
         }
@@ -249,9 +269,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_FIXED64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readFixed64());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readFixed64());
+            }
+          });
         } else {
           list.add(input.readFixed64());
         }
@@ -259,9 +281,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_SFIXED32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readSfixed32());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readSfixed32());
+            }
+          });
         } else {
           list.add(input.readSfixed32());
         }
@@ -269,9 +293,11 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_SFIXED64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          @pragma('vm:prefer-inline')
-          void readElem() => list.add(input.readSfixed64());
-          _readPacked(input, readElem);
+          input._withLimit(input.readInt32(), () {
+            while (!input.isAtEnd()) {
+              list.add(input.readSfixed64());
+            }
+          });
         } else {
           list.add(input.readSfixed64());
         }
@@ -293,15 +319,6 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         throw UnsupportedError('Unknown field type $fieldType');
     }
   }
-}
-
-@pragma('vm:prefer-inline')
-void _readPacked(CodedBufferReader input, final void Function() readFunc) {
-  input._withLimit(input.readInt32(), () {
-    while (!input.isAtEnd()) {
-      readFunc();
-    }
-  });
 }
 
 void _readPackableToListEnum(

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -129,45 +129,65 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_BOOL:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readBool());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            // No need to check the element as for `bool` fields we only need to
+            // check that the value is not null, and we know in `add` below that
+            // the value isn't null (`readBool` doesn't return `null`).
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readBool());
+              }
+            });
+          }
         } else {
-          list.add(input.readBool());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readBool());
         }
         break;
       case PbFieldType._REPEATED_BYTES:
         final list = fs._ensureRepeatedField(meta, fi);
-        list.add(input.readBytes());
+        list._checkModifiable('add');
+        list._addUnchecked(input.readBytes());
         break;
       case PbFieldType._REPEATED_STRING:
         final list = fs._ensureRepeatedField(meta, fi);
-        list.add(input.readString());
+        list._checkModifiable('add');
+        list._addUnchecked(input.readString());
         break;
       case PbFieldType._REPEATED_FLOAT:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readFloat());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readFloat());
+              }
+            });
+          }
         } else {
-          list.add(input.readFloat());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readFloat());
         }
         break;
       case PbFieldType._REPEATED_DOUBLE:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readDouble());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readDouble());
+              }
+            });
+          }
         } else {
-          list.add(input.readDouble());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readDouble());
         }
         break;
       case PbFieldType._REPEATED_ENUM:
@@ -184,121 +204,171 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_INT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readInt32());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readInt32());
+              }
+            });
+          }
         } else {
-          list.add(input.readInt32());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readInt32());
         }
         break;
       case PbFieldType._REPEATED_INT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readInt64());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readInt64());
+              }
+            });
+          }
         } else {
-          list.add(input.readInt64());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readInt64());
         }
         break;
       case PbFieldType._REPEATED_SINT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readSint32());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readSint32());
+              }
+            });
+          }
         } else {
-          list.add(input.readSint32());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readSint32());
         }
         break;
       case PbFieldType._REPEATED_SINT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readSint64());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readSint64());
+              }
+            });
+          }
         } else {
-          list.add(input.readSint64());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readSint64());
         }
         break;
       case PbFieldType._REPEATED_UINT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readUint32());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readUint32());
+              }
+            });
+          }
         } else {
-          list.add(input.readUint32());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readUint32());
         }
         break;
       case PbFieldType._REPEATED_UINT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readUint64());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readUint64());
+              }
+            });
+          }
         } else {
-          list.add(input.readUint64());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readUint64());
         }
         break;
       case PbFieldType._REPEATED_FIXED32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readFixed32());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readFixed32());
+              }
+            });
+          }
         } else {
-          list.add(input.readFixed32());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readFixed32());
         }
         break;
       case PbFieldType._REPEATED_FIXED64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readFixed64());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readFixed64());
+              }
+            });
+          }
         } else {
-          list.add(input.readFixed64());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readFixed64());
         }
         break;
       case PbFieldType._REPEATED_SFIXED32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readSfixed32());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readSfixed32());
+              }
+            });
+          }
         } else {
-          list.add(input.readSfixed32());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readSfixed32());
         }
         break;
       case PbFieldType._REPEATED_SFIXED64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          input._withLimit(input.readInt32(), () {
-            while (!input.isAtEnd()) {
-              list.add(input.readSfixed64());
-            }
-          });
+          final limit = input.readInt32();
+          if (limit != 0) {
+            list._checkModifiable('add');
+            input._withLimit(limit, () {
+              while (!input.isAtEnd()) {
+                list._addUnchecked(input.readSfixed64());
+              }
+            });
+          }
         } else {
-          list.add(input.readSfixed64());
+          list._checkModifiable('add');
+          list._addUnchecked(input.readSfixed64());
         }
         break;
       case PbFieldType._REPEATED_MESSAGE:

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -130,7 +130,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_BOOL:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readBool()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readBool());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readBool());
         }
@@ -146,7 +148,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_FLOAT:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readFloat()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readFloat());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readFloat());
         }
@@ -154,7 +158,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_DOUBLE:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readDouble()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readDouble());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readDouble());
         }
@@ -173,7 +179,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_INT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readInt32()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readInt32());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readInt32());
         }
@@ -181,7 +189,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_INT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readInt64()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readInt64());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readInt64());
         }
@@ -189,7 +199,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_SINT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readSint32()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readSint32());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readSint32());
         }
@@ -197,7 +209,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_SINT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readSint64()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readSint64());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readSint64());
         }
@@ -205,7 +219,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_UINT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readUint32()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readUint32());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readUint32());
         }
@@ -213,7 +229,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_UINT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readUint64()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readUint64());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readUint64());
         }
@@ -221,7 +239,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_FIXED32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readFixed32()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readFixed32());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readFixed32());
         }
@@ -229,7 +249,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_FIXED64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readFixed64()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readFixed64());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readFixed64());
         }
@@ -237,7 +259,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_SFIXED32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readSfixed32()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readSfixed32());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readSfixed32());
         }
@@ -245,7 +269,9 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
       case PbFieldType._REPEATED_SFIXED64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
-          _readPacked(input, () => list.add(input.readSfixed64()));
+          @pragma('vm:prefer-inline')
+          void readElem() => list.add(input.readSfixed64());
+          _readPacked(input, readElem);
         } else {
           list.add(input.readSfixed64());
         }
@@ -269,7 +295,8 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
   }
 }
 
-void _readPacked(CodedBufferReader input, void Function() readFunc) {
+@pragma('vm:prefer-inline')
+void _readPacked(CodedBufferReader input, final void Function() readFunc) {
   input._withLimit(input.readInt32(), () {
     while (!input.isAtEnd()) {
       readFunc();

--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -42,14 +42,17 @@ class CodedBufferReader {
     throw InvalidProtocolBufferException.truncatedMessage();
   }
 
+  @pragma('vm:prefer-inline')
   void checkLastTagWas(int value) {
     if (_lastTag != value) {
       throw InvalidProtocolBufferException.invalidEndTag();
     }
   }
 
+  @pragma('vm:prefer-inline')
   bool isAtEnd() => _bufferPos >= _currentLimit;
 
+  @pragma('vm:prefer-inline')
   void _withLimit(int byteLimit, Function() callback) {
     if (byteLimit < 0) {
       throw ArgumentError(
@@ -66,6 +69,7 @@ class CodedBufferReader {
     _currentLimit = oldLimit;
   }
 
+  @pragma('vm:prefer-inline')
   void _checkLimit(int increment) {
     assert(_currentLimit != -1);
     _bufferPos += increment;
@@ -121,28 +125,45 @@ class CodedBufferReader {
     _currentLimit = oldLimit;
   }
 
+  @pragma('vm:prefer-inline')
   int readEnum() => readInt32();
+  
+  @pragma('vm:prefer-inline')
   int readInt32() => _readRawVarint32(true);
+  
+  @pragma('vm:prefer-inline')
   Int64 readInt64() => _readRawVarint64();
+  
+  @pragma('vm:prefer-inline')
   int readUint32() => _readRawVarint32(false);
+  
+  @pragma('vm:prefer-inline')
   Int64 readUint64() => _readRawVarint64();
+  
+  @pragma('vm:prefer-inline')
   int readSint32() => _decodeZigZag32(readUint32());
+  
+  @pragma('vm:prefer-inline')
   Int64 readSint64() => _decodeZigZag64(readUint64());
 
+  @pragma('vm:prefer-inline')
   int readFixed32() {
     final pos = _bufferPos;
     _checkLimit(4);
     return _byteData.getUint32(pos, Endian.little);
   }
 
+  @pragma('vm:prefer-inline')
   Int64 readFixed64() => readSfixed64();
 
+  @pragma('vm:prefer-inline')
   int readSfixed32() {
     final pos = _bufferPos;
     _checkLimit(4);
     return _byteData.getInt32(pos, Endian.little);
   }
 
+  @pragma('vm:prefer-inline')
   Int64 readSfixed64() {
     final pos = _bufferPos;
     _checkLimit(8);
@@ -150,15 +171,18 @@ class CodedBufferReader {
     return Int64.fromBytes(view);
   }
 
+  @pragma('vm:prefer-inline')
   bool readBool() => _readRawVarint32(true) != 0;
 
   /// Read a length-delimited field as bytes.
+  @pragma('vm:prefer-inline')
   Uint8List readBytes() => Uint8List.fromList(readBytesAsView());
 
   /// Read a length-delimited field as a view of the [CodedBufferReader]'s
   /// buffer. When storing the returned value directly (instead of e.g. parsing
   /// it as a UTF-8 string and copying) use [readBytes] instead to avoid
   /// holding on to the whole message, or copy the returned view.
+  @pragma('vm:prefer-inline')
   Uint8List readBytesAsView() {
     final length = readInt32();
     _checkLimit(length);
@@ -166,6 +190,7 @@ class CodedBufferReader {
         _buffer.buffer, _buffer.offsetInBytes + _bufferPos - length, length);
   }
 
+  @pragma('vm:prefer-inline')
   String readString() {
     final length = readInt32();
     final stringPos = _bufferPos;
@@ -174,18 +199,21 @@ class CodedBufferReader {
         .convert(_buffer, stringPos, stringPos + length);
   }
 
+  @pragma('vm:prefer-inline')
   double readFloat() {
     final pos = _bufferPos;
     _checkLimit(4);
     return _byteData.getFloat32(pos, Endian.little);
   }
 
+  @pragma('vm:prefer-inline')
   double readDouble() {
     final pos = _bufferPos;
     _checkLimit(8);
     return _byteData.getFloat64(pos, Endian.little);
   }
 
+  @pragma('vm:prefer-inline')
   int readTag() {
     if (isAtEnd()) {
       _lastTag = 0;
@@ -228,6 +256,7 @@ class CodedBufferReader {
     }
   }
 
+  @pragma('vm:prefer-inline')
   static int _decodeZigZag32(int value) {
     if ((value & 0x1) == 1) {
       return -(value >> 1) - 1;
@@ -236,11 +265,13 @@ class CodedBufferReader {
     }
   }
 
+  @pragma('vm:prefer-inline')
   static Int64 _decodeZigZag64(Int64 value) {
     if ((value & 0x1) == 1) value = -value;
     return value >> 1;
   }
 
+  @pragma('vm:prefer-inline')
   int _readRawVarintByte() {
     _checkLimit(1);
     return _buffer[_bufferPos - 1];

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -66,6 +66,7 @@ class _ExtensionFieldSet {
     return newList;
   }
 
+  @pragma('vm:prefer-inline')
   dynamic _getFieldOrNull(Extension extension) => _values[extension.tagNumber];
 
   void _clearFieldAndInfo(Extension fi) {

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -4,6 +4,7 @@
 
 part of '../../protobuf.dart';
 
+@pragma('vm:never-inline')
 void _throwFrozenMessageModificationError(String messageName,
     [String? methodName]) {
   if (methodName != null) {
@@ -161,6 +162,7 @@ class _FieldSet {
     _unknownFields?._markReadOnly();
   }
 
+  @pragma('vm:prefer-inline')
   void _ensureWritable() {
     if (_isReadOnly) {
       _throwFrozenMessageModificationError(_messageName);

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -162,7 +162,6 @@ class _FieldSet {
     _unknownFields?._markReadOnly();
   }
 
-  @pragma('vm:prefer-inline')
   void _ensureWritable() {
     if (_isReadOnly) {
       _throwFrozenMessageModificationError(_messageName);

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -52,6 +52,12 @@ class PbList<E> extends ListBase<E> {
     _wrappedList.add(element);
   }
 
+  @pragma('dart2js:tryInline')
+  @pragma('vm:prefer-inline')
+  void _addUnchecked(E element) {
+    _wrappedList.add(element);
+  }
+
   @override
   @pragma('dart2js:never-inline')
   void addAll(Iterable<E> iterable) {

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -190,7 +190,6 @@ class UnknownFieldSet {
     _isReadOnly = true;
   }
 
-  @pragma('vm:prefer-inline')
   void _ensureWritable(String methodName) {
     if (_isReadOnly) {
       _throwFrozenMessageModificationError('UnknownFieldSet', methodName);

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -190,6 +190,7 @@ class UnknownFieldSet {
     _isReadOnly = true;
   }
 
+  @pragma('vm:prefer-inline')
   void _ensureWritable(String methodName) {
     if (_isReadOnly) {
       _throwFrozenMessageModificationError('UnknownFieldSet', methodName);


### PR DESCRIPTION
- Inline `_readPacked` manually and `_withLimit` with a pragma to eliminate
  closure allocation and calls in packed decoding loops.

  - `_readPacked` is manually inlined as VM's inliner doesn't properly fold
    constants after the inlinings, see
    https://github.com/dart-lang/sdk/issues/60068.

- Introduce `PbList._addUnchecked` to add to the list without checking the
  value for validity and list for mutability.

- When decoding a packed field, check the list mutability once, instead of in
  every element.

- When decoding a packed scalar field, don't check for value validity.

  For scalar fields we need to make sure the field value is not null, which is
  already guaranteed in the call sites as e.g. `input.readDouble` doesn't
  return nullable.

- Sprinkle a bunch of `prefer-inline`s to make sure VM will inline one liners.

Looking at the optimized flow graph, thish would be quite fast compared to the
current version. However I can't benchmark this yet as none of the benchmarks
use packed fields.

I will update the benchmarks first, then revisit this PR.