### PR TITLE
rev to 22.1.0 in prep for publishing

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 22.0.2-wip
+## 22.1.0
 
 * Fix factory argument types for protobuf `Map` fields. ([#975])
 * Fix import order changes when files are passed in different order to `protoc`.

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 22.0.2-wip
+version: 22.1.0
 description: A protobuf protoc compiler plugin used to generate Dart code.
 repository: https://github.com/google/protobuf.dart/tree/master/protoc_plugin
 


### PR DESCRIPTION
- bump to a new minor version (we'd added some new API methods)
- rev to a stable (non `-wip`) version in prep for publishing
