### PR TITLE
update the publish workflow; add a post_summaries one

### DIFF
--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,0 +1,17 @@
+name: Comment on the pull request
+
+on:
+  # Trigger this workflow after the Publish workflow completes. This workflow
+  # will have permissions to do things like create comments on the PR, even if
+  # the original workflow couldn't.
+  workflow_run:
+    workflows:
+      - Publish
+    types:
+      - completed
+
+jobs:
+  upload:
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    permissions:
+      pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,18 +3,17 @@
 name: Publish
 
 on:
-  # Trigger on pull requests that target the default branch.
   pull_request:
-    branches: [ master ]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-  # Also, trigger when tags are pushed to the repo.
+    branches: [master]
   push:
-    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
+    tags: ['[A-z]+-v[0-9]+.[0-9]+.[0-9]+*']
 
-# The script below will perform publishing checks (version checks, publishing
-# dry run, ...) when run on a PR, and perform an actual pub publish when run as
-# a result of a git tag event.
 jobs:
   publish:
     if: ${{ github.repository_owner == 'google' }}
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    permissions:
+      id-token: write
+      pull-requests: write
+    with:
+      write-comments: false


### PR DESCRIPTION
- update the publish workflow to write its comment to a workflow file
- add a post_summaries workflow - pull from the file and comment on the current PR

This config will allow PRs from forks to still get feedback in the PR from the publish workflow.