### PR TITLE
updates to the gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,17 +4,16 @@
 .packages
 .pub
 build/
-**/lib/generated/**
-packages
 pubspec.lock
-benchmarks/out
 doc/
 
 # `dart compile exe` outputs
 *.exe
 
 # `dart compile js` outputs
-*.js*
+*.js
+*.js.deps
+*.js.map
 
 # `dart compile wasm` outputs
 *.wasm

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![CI status](https://github.com/google/protobuf.dart/workflows/Dart%20CI/badge.svg)](https://github.com/google/protobuf.dart/actions?query=workflow%3A%22Dart%22+branch%3Amaster)
-
 ## Protobuf support for Dart
 
 [Protocol Buffers](https://developers.google.com/protocol-buffers) (protobuf)
@@ -7,14 +5,14 @@ are Google's language-neutral, platform-neutral, extensible mechanism for
 serializing structured data.
 
 This repository is home to packages related to
-[protobuf for Dart](https://pub.dev/documentation/protobuf/latest/).
+[protobuf support for Dart](https://pub.dev/documentation/protobuf/latest/).
 
-Package | Description | Published Version
---- | --- | ---
-[protobuf](protobuf/) | A support library for the generated code | [![pub package](https://img.shields.io/pub/v/protobuf.svg)](https://pub.dev/packages/protobuf)
-[protoc_plugin](protoc_plugin/) | A Dart back-end for the protoc compiler | [![pub package](https://img.shields.io/pub/v/protoc_plugin.svg)](https://pub.dev/packages/protoc_plugin)
-[api_benchmark](api_benchmark/) | Benchmarking for various API calls |
-[query_benchmark](query_benchmark/) | Benchmark for encoding and decoding of a "real-world" protobuf |
+| Package | Description | Published Version |
+| --- | --- | --- |
+| [protobuf](protobuf/) | Runtime library for protocol buffers support. | [![pub package](https://img.shields.io/pub/v/protobuf.svg)](https://pub.dev/packages/protobuf) |
+| [protoc_plugin](protoc_plugin/) | A protobuf protoc compiler plugin used to generate Dart code. | [![pub package] |(https://img.shields.io/pub/v/protoc_plugin.svg)](https://pub.dev/packages/protoc_plugin)
+| [api_benchmark](api_benchmark/) | Benchmarking a number of different api calls. | |
+| [benchmarks](benchmarks/) | Benchmarks for various protobuf functions. | |
 
 ## Publishing automation
 

--- a/api_benchmark/.gitignore
+++ b/api_benchmark/.gitignore
@@ -1,0 +1,1 @@
+lib/generated/**

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,2 @@
+lib/generated/
+out/

--- a/benchmarks/pubspec.yaml
+++ b/benchmarks/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: protobuf_benchmarks
-description: Benchmarks various protobuf functions
+description: Benchmarks for various protobuf functions.
 publish_to: none
 
 environment:

--- a/protoc_plugin/.gitignore
+++ b/protoc_plugin/.gitignore
@@ -9,4 +9,4 @@ benchmark/data/pubspec.link.lock
 benchmark/data/hostname.txt
 benchmark/data/latest_vm.pb.json
 benchmark/lib/generated
-out
+out/

--- a/tool/setup.sh
+++ b/tool/setup.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-wget -O protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protoc-3.17.3-linux-x86_64.zip
+wget -O protoc.zip \
+  https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protoc-3.17.3-linux-x86_64.zip
 unzip -d protoc protoc.zip
+
 if [[ -z "${GITHUB_ENV}" ]]; then
-  # Local mono_repo presubmit run
+  # Local run
   export PATH=$PWD/protoc/bin:$PATH
 else
   # GitHub Actions


### PR DESCRIPTION
- various updates to the gitignore files (this should address a pub publish warning - the git ignore were accidentally capturing one of the generated json files)
- minor updates to the readme and other files

The publish bot gitignore issue:

```
  Package validation found the following potential issue:
  * 1 checked-in file is ignored by a `.gitignore`.
    Previous versions of Pub would include those in the published package.
    
    Consider adjusting your `.gitignore` files to not ignore those files, and if you do not wish to
    publish these files use `.pubignore`. See also dart.dev/go/pubignore
    
    Files that are checked in while gitignored:
    
    test/goldens/serviceGenerator.pb.json
 ```

