### PR TITLE
address a merge issue with the protoc_plugin changelog

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -3,9 +3,9 @@
 * Bump `protobuf` constraint to `^4.1.0`
 * Read `default_host` and `oauth_scopes` options from gRPC service definitions
   and write that information to the generated gRPC clients.
-* Generate dartdocs for grpc services ([#973]).
 * Adjust the deprecation messages for the message `clone()` and `copyWith()`
   methods ([#998]).
+* Generate dartdocs for grpc services ([#973]).
 
   We now parse and generate code cooresponding to the proto options
   `google.api.default_host` and `google.api.oauth_scopes`:


### PR DESCRIPTION
- address a merge issue with the protoc_plugin changelog

Two PRs landed around the same time, and the additional content for the 'deprecation messages' entry was confused w/ the 'grpc services' entry.