### PR TITLE
Move plugin dependency_overrides from separate file to pubspec.yaml

### DIFF
--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -19,3 +19,7 @@ dev_dependencies:
 
 executables:
   protoc-gen-dart: protoc_plugin
+
+dependency_overrides:
+  protobuf:
+    path: ../protobuf

--- a/protoc_plugin/pubspec_overrides.yaml
+++ b/protoc_plugin/pubspec_overrides.yaml
@@ -1,3 +1,0 @@
-dependency_overrides:
-  protobuf:
-    path: ../protobuf


### PR DESCRIPTION
It's more common to have the overrides in the main pubspec.