### PR TITLE
Prefix grpc method 'call' and 'request' arguments with '$' to avoid shadowing user methods with the same name

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -15,6 +15,9 @@
 * `protoc_plugin` and generated files now require Dart 3.3.0. (#953)
 * Fix performance issues when handling documentation comments in protobufs.
   ([#935], [#955])
+* Fix grpc methods with names 'call' and 'request' conflicting with other
+  methods in the generated code and causing compile-time errors. ([#963],
+  [#159])
 
 [#738]: https://github.com/google/protobuf.dart/issues/738
 [#903]: https://github.com/google/protobuf.dart/pull/903
@@ -26,6 +29,8 @@
 [#953]: https://github.com/google/protobuf.dart/pull/953
 [#935]: https://github.com/google/protobuf.dart/pull/935
 [#955]: https://github.com/google/protobuf.dart/pull/955
+[#963]: https://github.com/google/protobuf.dart/issues/963
+[#153]: https://github.com/google/protobuf.dart/issues/153
 
 ## 21.1.2
 

--- a/protoc_plugin/lib/src/grpc_generator.dart
+++ b/protoc_plugin/lib/src/grpc_generator.dart
@@ -276,12 +276,12 @@ class _GrpcMethod {
     if (_clientStreaming) return;
 
     out.addBlock(
-        '$_serverReturnType ${_dartName}_Pre($_serviceCall call, $_future<$_requestType> request) async${_serverStreaming ? '*' : ''} {',
+        '$_serverReturnType ${_dartName}_Pre($_serviceCall \$call, $_future<$_requestType> \$request) async${_serverStreaming ? '*' : ''} {',
         '}', () {
       if (_serverStreaming) {
-        out.println('yield* $_dartName(call, await request);');
+        out.println('yield* $_dartName(\$call, await \$request);');
       } else {
-        out.println('return $_dartName(call, await request);');
+        out.println('return $_dartName(\$call, await \$request);');
       }
     });
     out.println();
@@ -289,7 +289,7 @@ class _GrpcMethod {
 
   void generateServiceMethodStub(IndentingWriter out) {
     out.println(
-        '$_serverReturnType $_dartName($_serviceCall call, $_argumentType request);');
+        '$_serverReturnType $_dartName($_serviceCall \$call, $_argumentType \$request);');
   }
 
   static final String _serviceCall = '$grpcImportPrefix.ServiceCall';

--- a/protoc_plugin/lib/src/grpc_generator.dart
+++ b/protoc_plugin/lib/src/grpc_generator.dart
@@ -289,7 +289,7 @@ class _GrpcMethod {
 
   void generateServiceMethodStub(IndentingWriter out) {
     out.println(
-        '$_serverReturnType $_dartName($_serviceCall \$call, $_argumentType \$request);');
+        '$_serverReturnType $_dartName($_serviceCall call, $_argumentType request);');
   }
 
   static final String _serviceCall = '$grpcImportPrefix.ServiceCall';

--- a/protoc_plugin/test/file_generator_test.dart
+++ b/protoc_plugin/test/file_generator_test.dart
@@ -330,7 +330,14 @@ void main() {
 
     final sd = ServiceDescriptorProto()
       ..name = 'Test'
-      ..method.addAll([unary, clientStreaming, serverStreaming, bidirectional, keywordCall, keywordRequest]);
+      ..method.addAll([
+        unary,
+        clientStreaming,
+        serverStreaming,
+        bidirectional,
+        keywordCall,
+        keywordRequest
+      ]);
 
     final fd = FileDescriptorProto()
       ..name = 'test'

--- a/protoc_plugin/test/file_generator_test.dart
+++ b/protoc_plugin/test/file_generator_test.dart
@@ -288,18 +288,21 @@ void main() {
       ..outputType = '.Output'
       ..clientStreaming = false
       ..serverStreaming = false;
+
     final clientStreaming = MethodDescriptorProto()
       ..name = 'ClientStreaming'
       ..inputType = '.Input'
       ..outputType = '.Output'
       ..clientStreaming = true
       ..serverStreaming = false;
+
     final serverStreaming = MethodDescriptorProto()
       ..name = 'ServerStreaming'
       ..inputType = '.Input'
       ..outputType = '.Output'
       ..clientStreaming = false
       ..serverStreaming = true;
+
     final bidirectional = MethodDescriptorProto()
       ..name = 'Bidirectional'
       ..inputType = '.Input'
@@ -307,9 +310,27 @@ void main() {
       ..clientStreaming = true
       ..serverStreaming = true;
 
+    // A method with name 'call' to test that it doesn't conflict with the
+    // method arguments with the same name, see issue #963.
+    final keywordCall = MethodDescriptorProto()
+      ..name = 'Call'
+      ..inputType = '.Input'
+      ..outputType = '.Output'
+      ..clientStreaming = false
+      ..serverStreaming = false;
+
+    // A method with name 'request' to test that it doesn't conflict with the
+    // method arguments with the same name, see issue #159.
+    final keywordRequest = MethodDescriptorProto()
+      ..name = 'Request'
+      ..inputType = '.Input'
+      ..outputType = '.Output'
+      ..clientStreaming = false
+      ..serverStreaming = false;
+
     final sd = ServiceDescriptorProto()
       ..name = 'Test'
-      ..method.addAll([unary, clientStreaming, serverStreaming, bidirectional]);
+      ..method.addAll([unary, clientStreaming, serverStreaming, bidirectional, keywordCall, keywordRequest]);
 
     final fd = FileDescriptorProto()
       ..name = 'test'

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -142,10 +142,10 @@ abstract class TestServiceBase extends $grpc.Service {
     return request($call, await $request);
   }
 
-  $async.Future<$0.Output> unary($grpc.ServiceCall $call, $0.Input $request);
-  $async.Future<$0.Output> clientStreaming($grpc.ServiceCall $call, $async.Stream<$0.Input> $request);
-  $async.Stream<$0.Output> serverStreaming($grpc.ServiceCall $call, $0.Input $request);
-  $async.Stream<$0.Output> bidirectional($grpc.ServiceCall $call, $async.Stream<$0.Input> $request);
-  $async.Future<$0.Output> call($grpc.ServiceCall $call, $0.Input $request);
-  $async.Future<$0.Output> request($grpc.ServiceCall $call, $0.Input $request);
+  $async.Future<$0.Output> unary($grpc.ServiceCall call, $0.Input request);
+  $async.Future<$0.Output> clientStreaming($grpc.ServiceCall call, $async.Stream<$0.Input> request);
+  $async.Stream<$0.Output> serverStreaming($grpc.ServiceCall call, $0.Input request);
+  $async.Stream<$0.Output> bidirectional($grpc.ServiceCall call, $async.Stream<$0.Input> request);
+  $async.Future<$0.Output> call($grpc.ServiceCall call, $0.Input request);
+  $async.Future<$0.Output> request($grpc.ServiceCall call, $0.Input request);
 }

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -37,6 +37,14 @@ class TestClient extends $grpc.Client {
       '/Test/Bidirectional',
       ($0.Input value) => value.writeToBuffer(),
       ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
+  static final _$call = $grpc.ClientMethod<$0.Input, $0.Output>(
+      '/Test/Call',
+      ($0.Input value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
+  static final _$request = $grpc.ClientMethod<$0.Input, $0.Output>(
+      '/Test/Request',
+      ($0.Input value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
 
   TestClient($grpc.ClientChannel channel,
       {$grpc.CallOptions? options,
@@ -58,6 +66,14 @@ class TestClient extends $grpc.Client {
 
   $grpc.ResponseStream<$0.Output> bidirectional($async.Stream<$0.Input> request, {$grpc.CallOptions? options}) {
     return $createStreamingCall(_$bidirectional, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.Output> call($0.Input request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$call, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.Output> request($0.Input request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$request, request, options: options);
   }
 }
 
@@ -94,18 +110,42 @@ abstract class TestServiceBase extends $grpc.Service {
         true,
         ($core.List<$core.int> value) => $0.Input.fromBuffer(value),
         ($0.Output value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.Input, $0.Output>(
+        'Call',
+        call_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.Input.fromBuffer(value),
+        ($0.Output value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.Input, $0.Output>(
+        'Request',
+        request_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.Input.fromBuffer(value),
+        ($0.Output value) => value.writeToBuffer()));
   }
 
-  $async.Future<$0.Output> unary_Pre($grpc.ServiceCall call, $async.Future<$0.Input> request) async {
-    return unary(call, await request);
+  $async.Future<$0.Output> unary_Pre($grpc.ServiceCall $call, $async.Future<$0.Input> $request) async {
+    return unary($call, await $request);
   }
 
-  $async.Stream<$0.Output> serverStreaming_Pre($grpc.ServiceCall call, $async.Future<$0.Input> request) async* {
-    yield* serverStreaming(call, await request);
+  $async.Stream<$0.Output> serverStreaming_Pre($grpc.ServiceCall $call, $async.Future<$0.Input> $request) async* {
+    yield* serverStreaming($call, await $request);
   }
 
-  $async.Future<$0.Output> unary($grpc.ServiceCall call, $0.Input request);
-  $async.Future<$0.Output> clientStreaming($grpc.ServiceCall call, $async.Stream<$0.Input> request);
-  $async.Stream<$0.Output> serverStreaming($grpc.ServiceCall call, $0.Input request);
-  $async.Stream<$0.Output> bidirectional($grpc.ServiceCall call, $async.Stream<$0.Input> request);
+  $async.Future<$0.Output> call_Pre($grpc.ServiceCall $call, $async.Future<$0.Input> $request) async {
+    return call($call, await $request);
+  }
+
+  $async.Future<$0.Output> request_Pre($grpc.ServiceCall $call, $async.Future<$0.Input> $request) async {
+    return request($call, await $request);
+  }
+
+  $async.Future<$0.Output> unary($grpc.ServiceCall $call, $0.Input $request);
+  $async.Future<$0.Output> clientStreaming($grpc.ServiceCall $call, $async.Stream<$0.Input> $request);
+  $async.Stream<$0.Output> serverStreaming($grpc.ServiceCall $call, $0.Input $request);
+  $async.Stream<$0.Output> bidirectional($grpc.ServiceCall $call, $async.Stream<$0.Input> $request);
+  $async.Future<$0.Output> call($grpc.ServiceCall $call, $0.Input $request);
+  $async.Future<$0.Output> request($grpc.ServiceCall $call, $0.Input $request);
 }


### PR DESCRIPTION
Fixes #159
Fixes #963

Tested:

- Protos in `googleapis`, `helloworld`, and `metadata` examples in [`grpc`][1] are re-generated using this patch and the projects are analyzed with `dart analyze` using the protobuf library in this patch.

- Global presubmits in cl/731182528.

[1]: https://github.com/grpc/grpc-dart/tree/master/example