### PR TITLE
revert the change to not generate empty enum files

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Update how we calculate import prefixes ([#1010]); import prefixes are now
   unique per-library instead of being unique across all generated libraries.
 * Ignore `unused_import` diagnostics for `*.pbjson.dart` files.
+* Revert the change to not generate empty `*.pbenum.dart` files; these can be
+  exported from other enum files.
 
 [#1010]: https://github.com/google/protobuf.dart/issues/1010
 

--- a/protoc_plugin/Makefile
+++ b/protoc_plugin/Makefile
@@ -69,7 +69,8 @@ TEST_PROTO_LIST = \
 	using_any
 TEST_PROTO_DIR=$(OUTPUT_DIR)
 TEST_PROTO_LIBS=$(foreach f, $(TEST_PROTO_LIST), \
-  $(TEST_PROTO_DIR)/$(f).pb.dart \
+	$(TEST_PROTO_DIR)/$(f).pb.dart \
+	$(TEST_PROTO_DIR)/$(f).pbenum.dart \
 	$(TEST_PROTO_DIR)/$(f).pbjson.dart)
 TEST_PROTO_SRC_DIR=test/protos
 TEST_PROTO_SRCS=$(foreach proto, $(TEST_PROTO_LIST), \

--- a/protoc_plugin/lib/src/file_generator.dart
+++ b/protoc_plugin/lib/src/file_generator.dart
@@ -232,11 +232,11 @@ class FileGenerator extends ProtobufContainer {
     }
 
     final mainWriter = generateMainFile(config);
-    final enumWriter = hasEnums ? generateEnumFile(config) : null;
+    final enumWriter = generateEnumFile(config);
 
     final files = [
       makeFile('.pb.dart', mainWriter.toString()),
-      if (enumWriter != null) makeFile('.pbenum.dart', enumWriter.toString()),
+      makeFile('.pbenum.dart', enumWriter.toString()),
       // TODO(devoncarew): Consider not emitting empty json files.
       makeFile('.pbjson.dart', generateJsonFile(config)),
     ];
@@ -245,9 +245,8 @@ class FileGenerator extends ProtobufContainer {
       files.addAll([
         makeFile('.pb.dart.meta',
             mainWriter.sourceLocationInfo.writeToJson().toString()),
-        if (enumWriter != null)
-          makeFile('.pbenum.dart.meta',
-              enumWriter.sourceLocationInfo.writeToJson().toString())
+        makeFile('.pbenum.dart.meta',
+            enumWriter.sourceLocationInfo.writeToJson().toString())
       ]);
     }
     if (options.useGrpc) {
@@ -355,7 +354,7 @@ class FileGenerator extends ProtobufContainer {
     }
 
     // Export enums in main file for backward compatibility.
-    if (enumCount > 0) {
+    if (hasEnums) {
       final url =
           config.resolveImport(protoFileUri, protoFileUri, '.pbenum.dart');
       importWriter.addExport(url.toString());
@@ -428,7 +427,7 @@ class FileGenerator extends ProtobufContainer {
 
     final importWriter = ImportWriter();
 
-    if (enumCount > 0) {
+    if (hasEnums) {
       // Make sure any other symbols in dart:core don't cause name conflicts
       // with enums that have the same name.
       importWriter.addImport(_coreImportUrl, prefix: coreImportPrefix);

--- a/protoc_plugin/lib/src/gen/dart_options.pbenum.dart
+++ b/protoc_plugin/lib/src/gen/dart_options.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: dart_options.proto
+//
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names

--- a/protoc_plugin/lib/src/gen/google/api/http.pbenum.dart
+++ b/protoc_plugin/lib/src/gen/google/api/http.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: google/api/http.proto
+//
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names

--- a/protoc_plugin/lib/src/gen/google/protobuf/duration.pbenum.dart
+++ b/protoc_plugin/lib/src/gen/google/protobuf/duration.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/duration.proto
+//
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names


### PR DESCRIPTION
Revert the change to not generate empty enum files (partial revert of https://github.com/google/protobuf.dart/pull/1006). Some enum files export other enums files, and we don't have any easy way to determine whether the file we're exporting was not generated.
