### PR TITLE
improve the readability of generated gRPC client files

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 22.4.0-wip
+## 22.4.0
 
 * Update how we calculate import prefixes ([#1010]); import prefixes are now
   unique per-library instead of being unique across all generated libraries.
 * Ignore `unused_import` diagnostics for `*.pbjson.dart` files.
 * Revert the change to not generate empty `*.pbenum.dart` files; these can be
   exported from other enum files.
+* Improve the readablity of generated gRPC client files.
 
 [#1010]: https://github.com/google/protobuf.dart/issues/1010
 

--- a/protoc_plugin/analysis_options.yaml
+++ b/protoc_plugin/analysis_options.yaml
@@ -2,7 +2,7 @@ include: ../analysis_options.yaml
 
 analyzer:
   errors:
-    # The generated code in lib/src/gen trigger this lint.
+    # The generated code in lib/src/gen triggers this lint.
     unintended_html_in_doc_comment: ignore
   exclude:
     - test/goldens/**

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 22.4.0-wip
+version: 22.4.0
 description: A protobuf protoc compiler plugin used to generate Dart code.
 repository: https://github.com/google/protobuf.dart/tree/master/protoc_plugin
 

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc.dart
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc.dart
@@ -31,66 +31,75 @@ class TestClient extends $grpc.Client {
     'https://www.googleapis.com/auth/datastore',
   ];
 
-  static final _$unary = $grpc.ClientMethod<$0.Input, $0.Output>(
-      '/Test/Unary',
-      ($0.Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
-  static final _$clientStreaming = $grpc.ClientMethod<$0.Input, $0.Output>(
-      '/Test/ClientStreaming',
-      ($0.Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
-  static final _$serverStreaming = $grpc.ClientMethod<$0.Input, $0.Output>(
-      '/Test/ServerStreaming',
-      ($0.Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
-  static final _$bidirectional = $grpc.ClientMethod<$0.Input, $0.Output>(
-      '/Test/Bidirectional',
-      ($0.Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
-  static final _$call = $grpc.ClientMethod<$0.Input, $0.Output>(
-      '/Test/Call',
-      ($0.Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
-  static final _$request = $grpc.ClientMethod<$0.Input, $0.Output>(
-      '/Test/Request',
-      ($0.Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
-
   TestClient(super.channel, {super.options, super.interceptors});
 
-  $grpc.ResponseFuture<$0.Output> unary($0.Input request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.Output> unary(
+    $0.Input request, {
+    $grpc.CallOptions? options,
+  }) {
     return $createUnaryCall(_$unary, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.Output> clientStreaming(
-      $async.Stream<$0.Input> request,
-      {$grpc.CallOptions? options}) {
+    $async.Stream<$0.Input> request, {
+    $grpc.CallOptions? options,
+  }) {
     return $createStreamingCall(_$clientStreaming, request, options: options)
         .single;
   }
 
-  $grpc.ResponseStream<$0.Output> serverStreaming($0.Input request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseStream<$0.Output> serverStreaming(
+    $0.Input request, {
+    $grpc.CallOptions? options,
+  }) {
     return $createStreamingCall(
         _$serverStreaming, $async.Stream.fromIterable([request]),
         options: options);
   }
 
-  $grpc.ResponseStream<$0.Output> bidirectional($async.Stream<$0.Input> request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseStream<$0.Output> bidirectional(
+    $async.Stream<$0.Input> request, {
+    $grpc.CallOptions? options,
+  }) {
     return $createStreamingCall(_$bidirectional, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.Output> call($0.Input request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.Output> call(
+    $0.Input request, {
+    $grpc.CallOptions? options,
+  }) {
     return $createUnaryCall(_$call, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.Output> request($0.Input request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.Output> request(
+    $0.Input request, {
+    $grpc.CallOptions? options,
+  }) {
     return $createUnaryCall(_$request, request, options: options);
   }
+
+  // method descriptors
+
+  static final _$unary = $grpc.ClientMethod<$0.Input, $0.Output>('/Test/Unary',
+      ($0.Input value) => value.writeToBuffer(), $0.Output.fromBuffer);
+  static final _$clientStreaming = $grpc.ClientMethod<$0.Input, $0.Output>(
+      '/Test/ClientStreaming',
+      ($0.Input value) => value.writeToBuffer(),
+      $0.Output.fromBuffer);
+  static final _$serverStreaming = $grpc.ClientMethod<$0.Input, $0.Output>(
+      '/Test/ServerStreaming',
+      ($0.Input value) => value.writeToBuffer(),
+      $0.Output.fromBuffer);
+  static final _$bidirectional = $grpc.ClientMethod<$0.Input, $0.Output>(
+      '/Test/Bidirectional',
+      ($0.Input value) => value.writeToBuffer(),
+      $0.Output.fromBuffer);
+  static final _$call = $grpc.ClientMethod<$0.Input, $0.Output>('/Test/Call',
+      ($0.Input value) => value.writeToBuffer(), $0.Output.fromBuffer);
+  static final _$request = $grpc.ClientMethod<$0.Input, $0.Output>(
+      '/Test/Request',
+      ($0.Input value) => value.writeToBuffer(),
+      $0.Output.fromBuffer);
 }
 
 @$pb.GrpcServiceName('Test')
@@ -147,28 +156,33 @@ abstract class TestServiceBase extends $grpc.Service {
     return unary($call, await $request);
   }
 
+  $async.Future<$0.Output> unary($grpc.ServiceCall call, $0.Input request);
+
+  $async.Future<$0.Output> clientStreaming(
+      $grpc.ServiceCall call, $async.Stream<$0.Input> request);
+
   $async.Stream<$0.Output> serverStreaming_Pre(
       $grpc.ServiceCall $call, $async.Future<$0.Input> $request) async* {
     yield* serverStreaming($call, await $request);
   }
+
+  $async.Stream<$0.Output> serverStreaming(
+      $grpc.ServiceCall call, $0.Input request);
+
+  $async.Stream<$0.Output> bidirectional(
+      $grpc.ServiceCall call, $async.Stream<$0.Input> request);
 
   $async.Future<$0.Output> call_Pre(
       $grpc.ServiceCall $call, $async.Future<$0.Input> $request) async {
     return call($call, await $request);
   }
 
+  $async.Future<$0.Output> call($grpc.ServiceCall call, $0.Input request);
+
   $async.Future<$0.Output> request_Pre(
       $grpc.ServiceCall $call, $async.Future<$0.Input> $request) async {
     return request($call, await $request);
   }
 
-  $async.Future<$0.Output> unary($grpc.ServiceCall call, $0.Input request);
-  $async.Future<$0.Output> clientStreaming(
-      $grpc.ServiceCall call, $async.Stream<$0.Input> request);
-  $async.Stream<$0.Output> serverStreaming(
-      $grpc.ServiceCall call, $0.Input request);
-  $async.Stream<$0.Output> bidirectional(
-      $grpc.ServiceCall call, $async.Stream<$0.Input> request);
-  $async.Future<$0.Output> call($grpc.ServiceCall call, $0.Input request);
   $async.Future<$0.Output> request($grpc.ServiceCall call, $0.Input request);
 }


### PR DESCRIPTION
Improve the readability of generated gRPC client files:

- emit the method descriptors at the end of the client class definition (after the service methods)
- emit the `foo_Pre()` and `foo()` methods together, instead of in separate parts of the service base class
