### PR TITLE
Add a helper for unchecked downcasts and use it

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -378,7 +378,7 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         list.add(subMessage);
         break;
       case PbFieldType._MAP:
-        final mapFieldInfo = fi as MapFieldInfo;
+        final mapFieldInfo = downcastUnchecked<MapFieldInfo>(fi);
         final mapEntryMeta = mapFieldInfo.mapEntryBuilderInfo;
         fs
             ._ensureMapField(meta, mapFieldInfo)

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -68,7 +68,7 @@ class CodedBufferWriter {
     final valueType = PbFieldType._baseType(fieldType);
 
     if ((fieldType & PbFieldType._PACKED_BIT) != 0) {
-      final list = fieldValue as List;
+      final list = downcastUnchecked<List>(fieldValue);
       if (list.isNotEmpty) {
         _writeTag(fieldNumber, WIRETYPE_LENGTH_DELIMITED);
         final mark = _startLengthDelimited();
@@ -81,7 +81,7 @@ class CodedBufferWriter {
     }
 
     if ((fieldType & PbFieldType._MAP_BIT) != 0) {
-      final map = fieldValue as PbMap;
+      final map = downcastUnchecked<PbMap>(fieldValue);
       final keyWireFormat = _wireTypes[_valueTypeIndex(map.keyFieldType)];
       final valueWireFormat = _wireTypes[_valueTypeIndex(map.valueFieldType)];
 
@@ -100,7 +100,7 @@ class CodedBufferWriter {
     final wireFormat = _wireTypes[_valueTypeIndex(valueType)];
 
     if ((fieldType & PbFieldType._REPEATED_BIT) != 0) {
-      final list = fieldValue as List;
+      final list = downcastUnchecked<List>(fieldValue);
       for (var i = 0; i < list.length; i++) {
         _writeValue(fieldNumber, valueType, list[i], wireFormat);
       }
@@ -250,7 +250,8 @@ class CodedBufferWriter {
   }
 
   void _endLengthDelimited(int index) {
-    final writtenSizeInBytes = _bytesTotal - _splices[index] as int;
+    final writtenSizeInBytes =
+        _bytesTotal - downcastUnchecked<int>(_splices[index]);
     // Note: 0 - writtenSizeInBytes to avoid -0.0 in JavaScript.
     _splices[index] = 0 - writtenSizeInBytes;
     _bytesTotal += _varint32LengthInBytes(writtenSizeInBytes);
@@ -342,7 +343,7 @@ class CodedBufferWriter {
         _writeVarint32(value ? 1 : 0);
         break;
       case PbFieldType._BYTES_BIT:
-        final List<int> bytes = value;
+        final bytes = downcastUnchecked<List<int>>(value);
         if (bytes is Uint8List) {
           _writeBytesNoTag(bytes);
         } else if (bytes.isEmpty) {
@@ -352,7 +353,7 @@ class CodedBufferWriter {
         }
         break;
       case PbFieldType._STRING_BIT:
-        final String string = value;
+        final string = downcastUnchecked<String>(value);
         if (string.isEmpty) {
           _writeEmptyBytes();
         } else {
@@ -366,7 +367,7 @@ class CodedBufferWriter {
         _writeFloat(value);
         break;
       case PbFieldType._ENUM_BIT:
-        final ProtobufEnum enum_ = value;
+        final enum_ = downcastUnchecked<ProtobufEnum>(value);
         _writeVarint32(enum_.value & 0xffffffff);
         break;
       case PbFieldType._GROUP_BIT:
@@ -376,11 +377,10 @@ class CodedBufferWriter {
         if (value is UnknownFieldSet) {
           // Give the variable a type to not rely on type promotion to
           // eliminate the dynamic call below.
-          // ignore: omit_local_variable_types
-          final UnknownFieldSet unknownFieldSet = value;
+          final unknownFieldSet = downcastUnchecked<UnknownFieldSet>(value);
           unknownFieldSet.writeToCodedBufferWriter(this);
         } else {
-          final GeneratedMessage message = value;
+          final message = downcastUnchecked<GeneratedMessage>(value);
           message.writeToCodedBufferWriter(this);
         }
         break;
@@ -416,7 +416,7 @@ class CodedBufferWriter {
         break;
       case PbFieldType._MESSAGE_BIT:
         final mark = _startLengthDelimited();
-        final GeneratedMessage msg = value;
+        final msg = downcastUnchecked<GeneratedMessage>(value);
         msg.writeToCodedBufferWriter(this);
         _endLengthDelimited(mark);
         break;

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -68,7 +68,10 @@ class _ExtensionFieldSet {
 
   @pragma('vm:prefer-inline')
   @pragma('wasm:prefer-inline')
-  dynamic _getFieldOrNull(Extension extension) => _values[extension.tagNumber];
+  dynamic _getFieldOrNull(FieldInfo extension) {
+    assert(extension is Extension);
+    return _values[extension.tagNumber];
+  }
 
   void _clearFieldAndInfo(Extension fi) {
     _clearField(fi);

--- a/protobuf/lib/src/protobuf/extension_registry.dart
+++ b/protobuf/lib/src/protobuf/extension_registry.dart
@@ -91,7 +91,7 @@ T _reparseMessage<T extends GeneratedMessage>(
   T? result;
   T ensureResult() {
     if (result == null) {
-      result ??= message.info_.createEmptyInstance!() as T;
+      result ??= downcastUnchecked<T>(message.info_.createEmptyInstance!());
       result!._fieldSet._shallowCopyValues(message._fieldSet);
     }
     return result!;

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -72,7 +72,7 @@ class _FieldSet {
   /// If [_frozenState] contains a boolean, the hashCode hasn't been memoized,
   /// so it will return null.
   int? get _memoizedHashCode =>
-      _frozenState is int ? _frozenState as int : null;
+      _frozenState is int ? downcastUnchecked<int?>(_frozenState) : null;
 
   /// Maps a `oneof` field index to the tag number which is currently set. If
   /// the index is not present, the oneof field is unset.
@@ -214,7 +214,7 @@ class _FieldSet {
   /// Works for both repeated and non-repeated fields.
   dynamic _getFieldOrNull(FieldInfo fi) {
     if (fi.index != null) return _values[fi.index!];
-    return _extensions?._getFieldOrNull(fi as Extension<dynamic>);
+    return _extensions?._getFieldOrNull(fi);
   }
 
   bool _hasField(int tagNumber) {
@@ -287,8 +287,8 @@ class _FieldSet {
     assert(!fi.isRepeated);
     if (fi.index == null) {
       _ensureExtensions()
-        .._addInfoUnchecked(fi as Extension<dynamic>)
-        .._setFieldUnchecked(fi, value);
+        .._addInfoUnchecked(downcastUnchecked<Extension>(fi))
+        .._setFieldUnchecked(downcastUnchecked<Extension>(fi), value);
     } else {
       _setNonExtensionFieldUnchecked(meta, fi, value);
     }
@@ -304,7 +304,8 @@ class _FieldSet {
     assert(!_isReadOnly);
     assert(fi.isRepeated);
     if (fi.index == null) {
-      return _ensureExtensions()._ensureRepeatedField(fi as Extension<T>);
+      return _ensureExtensions()
+          ._ensureRepeatedField(downcastUnchecked<Extension<T>>(fi));
     }
     final value = _getFieldOrNull(fi);
     if (value != null) return value;
@@ -349,7 +350,7 @@ class _FieldSet {
     final value = _values[index];
     if (value != null) return value;
     if (defaultValue != null) return defaultValue;
-    return _getDefault(_nonExtensionInfoByIndex(index)) as T;
+    return _getDefault(_nonExtensionInfoByIndex(index));
   }
 
   /// The implementation of a generated getter for a default value determined by
@@ -377,7 +378,7 @@ class _FieldSet {
     final value = _values[index];
     if (value != null) return value;
 
-    final fi = _nonExtensionInfoByIndex(index) as FieldInfo<T>;
+    final fi = downcastUnchecked<FieldInfo<T>>(_nonExtensionInfoByIndex(index));
     assert(fi.isRepeated);
 
     if (_isReadOnly) {
@@ -394,7 +395,8 @@ class _FieldSet {
     final value = _values[index];
     if (value != null) return value;
 
-    final fi = _nonExtensionInfoByIndex(index) as MapFieldInfo<K, V>;
+    final fi =
+        downcastUnchecked<MapFieldInfo<K, V>>(_nonExtensionInfoByIndex(index));
     assert(fi.isMapField);
 
     if (_isReadOnly) {
@@ -752,11 +754,11 @@ class _FieldSet {
       if (fieldValue == null) {
         return;
       }
-      final MapFieldInfo<dynamic, dynamic> f = fi as dynamic;
-      final PbMap<dynamic, dynamic> map =
-          f._ensureMapField(meta, this) as dynamic;
+      final f = downcastUnchecked<MapFieldInfo>(fi);
+      final map = downcastUnchecked<PbMap>(f._ensureMapField(meta, this));
       if (_isGroupOrMessage(f.valueFieldType)) {
-        final PbMap<dynamic, GeneratedMessage> fieldValueMap = fieldValue;
+        final fieldValueMap =
+            downcastUnchecked<PbMap<dynamic, GeneratedMessage>>(fieldValue);
         for (final entry in fieldValueMap.entries) {
           map[entry.key] = entry.value.deepCopy();
         }
@@ -769,14 +771,14 @@ class _FieldSet {
     if (fi.isRepeated) {
       if (_isGroupOrMessage(otherFi.type)) {
         // fieldValue must be a PbList of GeneratedMessage.
-        final PbList<GeneratedMessage> pbList = fieldValue;
+        final pbList = downcastUnchecked<PbList<GeneratedMessage>>(fieldValue);
         final repeatedFields = fi._ensureRepeatedField(meta, this);
         for (var i = 0; i < pbList.length; ++i) {
           repeatedFields.add(pbList[i].deepCopy());
         }
       } else {
         // fieldValue must be at least a PbList.
-        final PbList pbList = fieldValue;
+        final pbList = downcastUnchecked<PbList>(fieldValue);
         fi._ensureRepeatedField(meta, this).addAll(pbList);
       }
       return;
@@ -784,21 +786,22 @@ class _FieldSet {
 
     if (otherFi.isGroupOrMessage) {
       final currentFi = isExtension
-          ? _ensureExtensions()._getFieldOrNull(fi as Extension<dynamic>)
+          ? _ensureExtensions()
+              ._getFieldOrNull(downcastUnchecked<Extension>(fi))
           : _values[fi.index!];
 
       final GeneratedMessage msg = fieldValue;
       if (currentFi == null) {
         fieldValue = msg.deepCopy();
       } else {
-        final GeneratedMessage currentMsg = currentFi;
+        final currentMsg = downcastUnchecked<GeneratedMessage>(currentFi);
         fieldValue = currentMsg..mergeFromMessage(msg);
       }
     }
 
     if (isExtension) {
       _ensureExtensions()
-          ._setFieldAndInfo(fi as Extension<dynamic>, fieldValue);
+          ._setFieldAndInfo(downcastUnchecked<Extension>(fi), fieldValue);
     } else {
       _validateField(fi, fieldValue);
       _setNonExtensionFieldUnchecked(meta, fi, fieldValue);
@@ -866,13 +869,14 @@ class _FieldSet {
     for (var index = 0; index < info.byIndex.length; index++) {
       final fieldInfo = info.byIndex[index];
       if (fieldInfo.isMapField) {
-        final PbMap? map = _values[index];
+        final map = downcastUnchecked<PbMap?>(_values[index]);
         if (map != null) {
-          _values[index] = (fieldInfo as MapFieldInfo)._createMapField()
+          _values[index] = (downcastUnchecked<MapFieldInfo>(fieldInfo))
+              ._createMapField()
             ..addAll(map);
         }
       } else if (fieldInfo.isRepeated) {
-        final PbList? list = _values[index];
+        final list = downcastUnchecked<PbList?>(_values[index]);
         if (list != null) {
           _values[index] = fieldInfo._createRepeatedField()..addAll(list);
         }

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -595,13 +595,15 @@ extension GeneratedMessageGenericExtensions<T extends GeneratedMessage> on T {
     if (!isFrozen) {
       throw ArgumentError('Rebuilding only works on frozen messages.');
     }
-    final t = toBuilder();
-    updates(t as T);
-    return t..freeze();
+    final newMessage = toBuilder();
+    final newMessageAsT = downcastUnchecked<T>(newMessage);
+    updates(newMessageAsT);
+    return newMessageAsT..freeze();
   }
 
   /// Returns a writable deep copy of this message.
   @UseResult('[GeneratedMessageGenericExtensions.deepCopy] '
       'does not update the message, returns a new message')
-  T deepCopy() => info_.createEmptyInstance!() as T..mergeFromMessage(this);
+  T deepCopy() => downcastUnchecked<T>(info_.createEmptyInstance!())
+    ..mergeFromMessage(this);
 }

--- a/protobuf/lib/src/protobuf/json.dart
+++ b/protobuf/lib/src/protobuf/json.dart
@@ -9,7 +9,7 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
     final baseType = PbFieldType._baseType(fieldType);
 
     if (_isRepeated(fieldType)) {
-      final PbList list = fieldValue;
+      final list = downcastUnchecked<PbList>(fieldValue);
       return List.from(list.map((e) => convertToMap(e, baseType)));
     }
 
@@ -24,22 +24,22 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
         return fieldValue;
       case PbFieldType._FLOAT_BIT:
       case PbFieldType._DOUBLE_BIT:
-        final value = fieldValue as double;
+        final value = downcastUnchecked<double>(fieldValue);
         if (value.isNaN) {
           return _nan;
         }
         if (value.isInfinite) {
           return value.isNegative ? _negativeInfinity : _infinity;
         }
-        if (fieldValue.toInt() == fieldValue) {
-          return fieldValue.toInt();
+        if (value.toInt() == fieldValue) {
+          return value.toInt();
         }
         return value;
       case PbFieldType._BYTES_BIT:
         // Encode 'bytes' as a base64-encoded string.
-        return base64Encode(fieldValue as List<int>);
+        return base64Encode(fieldValue);
       case PbFieldType._ENUM_BIT:
-        final ProtobufEnum enum_ = fieldValue;
+        final enum_ = downcastUnchecked<ProtobufEnum>(fieldValue);
         return enum_.value; // assume |value| < 2^52
       case PbFieldType._INT64_BIT:
       case PbFieldType._SINT64_BIT:
@@ -51,7 +51,7 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
         return int_.toStringUnsigned();
       case PbFieldType._GROUP_BIT:
       case PbFieldType._MESSAGE_BIT:
-        final GeneratedMessage msg = fieldValue;
+        final msg = downcastUnchecked<GeneratedMessage>(fieldValue);
         return msg.writeToJsonMap();
       default:
         throw UnsupportedError('Unknown type $fieldType');
@@ -73,7 +73,7 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
     }
     if (_isMapField(fi.type)) {
       result['${fi.tagNumber}'] =
-          writeMap(value, fi as MapFieldInfo<dynamic, dynamic>);
+          writeMap(value, downcastUnchecked<MapFieldInfo>(fi));
       continue;
     }
     result['${fi.tagNumber}'] = convertToMap(value, fi.type);
@@ -116,7 +116,7 @@ void _mergeFromJsonMap(
     }
     if (fi.isMapField) {
       _appendJsonMap(
-          meta, fs, json[key], fi as MapFieldInfo<dynamic, dynamic>, registry);
+          meta, fs, json[key], downcastUnchecked<MapFieldInfo>(fi), registry);
     } else if (fi.isRepeated) {
       _appendJsonList(meta, fs, json[key], fi, registry);
     } else {
@@ -149,7 +149,7 @@ void _appendJsonMap(BuilderInfo meta, _FieldSet fs, List jsonList,
   final entryMeta = fi.mapEntryBuilderInfo;
   final map = fi._ensureMapField(meta, fs);
   for (final jsonEntryDynamic in jsonList) {
-    final jsonEntry = jsonEntryDynamic as Map<String, dynamic>;
+    final jsonEntry = downcastUnchecked<Map<String, dynamic>>(jsonEntryDynamic);
     final entryFieldSet = _FieldSet(null, entryMeta);
     final convertedKey = _convertJsonValue(
         entryMeta,
@@ -285,7 +285,7 @@ dynamic _convertJsonValue(BuilderInfo meta, _FieldSet fs, value, int tagNumber,
     case PbFieldType._GROUP_BIT:
     case PbFieldType._MESSAGE_BIT:
       if (value is Map) {
-        final messageValue = value as Map<String, dynamic>;
+        final messageValue = downcastUnchecked<Map<String, dynamic>>(value);
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         _mergeFromJsonMap(subMessage._fieldSet, messageValue, registry);
         return subMessage;

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -219,7 +219,8 @@ class PbList<E> extends ListBase<E> {
     // Per spec `repeated map<..>` and `repeated repeated ..` are not allowed
     // so we only check for messages
     if (_wrappedList.isNotEmpty && _wrappedList[0] is GeneratedMessage) {
-      for (final elem in _wrappedList as Iterable<GeneratedMessage>) {
+      for (final elem
+          in downcastUnchecked<Iterable<GeneratedMessage>>(_wrappedList)) {
         elem.freeze();
       }
     }

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -117,7 +117,8 @@ class PbMap<K, V> extends MapBase<K, V> {
   PbMap freeze() {
     _isReadOnly = true;
     if (_isGroupOrMessage(valueFieldType)) {
-      for (final subMessage in values as Iterable<GeneratedMessage>) {
+      for (final subMessage
+          in downcastUnchecked<Iterable<GeneratedMessage>>(values)) {
         subMessage.freeze();
       }
     }

--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -16,7 +16,7 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
       case PbFieldType._STRING_BIT:
         return key;
       case PbFieldType._UINT64_BIT:
-        return (key as Int64).toStringUnsigned();
+        return downcastUnchecked<Int64>(key).toStringUnsigned();
       case PbFieldType._INT32_BIT:
       case PbFieldType._SINT32_BIT:
       case PbFieldType._UINT32_BIT:
@@ -37,14 +37,15 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
 
     if (_isGroupOrMessage(fieldType!)) {
       return _writeToProto3Json(
-          (fieldValue as GeneratedMessage)._fieldSet, typeRegistry);
+          downcastUnchecked<GeneratedMessage>(fieldValue)._fieldSet,
+          typeRegistry);
     } else if (_isEnum(fieldType)) {
-      return (fieldValue as ProtobufEnum).name;
+      return downcastUnchecked<ProtobufEnum>(fieldValue).name;
     } else {
       final baseType = PbFieldType._baseType(fieldType);
       switch (baseType) {
         case PbFieldType._BOOL_BIT:
-          return fieldValue as bool;
+          return downcastUnchecked<bool>(fieldValue);
         case PbFieldType._STRING_BIT:
           return fieldValue;
         case PbFieldType._INT32_BIT:
@@ -72,7 +73,7 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
           }
           return value;
         case PbFieldType._UINT64_BIT:
-          return (fieldValue as Int64).toStringUnsigned();
+          return downcastUnchecked<Int64>(fieldValue).toStringUnsigned();
         case PbFieldType._BYTES_BIT:
           return base64Encode(fieldValue);
         default:
@@ -95,13 +96,13 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
     }
     dynamic jsonValue;
     if (fieldInfo.isMapField) {
-      jsonValue = (value as PbMap).map((key, entryValue) {
-        final mapEntryInfo = fieldInfo as MapFieldInfo;
+      jsonValue = downcastUnchecked<PbMap>(value).map((key, entryValue) {
+        final mapEntryInfo = downcastUnchecked<MapFieldInfo>(fieldInfo);
         return MapEntry(convertToMapKey(key, mapEntryInfo.keyFieldType),
             valueToProto3Json(entryValue, mapEntryInfo.valueFieldType));
       });
     } else if (fieldInfo.isRepeated) {
-      jsonValue = (value as PbList)
+      jsonValue = downcastUnchecked<PbList>(value)
           .map((element) => valueToProto3Json(element, fieldInfo.type))
           .toList();
     } else {
@@ -361,8 +362,8 @@ void _mergeFromProto3Json(
 
           if (_isMapField(fieldInfo.type)) {
             if (value is Map) {
-              final mapFieldInfo = fieldInfo as MapFieldInfo<dynamic, dynamic>;
-              final Map fieldValues = fieldSet._ensureMapField(meta, fieldInfo);
+              final mapFieldInfo = downcastUnchecked<MapFieldInfo>(fieldInfo);
+              final fieldValues = fieldSet._ensureMapField(meta, mapFieldInfo);
               value.forEach((subKey, subValue) {
                 if (subKey is! String) {
                   throw context.parseException('Expected a String key', subKey);
@@ -391,8 +392,8 @@ void _mergeFromProto3Json(
           } else if (_isGroupOrMessage(fieldInfo.type)) {
             // TODO(sigurdm) consider a cleaner separation between parsing and
             // merging.
-            final parsedSubMessage =
-                convertProto3JsonValue(value, fieldInfo) as GeneratedMessage;
+            final parsedSubMessage = downcastUnchecked<GeneratedMessage>(
+                convertProto3JsonValue(value, fieldInfo));
             final GeneratedMessage? original =
                 fieldSet._values[fieldInfo.index!];
             if (original == null) {

--- a/protobuf/lib/src/protobuf/utils.dart
+++ b/protobuf/lib/src/protobuf/utils.dart
@@ -52,3 +52,8 @@ class _HashUtils {
   static int _hash2(a, b) =>
       _finish(_combine(_combine(0, a.hashCode), b.hashCode));
 }
+
+@pragma('vm:prefer-inline')
+@pragma('wasm:prefer-inline')
+@pragma('dart2js:tryInline')
+T downcastUnchecked<T>(dynamic value) => value;


### PR DESCRIPTION
Lints don't like `final T x = expr as dynamic` pattern, but that pattern is faster with dart2js compared to `expr as T`.

Add a helper to encapsulate the strange pattern and use it everywhere.

Not ready: this seems to reduce dart2js performance:

```
// Before
protobuf_query_encode_binary(RunTimeRaw): 9578.260869565218 us.

// After
protobuf_query_encode_binary(RunTimeRaw): 10208.333333333332 us.
```

I will revert changes to existing `as` casts and only use the new helper on `final T x = expr as dynamic`s.