### PR TITLE
Sort input proto files before processing

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 22.0.2-wip
 
 * Fix factory argument types for protobuf `Map` fields. ([#975])
+* Fix import order changes when files are passed in different order to `protoc`.
+([#952])
 
 [#975]: https://github.com/google/protobuf.dart/issues/975
+[#952]: https://github.com/google/protobuf.dart/issues/952
 
 ## 22.0.1
 

--- a/protoc_plugin/lib/src/code_generator.dart
+++ b/protoc_plugin/lib/src/code_generator.dart
@@ -5,6 +5,7 @@
 import 'dart:io' hide BytesBuilder;
 import 'dart:typed_data' show BytesBuilder;
 
+import 'package:collection/collection.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart';
 
@@ -104,6 +105,8 @@ class CodeGenerator {
       final request = CodeGeneratorRequest();
       request.mergeFromCodedBufferReader(reader, extensions);
       reader.checkLastTagWas(0);
+
+      request.protoFile.sortBy((desc) => desc.name);
 
       final response = CodeGeneratorResponse();
 

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
+  collection: ^1.15.0
   fixnum: ^1.0.0
   path: ^1.8.0
   protobuf: ^4.0.0
 
 dev_dependencies:
-  collection: ^1.15.0
   dart_flutter_team_lints: ^1.0.0
   matcher: ^0.12.10
   test: ^1.16.0


### PR DESCRIPTION
This makes the plugin generate identical files when command line argument orders change.

Fixes #952.

---

cl/755913309