### PR TITLE
Split protobuf package into libraries

### DIFF
--- a/protobuf/lib/protobuf.dart
+++ b/protobuf/lib/protobuf.dart
@@ -7,61 +7,14 @@
 /// [1]: https://developers.google.com/protocol-buffers
 library;
 
-import 'dart:collection' show ListBase, MapBase;
-import 'dart:convert'
-    show
-        Utf8Decoder,
-        Utf8Encoder,
-        base64Decode,
-        base64Encode,
-        jsonDecode,
-        jsonEncode;
-import 'dart:math' as math;
-import 'dart:typed_data' show ByteData, Endian, Uint8List;
-
-import 'package:fixnum/fixnum.dart' show Int64;
-import 'package:meta/meta.dart' show UseResult;
-
-import 'src/protobuf/json_parsing_context.dart';
-import 'src/protobuf/permissive_compare.dart';
-import 'src/protobuf/type_registry.dart';
-
-export 'src/protobuf/type_registry.dart' show TypeRegistry;
-
-part 'src/protobuf/annotations.dart';
-part 'src/protobuf/builder_info.dart';
-part 'src/protobuf/coded_buffer.dart';
-part 'src/protobuf/coded_buffer_reader.dart';
-part 'src/protobuf/coded_buffer_writer.dart';
-part 'src/protobuf/consts.dart';
-part 'src/protobuf/exceptions.dart';
-part 'src/protobuf/extension.dart';
-part 'src/protobuf/extension_field_set.dart';
-part 'src/protobuf/extension_registry.dart';
-part 'src/protobuf/field_error.dart';
-part 'src/protobuf/field_info.dart';
-part 'src/protobuf/field_set.dart';
-part 'src/protobuf/field_type.dart';
-part 'src/protobuf/generated_message.dart';
-part 'src/protobuf/generated_service.dart';
-part 'src/protobuf/json.dart';
-part 'src/protobuf/message_set.dart';
-part 'src/protobuf/pb_list.dart';
-part 'src/protobuf/pb_map.dart';
-part 'src/protobuf/proto3_json.dart';
-part 'src/protobuf/protobuf_enum.dart';
-part 'src/protobuf/rpc_client.dart';
-part 'src/protobuf/unknown_field_set.dart';
-part 'src/protobuf/unpack.dart';
-part 'src/protobuf/utils.dart';
-part 'src/protobuf/wire_format.dart';
-
-// TODO(sra): Use `Int64.parse()` when available:
-// https://github.com/dart-lang/fixnum/issues/18.
-/// @nodoc
-Int64 parseLongInt(String text) {
-  if (text.startsWith('0x')) return Int64.parseHex(text.substring(2));
-  if (text.startsWith('+0x')) return Int64.parseHex(text.substring(3));
-  if (text.startsWith('-0x')) return -Int64.parseHex(text.substring(3));
-  return Int64.parseInt(text);
-}
+export 'src/protobuf/internal.dart'
+    hide
+        BuilderInfoInternalExtension,
+        EnumFieldInfoExtension,
+        ExtensionFieldSet,
+        ExtensionFieldSetInternalExtension,
+        FieldInfoInternalExtension,
+        FieldSet,
+        FieldSetInternalExtension,
+        GeneratedMessageInternalExtension,
+        MapFieldInfoInternalExtension;

--- a/protobuf/lib/src/protobuf/annotations.dart
+++ b/protobuf/lib/src/protobuf/annotations.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Annotation for marking accessors that belong together.
 class TagNumber {

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Per-message type setup.
 class BuilderInfo {
@@ -28,7 +28,7 @@ class BuilderInfo {
   final Map<String, FieldInfo> byName = <String, FieldInfo>{};
 
   /// Mapping from `oneof` field [FieldInfo.tagNumber]s to the their indices in
-  /// [_FieldSet._oneofCases].
+  /// [FieldSet._oneofCases].
   final Map<int, int> oneofs = <int, int>{};
 
   /// Whether the message has extension fields.
@@ -105,7 +105,7 @@ class BuilderInfo {
         name,
         tagNumber,
         index,
-        PbFieldType.M,
+        PbFieldTypeInternal.M,
         keyFieldType,
         valueFieldType,
         mapEntryBuilderInfo,
@@ -179,13 +179,13 @@ class BuilderInfo {
     );
   }
 
-  /// Adds PbFieldType.OS String with no default value to reduce generated
+  /// Adds PbFieldTypeInternal.OS String with no default value to reduce generated
   /// code size.
   void aOS(int tagNumber, String name, {String? protoName}) {
     add<String>(
       tagNumber,
       name,
-      PbFieldType.OS,
+      PbFieldTypeInternal.OS,
       null,
       null,
       null,
@@ -194,13 +194,13 @@ class BuilderInfo {
     );
   }
 
-  /// Adds PbFieldType.PS String with no default value.
+  /// Adds PbFieldTypeInternal.PS String with no default value.
   void pPS(int tagNumber, String name, {String? protoName}) {
     addRepeated<String>(
       tagNumber,
       name,
-      PbFieldType.PS,
-      getCheckFunction(PbFieldType.PS),
+      PbFieldTypeInternal.PS,
+      getCheckFunction(PbFieldTypeInternal.PS),
       null,
       null,
       null,
@@ -208,12 +208,12 @@ class BuilderInfo {
     );
   }
 
-  /// Adds PbFieldType.QS String with no default value.
+  /// Adds PbFieldTypeInternal.QS String with no default value.
   void aQS(int tagNumber, String name, {String? protoName}) {
     add<String>(
       tagNumber,
       name,
-      PbFieldType.QS,
+      PbFieldTypeInternal.QS,
       null,
       null,
       null,
@@ -227,7 +227,7 @@ class BuilderInfo {
     add<Int64>(
       tagNumber,
       name,
-      PbFieldType.O6,
+      PbFieldTypeInternal.O6,
       Int64.ZERO,
       null,
       null,
@@ -241,7 +241,7 @@ class BuilderInfo {
     add<bool>(
       tagNumber,
       name,
-      PbFieldType.OB,
+      PbFieldTypeInternal.OB,
       null,
       null,
       null,
@@ -321,7 +321,7 @@ class BuilderInfo {
     add<T>(
       tagNumber,
       name,
-      PbFieldType.OM,
+      PbFieldTypeInternal.OM,
       GeneratedMessage._defaultMakerFor<T>(subBuilder),
       subBuilder,
       null,
@@ -339,7 +339,7 @@ class BuilderInfo {
     add<T>(
       tagNumber,
       name,
-      PbFieldType.QM,
+      PbFieldTypeInternal.QM,
       GeneratedMessage._defaultMakerFor<T>(subBuilder),
       subBuilder,
       null,
@@ -486,4 +486,17 @@ class BuilderInfo {
         ?.valueOf
         ?.call(rawValue);
   }
+}
+
+extension BuilderInfoInternalExtension on BuilderInfo {
+  GeneratedMessage makeEmptyMessage(
+    int tagNumber,
+    ExtensionRegistry? extensionRegistry,
+  ) => _makeEmptyMessage(tagNumber, extensionRegistry);
+
+  ProtobufEnum? decodeEnum(
+    int tagNumber,
+    ExtensionRegistry? registry,
+    int rawValue,
+  ) => _decodeEnum(tagNumber, registry, rawValue);
 }

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
-void _writeToCodedBufferWriter(_FieldSet fs, CodedBufferWriter out) {
+void _writeToCodedBufferWriter(FieldSet fs, CodedBufferWriter out) {
   // Sorting by tag number isn't required, but it sometimes enables
   // performance optimizations for the receiver. See:
   // https://developers.google.com/protocol-buffers/docs/encoding?hl=en#order
@@ -31,7 +31,7 @@ void _writeToCodedBufferWriter(_FieldSet fs, CodedBufferWriter out) {
 
 void _mergeFromCodedBufferReader(
   BuilderInfo meta,
-  _FieldSet fs,
+  FieldSet fs,
   CodedBufferReader input,
   ExtensionRegistry registry,
 ) {
@@ -54,24 +54,25 @@ void _mergeFromCodedBufferReader(
 
     // Ignore required/optional packed/unpacked.
     var fieldType = fi.type;
-    fieldType &= ~(PbFieldType._PACKED_BIT | PbFieldType._REQUIRED_BIT);
+    fieldType &=
+        ~(PbFieldTypeInternal._PACKED_BIT | PbFieldTypeInternal._REQUIRED_BIT);
     switch (fieldType) {
-      case PbFieldType._OPTIONAL_BOOL:
+      case PbFieldTypeInternal._OPTIONAL_BOOL:
         fs._setFieldUnchecked(meta, fi, input.readBool());
         break;
-      case PbFieldType._OPTIONAL_BYTES:
+      case PbFieldTypeInternal._OPTIONAL_BYTES:
         fs._setFieldUnchecked(meta, fi, input.readBytes());
         break;
-      case PbFieldType._OPTIONAL_STRING:
+      case PbFieldTypeInternal._OPTIONAL_STRING:
         fs._setFieldUnchecked(meta, fi, input.readString());
         break;
-      case PbFieldType._OPTIONAL_FLOAT:
+      case PbFieldTypeInternal._OPTIONAL_FLOAT:
         fs._setFieldUnchecked(meta, fi, input.readFloat());
         break;
-      case PbFieldType._OPTIONAL_DOUBLE:
+      case PbFieldTypeInternal._OPTIONAL_DOUBLE:
         fs._setFieldUnchecked(meta, fi, input.readDouble());
         break;
-      case PbFieldType._OPTIONAL_ENUM:
+      case PbFieldTypeInternal._OPTIONAL_ENUM:
         final rawValue = input.readEnum();
         final value = meta._decodeEnum(tagNumber, registry, rawValue);
         if (value == null) {
@@ -81,7 +82,7 @@ void _mergeFromCodedBufferReader(
           fs._setFieldUnchecked(meta, fi, value);
         }
         break;
-      case PbFieldType._OPTIONAL_GROUP:
+      case PbFieldTypeInternal._OPTIONAL_GROUP:
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         final oldValue = fs._getFieldOrNull(fi);
         if (oldValue != null) {
@@ -90,37 +91,37 @@ void _mergeFromCodedBufferReader(
         input.readGroup(tagNumber, subMessage, registry);
         fs._setFieldUnchecked(meta, fi, subMessage);
         break;
-      case PbFieldType._OPTIONAL_INT32:
+      case PbFieldTypeInternal._OPTIONAL_INT32:
         fs._setFieldUnchecked(meta, fi, input.readInt32());
         break;
-      case PbFieldType._OPTIONAL_INT64:
+      case PbFieldTypeInternal._OPTIONAL_INT64:
         fs._setFieldUnchecked(meta, fi, input.readInt64());
         break;
-      case PbFieldType._OPTIONAL_SINT32:
+      case PbFieldTypeInternal._OPTIONAL_SINT32:
         fs._setFieldUnchecked(meta, fi, input.readSint32());
         break;
-      case PbFieldType._OPTIONAL_SINT64:
+      case PbFieldTypeInternal._OPTIONAL_SINT64:
         fs._setFieldUnchecked(meta, fi, input.readSint64());
         break;
-      case PbFieldType._OPTIONAL_UINT32:
+      case PbFieldTypeInternal._OPTIONAL_UINT32:
         fs._setFieldUnchecked(meta, fi, input.readUint32());
         break;
-      case PbFieldType._OPTIONAL_UINT64:
+      case PbFieldTypeInternal._OPTIONAL_UINT64:
         fs._setFieldUnchecked(meta, fi, input.readUint64());
         break;
-      case PbFieldType._OPTIONAL_FIXED32:
+      case PbFieldTypeInternal._OPTIONAL_FIXED32:
         fs._setFieldUnchecked(meta, fi, input.readFixed32());
         break;
-      case PbFieldType._OPTIONAL_FIXED64:
+      case PbFieldTypeInternal._OPTIONAL_FIXED64:
         fs._setFieldUnchecked(meta, fi, input.readFixed64());
         break;
-      case PbFieldType._OPTIONAL_SFIXED32:
+      case PbFieldTypeInternal._OPTIONAL_SFIXED32:
         fs._setFieldUnchecked(meta, fi, input.readSfixed32());
         break;
-      case PbFieldType._OPTIONAL_SFIXED64:
+      case PbFieldTypeInternal._OPTIONAL_SFIXED64:
         fs._setFieldUnchecked(meta, fi, input.readSfixed64());
         break;
-      case PbFieldType._OPTIONAL_MESSAGE:
+      case PbFieldTypeInternal._OPTIONAL_MESSAGE:
         final GeneratedMessage? oldValue = fs._getFieldOrNull(fi);
         if (oldValue != null) {
           input.readMessage(oldValue, registry);
@@ -130,7 +131,7 @@ void _mergeFromCodedBufferReader(
           fs._setFieldUnchecked(meta, fi, subMessage);
         }
         break;
-      case PbFieldType._REPEATED_BOOL:
+      case PbFieldTypeInternal._REPEATED_BOOL:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -150,17 +151,17 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readBool());
         }
         break;
-      case PbFieldType._REPEATED_BYTES:
+      case PbFieldTypeInternal._REPEATED_BYTES:
         final list = fs._ensureRepeatedField(meta, fi);
         list._checkModifiable('add');
         list._addUnchecked(input.readBytes());
         break;
-      case PbFieldType._REPEATED_STRING:
+      case PbFieldTypeInternal._REPEATED_STRING:
         final list = fs._ensureRepeatedField(meta, fi);
         list._checkModifiable('add');
         list._addUnchecked(input.readString());
         break;
-      case PbFieldType._REPEATED_FLOAT:
+      case PbFieldTypeInternal._REPEATED_FLOAT:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -177,7 +178,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readFloat());
         }
         break;
-      case PbFieldType._REPEATED_DOUBLE:
+      case PbFieldTypeInternal._REPEATED_DOUBLE:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -194,7 +195,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readDouble());
         }
         break;
-      case PbFieldType._REPEATED_ENUM:
+      case PbFieldTypeInternal._REPEATED_ENUM:
         final list = fs._ensureRepeatedField(meta, fi);
         _readPackableToListEnum(
           list,
@@ -206,13 +207,13 @@ void _mergeFromCodedBufferReader(
           registry,
         );
         break;
-      case PbFieldType._REPEATED_GROUP:
+      case PbFieldTypeInternal._REPEATED_GROUP:
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readGroup(tagNumber, subMessage, registry);
         final list = fs._ensureRepeatedField(meta, fi);
         list.add(subMessage);
         break;
-      case PbFieldType._REPEATED_INT32:
+      case PbFieldTypeInternal._REPEATED_INT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -229,7 +230,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readInt32());
         }
         break;
-      case PbFieldType._REPEATED_INT64:
+      case PbFieldTypeInternal._REPEATED_INT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -246,7 +247,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readInt64());
         }
         break;
-      case PbFieldType._REPEATED_SINT32:
+      case PbFieldTypeInternal._REPEATED_SINT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -263,7 +264,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readSint32());
         }
         break;
-      case PbFieldType._REPEATED_SINT64:
+      case PbFieldTypeInternal._REPEATED_SINT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -280,7 +281,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readSint64());
         }
         break;
-      case PbFieldType._REPEATED_UINT32:
+      case PbFieldTypeInternal._REPEATED_UINT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -297,7 +298,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readUint32());
         }
         break;
-      case PbFieldType._REPEATED_UINT64:
+      case PbFieldTypeInternal._REPEATED_UINT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -314,7 +315,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readUint64());
         }
         break;
-      case PbFieldType._REPEATED_FIXED32:
+      case PbFieldTypeInternal._REPEATED_FIXED32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -331,7 +332,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readFixed32());
         }
         break;
-      case PbFieldType._REPEATED_FIXED64:
+      case PbFieldTypeInternal._REPEATED_FIXED64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -348,7 +349,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readFixed64());
         }
         break;
-      case PbFieldType._REPEATED_SFIXED32:
+      case PbFieldTypeInternal._REPEATED_SFIXED32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -365,7 +366,7 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readSfixed32());
         }
         break;
-      case PbFieldType._REPEATED_SFIXED64:
+      case PbFieldTypeInternal._REPEATED_SFIXED64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
           final limit = input.readInt32();
@@ -382,13 +383,13 @@ void _mergeFromCodedBufferReader(
           list._addUnchecked(input.readSfixed64());
         }
         break;
-      case PbFieldType._REPEATED_MESSAGE:
+      case PbFieldTypeInternal._REPEATED_MESSAGE:
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readMessage(subMessage, registry);
         final list = fs._ensureRepeatedField(meta, fi);
         list.add(subMessage);
         break;
-      case PbFieldType._MAP:
+      case PbFieldTypeInternal._MAP:
         final mapFieldInfo = fi as MapFieldInfo;
         final mapEntryMeta = mapFieldInfo.mapEntryBuilderInfo;
         fs
@@ -404,7 +405,7 @@ void _mergeFromCodedBufferReader(
 void _readPackableToListEnum(
   List list,
   BuilderInfo meta,
-  _FieldSet fs,
+  FieldSet fs,
   CodedBufferReader input,
   int wireType,
   int tagNumber,
@@ -426,7 +427,7 @@ void _readPackableToListEnum(
 void _readRepeatedEnum(
   List list,
   BuilderInfo meta,
-  _FieldSet fs,
+  FieldSet fs,
   CodedBufferReader input,
   int tagNumber,
   ExtensionRegistry registry,

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -17,7 +17,7 @@ void _writeToCodedBufferWriter(FieldSet fs, CodedBufferWriter out) {
 
   final extensions = fs._extensions;
   if (extensions != null) {
-    for (final tagNumber in _sorted(extensions._tagNumbers)) {
+    for (final tagNumber in sorted(extensions._tagNumbers)) {
       final fi = extensions._getInfoOrNull(tagNumber)!;
       out.writeField(tagNumber, fi.type, extensions._getFieldOrNull(fi));
     }

--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Reader used for converting binary-encoded protobufs into
 /// [GeneratedMessage]s.

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Writer used for converting [GeneratedMessage]s into binary
 /// representation.
@@ -65,9 +65,9 @@ class CodedBufferWriter {
   }
 
   void writeField(int fieldNumber, int fieldType, Object? fieldValue) {
-    final valueType = PbFieldType._baseType(fieldType);
+    final valueType = PbFieldTypeInternal._baseType(fieldType);
 
-    if ((fieldType & PbFieldType._PACKED_BIT) != 0) {
+    if ((fieldType & PbFieldTypeInternal._PACKED_BIT) != 0) {
       final list = fieldValue as List;
       if (list.isNotEmpty) {
         _writeTag(fieldNumber, WIRETYPE_LENGTH_DELIMITED);
@@ -80,7 +80,7 @@ class CodedBufferWriter {
       return;
     }
 
-    if ((fieldType & PbFieldType._MAP_BIT) != 0) {
+    if ((fieldType & PbFieldTypeInternal._MAP_BIT) != 0) {
       final map = fieldValue as PbMap;
       final keyWireFormat = _wireTypes[_valueTypeIndex(map.keyFieldType)];
       final valueWireFormat = _wireTypes[_valueTypeIndex(map.valueFieldType)];
@@ -107,7 +107,7 @@ class CodedBufferWriter {
 
     final wireFormat = _wireTypes[_valueTypeIndex(valueType)];
 
-    if ((fieldType & PbFieldType._REPEATED_BIT) != 0) {
+    if ((fieldType & PbFieldTypeInternal._REPEATED_BIT) != 0) {
       final list = fieldValue as List;
       for (var i = 0; i < list.length; i++) {
         _writeValue(fieldNumber, valueType, list[i], wireFormat);
@@ -353,10 +353,10 @@ class CodedBufferWriter {
 
   void _writeValueAs(int valueType, dynamic value) {
     switch (valueType) {
-      case PbFieldType._BOOL_BIT:
+      case PbFieldTypeInternal._BOOL_BIT:
         _writeVarint32(value ? 1 : 0);
         break;
-      case PbFieldType._BYTES_BIT:
+      case PbFieldTypeInternal._BYTES_BIT:
         final List<int> bytes = value;
         if (bytes is Uint8List) {
           _writeBytesNoTag(bytes);
@@ -366,7 +366,7 @@ class CodedBufferWriter {
           _writeBytesNoTag(Uint8List.fromList(bytes));
         }
         break;
-      case PbFieldType._STRING_BIT:
+      case PbFieldTypeInternal._STRING_BIT:
         final String string = value;
         if (string.isEmpty) {
           _writeEmptyBytes();
@@ -374,17 +374,17 @@ class CodedBufferWriter {
           _writeBytesNoTag(const Utf8Encoder().convert(string));
         }
         break;
-      case PbFieldType._DOUBLE_BIT:
+      case PbFieldTypeInternal._DOUBLE_BIT:
         _writeDouble(value);
         break;
-      case PbFieldType._FLOAT_BIT:
+      case PbFieldTypeInternal._FLOAT_BIT:
         _writeFloat(value);
         break;
-      case PbFieldType._ENUM_BIT:
+      case PbFieldTypeInternal._ENUM_BIT:
         final ProtobufEnum enum_ = value;
         _writeVarint32(enum_.value & 0xffffffff);
         break;
-      case PbFieldType._GROUP_BIT:
+      case PbFieldTypeInternal._GROUP_BIT:
         // `value` is `UnknownFieldSet` or `GeneratedMessage`. Test for
         // `UnknownFieldSet` as it doesn't have subtypes, so the type test will
         // be fast.
@@ -399,37 +399,37 @@ class CodedBufferWriter {
           message.writeToCodedBufferWriter(this);
         }
         break;
-      case PbFieldType._INT32_BIT:
+      case PbFieldTypeInternal._INT32_BIT:
         _writeVarint64(Int64(value));
         break;
-      case PbFieldType._INT64_BIT:
+      case PbFieldTypeInternal._INT64_BIT:
         _writeVarint64(value);
         break;
-      case PbFieldType._SINT32_BIT:
+      case PbFieldTypeInternal._SINT32_BIT:
         _writeVarint32(_encodeZigZag32(value));
         break;
-      case PbFieldType._SINT64_BIT:
+      case PbFieldTypeInternal._SINT64_BIT:
         _writeVarint64(_encodeZigZag64(value));
         break;
-      case PbFieldType._UINT32_BIT:
+      case PbFieldTypeInternal._UINT32_BIT:
         _writeVarint32(value);
         break;
-      case PbFieldType._UINT64_BIT:
+      case PbFieldTypeInternal._UINT64_BIT:
         _writeVarint64(value);
         break;
-      case PbFieldType._FIXED32_BIT:
+      case PbFieldTypeInternal._FIXED32_BIT:
         _writeInt32(value);
         break;
-      case PbFieldType._FIXED64_BIT:
+      case PbFieldTypeInternal._FIXED64_BIT:
         _writeInt64(value);
         break;
-      case PbFieldType._SFIXED32_BIT:
+      case PbFieldTypeInternal._SFIXED32_BIT:
         _writeInt32(value);
         break;
-      case PbFieldType._SFIXED64_BIT:
+      case PbFieldTypeInternal._SFIXED64_BIT:
         _writeInt64(value);
         break;
-      case PbFieldType._MESSAGE_BIT:
+      case PbFieldTypeInternal._MESSAGE_BIT:
         final mark = _startLengthDelimited();
         final GeneratedMessage msg = value;
         msg.writeToCodedBufferWriter(this);
@@ -459,7 +459,7 @@ class CodedBufferWriter {
   ) {
     _writeTag(fieldNumber, wireFormat);
     _writeValueAs(valueType, value);
-    if (valueType == PbFieldType._GROUP_BIT) {
+    if (valueType == PbFieldTypeInternal._GROUP_BIT) {
       _writeTag(fieldNumber, WIRETYPE_END_GROUP);
     }
   }

--- a/protobuf/lib/src/protobuf/consts.dart
+++ b/protobuf/lib/src/protobuf/consts.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Constant string value of `double.infinity.toString()` and the infinity
 /// value recognized by `double.parse(..)`.

--- a/protobuf/lib/src/protobuf/consts.dart
+++ b/protobuf/lib/src/protobuf/consts.dart
@@ -2,16 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of 'internal.dart';
-
 /// Constant string value of `double.infinity.toString()` and the infinity
 /// value recognized by `double.parse(..)`.
-const _infinity = 'Infinity';
+const infinity = 'Infinity';
 
 /// Constant string value of `double.negativeInfinity.toString()` and the
 /// negative infinity value recognized by `double.parse(..)`.
-const _negativeInfinity = '-Infinity';
+const negativeInfinity = '-Infinity';
 
 /// Constant string value of `double.nan.toString()` and the NaN (not a number)
 /// value recognized by `double.parse(..)`.
-const _nan = 'NaN';
+const nan = 'NaN';

--- a/protobuf/lib/src/protobuf/exceptions.dart
+++ b/protobuf/lib/src/protobuf/exceptions.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 const _truncatedMessageText = '''
 While parsing a protocol message, the input ended unexpectedly

--- a/protobuf/lib/src/protobuf/extension.dart
+++ b/protobuf/lib/src/protobuf/extension.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// An object representing an extension field.
 class Extension<T> extends FieldInfo<T> {

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -2,15 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
-class _ExtensionFieldSet {
-  final _FieldSet _parent;
+class ExtensionFieldSet {
+  final FieldSet _parent;
   final Map<int, Extension> _info = <int, Extension>{};
   final Map<int, dynamic> _values = <int, dynamic>{};
   bool _isReadOnly = false;
 
-  _ExtensionFieldSet(this._parent);
+  ExtensionFieldSet(this._parent);
 
   Extension? _getInfoOrNull(int tagNumber) => _info[tagNumber];
 
@@ -157,7 +157,7 @@ class _ExtensionFieldSet {
 
   bool get _hasValues => _values.isNotEmpty;
 
-  bool _equalValues(_ExtensionFieldSet? other) =>
+  bool _equalValues(ExtensionFieldSet? other) =>
       other != null && _areMapsEqual(_values, other._values);
 
   void _clearValues() => _values.clear();
@@ -166,7 +166,7 @@ class _ExtensionFieldSet {
   ///
   /// Repeated fields are copied.
   /// Extensions cannot contain map fields.
-  void _shallowCopyValues(_ExtensionFieldSet original) {
+  void _shallowCopyValues(ExtensionFieldSet original) {
     for (final tagNumber in original._tagNumbers) {
       final extension = original._getInfoOrNull(tagNumber)!;
       _addInfoUnchecked(extension);
@@ -211,4 +211,10 @@ class _ExtensionFieldSet {
       );
     }
   }
+}
+
+extension ExtensionFieldSetInternalExtension on ExtensionFieldSet {
+  Map<int, dynamic> get values => _values;
+  Iterable<int> get tagNumbers => _tagNumbers;
+  Extension? getInfoOrNull(int tagNumber) => _getInfoOrNull(tagNumber);
 }

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -158,7 +158,7 @@ class ExtensionFieldSet {
   bool get _hasValues => _values.isNotEmpty;
 
   bool _equalValues(ExtensionFieldSet? other) =>
-      other != null && _areMapsEqual(_values, other._values);
+      other != null && areMapsEqual(_values, other._values);
 
   void _clearValues() => _values.clear();
 

--- a/protobuf/lib/src/protobuf/extension_registry.dart
+++ b/protobuf/lib/src/protobuf/extension_registry.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// A collection of [Extension] objects, organized by the message type they
 /// extend.

--- a/protobuf/lib/src/protobuf/field_error.dart
+++ b/protobuf/lib/src/protobuf/field_error.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Returns the error message for an invalid field value,
 /// or null if it's valid.
@@ -10,53 +10,53 @@ part of '../../protobuf.dart';
 /// For enums, group, and message fields, this check is only approximate,
 /// because the exact type isn't included in [fieldType].
 String? _getFieldError(int fieldType, var value) {
-  switch (PbFieldType._baseType(fieldType)) {
-    case PbFieldType._BOOL_BIT:
+  switch (PbFieldTypeInternal._baseType(fieldType)) {
+    case PbFieldTypeInternal._BOOL_BIT:
       if (value is! bool) return 'not type bool';
       return null;
-    case PbFieldType._BYTES_BIT:
+    case PbFieldTypeInternal._BYTES_BIT:
       if (value is! List) return 'not List';
       return null;
-    case PbFieldType._STRING_BIT:
+    case PbFieldTypeInternal._STRING_BIT:
       if (value is! String) return 'not type String';
       return null;
-    case PbFieldType._FLOAT_BIT:
+    case PbFieldTypeInternal._FLOAT_BIT:
       if (value is! double) return 'not type double';
       if (!_isFloat32(value)) return 'out of range for float';
       return null;
-    case PbFieldType._DOUBLE_BIT:
+    case PbFieldTypeInternal._DOUBLE_BIT:
       if (value is! double) return 'not type double';
       return null;
-    case PbFieldType._ENUM_BIT:
+    case PbFieldTypeInternal._ENUM_BIT:
       if (value is! ProtobufEnum) return 'not type ProtobufEnum';
       return null;
 
-    case PbFieldType._INT32_BIT:
-    case PbFieldType._SINT32_BIT:
-    case PbFieldType._SFIXED32_BIT:
+    case PbFieldTypeInternal._INT32_BIT:
+    case PbFieldTypeInternal._SINT32_BIT:
+    case PbFieldTypeInternal._SFIXED32_BIT:
       if (value is! int) return 'not type int';
       if (!_isSigned32(value)) return 'out of range for signed 32-bit int';
       return null;
 
-    case PbFieldType._UINT32_BIT:
-    case PbFieldType._FIXED32_BIT:
+    case PbFieldTypeInternal._UINT32_BIT:
+    case PbFieldTypeInternal._FIXED32_BIT:
       if (value is! int) return 'not type int';
       if (!_isUnsigned32(value)) return 'out of range for unsigned 32-bit int';
       return null;
 
-    case PbFieldType._INT64_BIT:
-    case PbFieldType._SINT64_BIT:
-    case PbFieldType._UINT64_BIT:
-    case PbFieldType._FIXED64_BIT:
-    case PbFieldType._SFIXED64_BIT:
+    case PbFieldTypeInternal._INT64_BIT:
+    case PbFieldTypeInternal._SINT64_BIT:
+    case PbFieldTypeInternal._UINT64_BIT:
+    case PbFieldTypeInternal._FIXED64_BIT:
+    case PbFieldTypeInternal._SFIXED64_BIT:
       // We always use the full range of the same Dart type.
       // It's up to the caller to treat the Int64 as signed or unsigned.
       // See: https://github.com/google/protobuf.dart/issues/44
       if (value is! Int64) return 'not Int64';
       return null;
 
-    case PbFieldType._GROUP_BIT:
-    case PbFieldType._MESSAGE_BIT:
+    case PbFieldTypeInternal._GROUP_BIT:
+    case PbFieldTypeInternal._MESSAGE_BIT:
       if (value is! GeneratedMessage) return 'not a GeneratedMessage';
       return null;
     default:
@@ -74,33 +74,33 @@ String? _getFieldError(int fieldType, var value) {
 /// @nodoc
 CheckFunc getCheckFunction(int fieldType) {
   switch (fieldType & ~0x7) {
-    case PbFieldType._BOOL_BIT:
-    case PbFieldType._BYTES_BIT:
-    case PbFieldType._STRING_BIT:
-    case PbFieldType._DOUBLE_BIT:
-    case PbFieldType._ENUM_BIT:
-    case PbFieldType._GROUP_BIT:
-    case PbFieldType._MESSAGE_BIT:
-    case PbFieldType._INT64_BIT:
-    case PbFieldType._SINT64_BIT:
-    case PbFieldType._SFIXED64_BIT:
-    case PbFieldType._UINT64_BIT:
-    case PbFieldType._FIXED64_BIT:
+    case PbFieldTypeInternal._BOOL_BIT:
+    case PbFieldTypeInternal._BYTES_BIT:
+    case PbFieldTypeInternal._STRING_BIT:
+    case PbFieldTypeInternal._DOUBLE_BIT:
+    case PbFieldTypeInternal._ENUM_BIT:
+    case PbFieldTypeInternal._GROUP_BIT:
+    case PbFieldTypeInternal._MESSAGE_BIT:
+    case PbFieldTypeInternal._INT64_BIT:
+    case PbFieldTypeInternal._SINT64_BIT:
+    case PbFieldTypeInternal._SFIXED64_BIT:
+    case PbFieldTypeInternal._UINT64_BIT:
+    case PbFieldTypeInternal._FIXED64_BIT:
       // We always use the full range of the same Dart type.
       // It's up to the caller to treat the Int64 as signed or unsigned.
       // See: https://github.com/google/protobuf.dart/issues/44
       return _checkNotNull;
 
-    case PbFieldType._FLOAT_BIT:
+    case PbFieldTypeInternal._FLOAT_BIT:
       return _checkFloat;
 
-    case PbFieldType._INT32_BIT:
-    case PbFieldType._SINT32_BIT:
-    case PbFieldType._SFIXED32_BIT:
+    case PbFieldTypeInternal._INT32_BIT:
+    case PbFieldTypeInternal._SINT32_BIT:
+    case PbFieldTypeInternal._SFIXED32_BIT:
       return _checkSigned32;
 
-    case PbFieldType._UINT32_BIT:
-    case PbFieldType._FIXED32_BIT:
+    case PbFieldTypeInternal._UINT32_BIT:
+    case PbFieldTypeInternal._FIXED32_BIT:
       return _checkUnsigned32;
   }
   throw ArgumentError('check function not implemented: $fieldType');

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -545,7 +545,7 @@ class FieldSet {
   }
 
   bool _equalFieldValues(Object? left, Object? right) {
-    if (left != null && right != null) return _deepEquals(left, right);
+    if (left != null && right != null) return deepEquals(left, right);
 
     final val = left ?? right;
 
@@ -584,7 +584,7 @@ class FieldSet {
     }
 
     // Hash with descriptor.
-    var hash = _HashUtils._combine(0, _meta.hashCode);
+    var hash = HashUtils.combine(0, _meta.hashCode);
 
     // Hash with non-extension fields.
     final values = _values;
@@ -597,7 +597,7 @@ class FieldSet {
     // Hash with extension fields.
     final extensions = _extensions;
     if (extensions != null) {
-      final sortedByTagNumbers = _sorted(extensions._tagNumbers);
+      final sortedByTagNumbers = sorted(extensions._tagNumbers);
       for (final tagNumber in sortedByTagNumbers) {
         final fi = extensions._getInfoOrNull(tagNumber)!;
         hash = _hashField(hash, fi, extensions._getFieldOrNull(fi));
@@ -605,7 +605,7 @@ class FieldSet {
     }
 
     // Hash with unknown fields.
-    hash = _HashUtils._combine(hash, _unknownFields?.hashCode ?? 0);
+    hash = HashUtils.combine(hash, _unknownFields?.hashCode ?? 0);
 
     // Ignore _unknownJsonData to preserve existing hashing behavior.
 
@@ -625,18 +625,18 @@ class FieldSet {
       return hash;
     }
 
-    hash = _HashUtils._combine(hash, fi.tagNumber);
+    hash = HashUtils.combine(hash, fi.tagNumber);
     if (_isBytes(fi.type)) {
       // Bytes are represented as a List<int> (Usually with byte-data).
       // We special case that to match our equality semantics.
-      hash = _HashUtils._combine(hash, _HashUtils._hashObjects(value));
+      hash = HashUtils.combine(hash, HashUtils.hashObjects(value));
     } else if (!_isEnum(fi.type)) {
-      hash = _HashUtils._combine(hash, value.hashCode);
+      hash = HashUtils.combine(hash, value.hashCode);
     } else if (fi.isRepeated) {
       final PbList list = value;
-      hash = _HashUtils._combine(
+      hash = HashUtils.combine(
         hash,
-        _HashUtils._hashObjects(
+        HashUtils.hashObjects(
           list.map((enm) {
             final ProtobufEnum enm_ = enm;
             return enm_.value;
@@ -645,7 +645,7 @@ class FieldSet {
       );
     } else {
       final ProtobufEnum enm = value;
-      hash = _HashUtils._combine(hash, enm.value);
+      hash = HashUtils.combine(hash, enm.value);
     }
 
     return hash;

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 @pragma('vm:never-inline')
 @pragma('wasm:never-inline')
@@ -25,7 +25,7 @@ void _throwFrozenMessageModificationError(
 /// These fields and methods are in a separate class to avoid polymorphic
 /// access due to inheritance. This turns out to be faster when compiled to
 /// JavaScript.
-class _FieldSet {
+class FieldSet {
   final GeneratedMessage? _message;
 
   /// The value of each non-extension field in a fixed-length array.
@@ -34,7 +34,7 @@ class _FieldSet {
   final List _values;
 
   /// Contains all the extension fields, or null if there aren't any.
-  _ExtensionFieldSet? _extensions;
+  ExtensionFieldSet? _extensions;
 
   /// Contains all the unknown fields, or null if there aren't any.
   UnknownFieldSet? _unknownFields;
@@ -53,7 +53,7 @@ class _FieldSet {
   /// code as an `int`.
   Object _frozenState = false;
 
-  /// The [BuilderInfo] for the [GeneratedMessage] this [_FieldSet] belongs to.
+  /// The [BuilderInfo] for the [GeneratedMessage] this [FieldSet] belongs to.
   ///
   /// WARNING: Avoid calling this for any performance critical code, instead
   /// obtain the [BuilderInfo] on the call site.
@@ -82,7 +82,7 @@ class _FieldSet {
   /// the index is not present, the oneof field is unset.
   final Map<int, int>? _oneofCases;
 
-  _FieldSet(this._message, BuilderInfo meta)
+  FieldSet(this._message, BuilderInfo meta)
     : _values = _makeValueList(meta.byIndex.length),
       _oneofCases = meta.oneofs.isEmpty ? null : <int, int>{};
 
@@ -106,8 +106,8 @@ class _FieldSet {
   /// The [FieldInfo] for each non-extension field in tag order.
   Iterable<FieldInfo> get _infosSortedByTag => _meta.sortedByTag;
 
-  _ExtensionFieldSet _ensureExtensions() =>
-      _extensions ??= _ExtensionFieldSet(this);
+  ExtensionFieldSet _ensureExtensions() =>
+      _extensions ??= ExtensionFieldSet(this);
 
   UnknownFieldSet _ensureUnknownFields() {
     if (_unknownFields == null) {
@@ -510,7 +510,7 @@ class _FieldSet {
     _extensions?._clearValues();
   }
 
-  bool _equals(_FieldSet o) {
+  bool _equals(FieldSet o) {
     if (_meta != o._meta) return false;
     for (var i = 0; i < _values.length; i++) {
       if (!_equalFieldValues(_values[i], o._values[i])) return false;
@@ -716,7 +716,7 @@ class _FieldSet {
   /// Singular fields that are set in [other] overwrite the corresponding fields
   /// in this message. Repeated fields are appended. Singular sub-messages are
   /// recursively merged.
-  void _mergeFromMessage(_FieldSet other) {
+  void _mergeFromMessage(FieldSet other) {
     // TODO(https://github.com/google/protobuf.dart/issues/60): Recognize
     // when `this` and [other] are the same protobuf (e.g. from cloning). In
     // this case, we can merge the non-extension fields without field lookups or
@@ -880,7 +880,7 @@ class _FieldSet {
   /// Makes a shallow copy of all values from [original] to this.
   ///
   /// Map fields and repeated fields are copied.
-  void _shallowCopyValues(_FieldSet original) {
+  void _shallowCopyValues(FieldSet original) {
     _values.setRange(0, original._values.length, original._values);
     final info = _meta;
     for (var index = 0; index < info.byIndex.length; index++) {
@@ -916,4 +916,27 @@ class _FieldSet {
 
     _oneofCases?.addAll(original._oneofCases!);
   }
+}
+
+extension FieldSetInternalExtension on FieldSet {
+  Iterable<FieldInfo> get infos => _infos;
+  Iterable<FieldInfo> get infosSortedByTag => _infosSortedByTag;
+  List get values => _values;
+  ExtensionFieldSet? get extensions => _extensions;
+  UnknownFieldSet? get unknownFields => _unknownFields;
+  Map<String, dynamic>? get unknownJsonData => _unknownJsonData;
+  set unknownJsonData(Map<String, dynamic>? value) => _unknownJsonData = value;
+  BuilderInfo get meta => _meta;
+  GeneratedMessage? get message => _message;
+  String get messageName => _messageName;
+
+  void ensureWritable() => _ensureWritable();
+  PbList<T> ensureRepeatedField<T>(BuilderInfo meta, FieldInfo<T> fi) =>
+      _ensureRepeatedField(meta, fi);
+  PbMap<K, V> ensureMapField<K, V>(BuilderInfo meta, MapFieldInfo<K, V> fi) =>
+      _ensureMapField(meta, fi);
+  void validateField(FieldInfo fi, dynamic newValue) =>
+      _validateField(fi, newValue);
+  void setFieldUnchecked(BuilderInfo meta, FieldInfo fi, dynamic value) =>
+      _setFieldUnchecked(meta, fi, value);
 }

--- a/protobuf/lib/src/protobuf/field_type.dart
+++ b/protobuf/lib/src/protobuf/field_type.dart
@@ -3,31 +3,36 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: constant_identifier_names,non_constant_identifier_names
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
-bool _isRepeated(int fieldType) => (fieldType & PbFieldType._REPEATED_BIT) != 0;
+bool _isRepeated(int fieldType) =>
+    (fieldType & PbFieldTypeInternal._REPEATED_BIT) != 0;
 
-bool _isRequired(int fieldType) => (fieldType & PbFieldType._REQUIRED_BIT) != 0;
+bool _isRequired(int fieldType) =>
+    (fieldType & PbFieldTypeInternal._REQUIRED_BIT) != 0;
 
 bool _isEnum(int fieldType) =>
-    PbFieldType._baseType(fieldType) == PbFieldType._ENUM_BIT;
+    PbFieldTypeInternal._baseType(fieldType) == PbFieldTypeInternal._ENUM_BIT;
 
 bool _isBytes(int fieldType) =>
-    PbFieldType._baseType(fieldType) == PbFieldType._BYTES_BIT;
+    PbFieldTypeInternal._baseType(fieldType) == PbFieldTypeInternal._BYTES_BIT;
 
 bool _isGroupOrMessage(int fieldType) =>
-    (fieldType & (PbFieldType._GROUP_BIT | PbFieldType._MESSAGE_BIT)) != 0;
+    (fieldType &
+        (PbFieldTypeInternal._GROUP_BIT | PbFieldTypeInternal._MESSAGE_BIT)) !=
+    0;
 
-bool _isMapField(int fieldType) => (fieldType & PbFieldType._MAP_BIT) != 0;
+bool _isMapField(int fieldType) =>
+    (fieldType & PbFieldTypeInternal._MAP_BIT) != 0;
 
 /// Defines constants and functions for dealing with fieldType bits.
-class PbFieldType {
+class PbFieldTypeInternal {
   /// Returns the base field type without any of the required, repeated
   /// and packed bits.
   static int _baseType(int fieldType) =>
       fieldType & ~(_REQUIRED_BIT | _REPEATED_BIT | _PACKED_BIT | _MAP_BIT);
 
-  static MakeDefaultFunc? _defaultForType(int type) {
+  static MakeDefaultFunc? defaultForType(int type) {
     switch (type) {
       case _OPTIONAL_BOOL:
       case _REQUIRED_BOOL:

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: non_constant_identifier_names
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Type of an empty message builder.
 typedef CreateBuilderFunc = GeneratedMessage Function();
@@ -25,13 +25,13 @@ typedef ValueOfFunc = ProtobufEnum? Function(int value);
 /// `GeneratedMessage_reservedNames` and should be unlikely to be used in a
 /// proto file.
 abstract class GeneratedMessage {
-  _FieldSet? __fieldSet;
+  FieldSet? __fieldSet;
 
   @pragma('dart2js:tryInline')
-  _FieldSet get _fieldSet => __fieldSet!;
+  FieldSet get _fieldSet => __fieldSet!;
 
   GeneratedMessage() {
-    __fieldSet = _FieldSet(this, info_);
+    __fieldSet = FieldSet(this, info_);
 
     // The following two returns confuse dart2js into avoiding inlining the
     // constructor *body*. A `@pragma('dart2js:never-inline')` annotation on
@@ -636,4 +636,8 @@ extension GeneratedMessageGenericExtensions<T extends GeneratedMessage> on T {
     'does not update the message, returns a new message',
   )
   T deepCopy() => info_.createEmptyInstance!() as T..mergeFromMessage(this);
+}
+
+extension GeneratedMessageInternalExtension on GeneratedMessage {
+  FieldSet get fieldSet => _fieldSet;
 }

--- a/protobuf/lib/src/protobuf/generated_service.dart
+++ b/protobuf/lib/src/protobuf/generated_service.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Server side context.
 class ServerContext {

--- a/protobuf/lib/src/protobuf/internal.dart
+++ b/protobuf/lib/src/protobuf/internal.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2011, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Runtime library for Dart implementation of [protobufs][1].
+///
+/// [1]: https://developers.google.com/protocol-buffers
+library;
+
+import 'dart:collection' show ListBase, MapBase;
+import 'dart:convert'
+    show
+        Utf8Decoder,
+        Utf8Encoder,
+        base64Decode,
+        base64Encode,
+        jsonDecode,
+        jsonEncode;
+import 'dart:math' as math;
+import 'dart:typed_data' show ByteData, Endian, Uint8List;
+
+import 'package:fixnum/fixnum.dart' show Int64;
+import 'package:meta/meta.dart' show UseResult;
+
+import 'json_parsing_context.dart';
+import 'permissive_compare.dart';
+import 'type_registry.dart';
+
+export 'type_registry.dart' show TypeRegistry;
+
+part 'annotations.dart';
+part 'builder_info.dart';
+part 'coded_buffer.dart';
+part 'coded_buffer_reader.dart';
+part 'coded_buffer_writer.dart';
+part 'consts.dart';
+part 'exceptions.dart';
+part 'extension.dart';
+part 'extension_field_set.dart';
+part 'extension_registry.dart';
+part 'field_error.dart';
+part 'field_info.dart';
+part 'field_set.dart';
+part 'field_type.dart';
+part 'generated_message.dart';
+part 'generated_service.dart';
+part 'json.dart';
+part 'message_set.dart';
+part 'pb_list.dart';
+part 'pb_map.dart';
+part 'proto3_json.dart';
+part 'protobuf_enum.dart';
+part 'rpc_client.dart';
+part 'unknown_field_set.dart';
+part 'unpack.dart';
+part 'utils.dart';
+part 'wire_format.dart';
+
+// TODO(sra): Use `Int64.parse()` when available:
+// https://github.com/dart-lang/fixnum/issues/18.
+/// @nodoc
+Int64 parseLongInt(String text) {
+  if (text.startsWith('0x')) return Int64.parseHex(text.substring(2));
+  if (text.startsWith('+0x')) return Int64.parseHex(text.substring(3));
+  if (text.startsWith('-0x')) return -Int64.parseHex(text.substring(3));
+  return Int64.parseInt(text);
+}

--- a/protobuf/lib/src/protobuf/internal.dart
+++ b/protobuf/lib/src/protobuf/internal.dart
@@ -22,6 +22,7 @@ import 'dart:typed_data' show ByteData, Endian, Uint8List;
 import 'package:fixnum/fixnum.dart' show Int64;
 import 'package:meta/meta.dart' show UseResult;
 
+import 'consts.dart';
 import 'json_parsing_context.dart';
 import 'permissive_compare.dart';
 import 'type_registry.dart';
@@ -33,7 +34,6 @@ part 'builder_info.dart';
 part 'coded_buffer.dart';
 part 'coded_buffer_reader.dart';
 part 'coded_buffer_writer.dart';
-part 'consts.dart';
 part 'exceptions.dart';
 part 'extension.dart';
 part 'extension_field_set.dart';

--- a/protobuf/lib/src/protobuf/internal.dart
+++ b/protobuf/lib/src/protobuf/internal.dart
@@ -26,6 +26,7 @@ import 'consts.dart';
 import 'json_parsing_context.dart';
 import 'permissive_compare.dart';
 import 'type_registry.dart';
+import 'utils.dart';
 
 export 'type_registry.dart' show TypeRegistry;
 
@@ -53,7 +54,6 @@ part 'protobuf_enum.dart';
 part 'rpc_client.dart';
 part 'unknown_field_set.dart';
 part 'unpack.dart';
-part 'utils.dart';
 part 'wire_format.dart';
 
 // TODO(sra): Use `Int64.parse()` when available:

--- a/protobuf/lib/src/protobuf/json.dart
+++ b/protobuf/lib/src/protobuf/json.dart
@@ -84,7 +84,7 @@ Map<String, dynamic> _writeToJsonMap(FieldSet fs) {
   }
   final extensions = fs._extensions;
   if (extensions != null) {
-    for (final tagNumber in _sorted(extensions._tagNumbers)) {
+    for (final tagNumber in sorted(extensions._tagNumbers)) {
       final value = extensions._values[tagNumber];
       if (value is List && value.isEmpty) {
         continue; // It's repeated or an empty byte array.

--- a/protobuf/lib/src/protobuf/json.dart
+++ b/protobuf/lib/src/protobuf/json.dart
@@ -2,11 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
-Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
+Map<String, dynamic> _writeToJsonMap(FieldSet fs) {
   dynamic convertToMap(dynamic fieldValue, int fieldType) {
-    final baseType = PbFieldType._baseType(fieldType);
+    final baseType = PbFieldTypeInternal._baseType(fieldType);
 
     if (_isRepeated(fieldType)) {
       final PbList list = fieldValue;
@@ -14,16 +14,16 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
     }
 
     switch (baseType) {
-      case PbFieldType._BOOL_BIT:
-      case PbFieldType._STRING_BIT:
-      case PbFieldType._INT32_BIT:
-      case PbFieldType._SINT32_BIT:
-      case PbFieldType._UINT32_BIT:
-      case PbFieldType._FIXED32_BIT:
-      case PbFieldType._SFIXED32_BIT:
+      case PbFieldTypeInternal._BOOL_BIT:
+      case PbFieldTypeInternal._STRING_BIT:
+      case PbFieldTypeInternal._INT32_BIT:
+      case PbFieldTypeInternal._SINT32_BIT:
+      case PbFieldTypeInternal._UINT32_BIT:
+      case PbFieldTypeInternal._FIXED32_BIT:
+      case PbFieldTypeInternal._SFIXED32_BIT:
         return fieldValue;
-      case PbFieldType._FLOAT_BIT:
-      case PbFieldType._DOUBLE_BIT:
+      case PbFieldTypeInternal._FLOAT_BIT:
+      case PbFieldTypeInternal._DOUBLE_BIT:
         final value = fieldValue as double;
         if (value.isNaN) {
           return _nan;
@@ -35,22 +35,22 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
           return fieldValue.toInt();
         }
         return value;
-      case PbFieldType._BYTES_BIT:
+      case PbFieldTypeInternal._BYTES_BIT:
         // Encode 'bytes' as a base64-encoded string.
         return base64Encode(fieldValue as List<int>);
-      case PbFieldType._ENUM_BIT:
+      case PbFieldTypeInternal._ENUM_BIT:
         final ProtobufEnum enum_ = fieldValue;
         return enum_.value; // assume |value| < 2^52
-      case PbFieldType._INT64_BIT:
-      case PbFieldType._SINT64_BIT:
-      case PbFieldType._SFIXED64_BIT:
+      case PbFieldTypeInternal._INT64_BIT:
+      case PbFieldTypeInternal._SINT64_BIT:
+      case PbFieldTypeInternal._SFIXED64_BIT:
         return fieldValue.toString();
-      case PbFieldType._UINT64_BIT:
-      case PbFieldType._FIXED64_BIT:
+      case PbFieldTypeInternal._UINT64_BIT:
+      case PbFieldTypeInternal._FIXED64_BIT:
         final Int64 int_ = fieldValue;
         return int_.toStringUnsigned();
-      case PbFieldType._GROUP_BIT:
-      case PbFieldType._MESSAGE_BIT:
+      case PbFieldTypeInternal._GROUP_BIT:
+      case PbFieldTypeInternal._MESSAGE_BIT:
         final GeneratedMessage msg = fieldValue;
         return msg.writeToJsonMap();
       default:
@@ -105,7 +105,7 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
 // Merge fields from a previously decoded JSON object.
 // (Called recursively on nested messages.)
 void _mergeFromJsonMap(
-  _FieldSet fs,
+  FieldSet fs,
   Map<String, dynamic> json,
   ExtensionRegistry? registry,
 ) {
@@ -139,7 +139,7 @@ void _mergeFromJsonMap(
 
 void _appendJsonList(
   BuilderInfo meta,
-  _FieldSet fs,
+  FieldSet fs,
   List jsonList,
   FieldInfo fi,
   ExtensionRegistry? registry,
@@ -169,7 +169,7 @@ void _appendJsonList(
 
 void _appendJsonMap(
   BuilderInfo meta,
-  _FieldSet fs,
+  FieldSet fs,
   List jsonList,
   MapFieldInfo fi,
   ExtensionRegistry? registry,
@@ -178,7 +178,7 @@ void _appendJsonMap(
   final map = fi._ensureMapField(meta, fs);
   for (final jsonEntryDynamic in jsonList) {
     final jsonEntry = jsonEntryDynamic as Map<String, dynamic>;
-    final entryFieldSet = _FieldSet(null, entryMeta);
+    final entryFieldSet = FieldSet(null, entryMeta);
     final convertedKey = _convertJsonValue(
       entryMeta,
       entryFieldSet,
@@ -205,7 +205,7 @@ void _appendJsonMap(
 
 void _setJsonField(
   BuilderInfo meta,
-  _FieldSet fs,
+  FieldSet fs,
   json,
   FieldInfo fi,
   ExtensionRegistry? registry,
@@ -239,15 +239,15 @@ void _setJsonField(
 /// Throws [ArgumentError] if it cannot convert the value.
 dynamic _convertJsonValue(
   BuilderInfo meta,
-  _FieldSet fs,
+  FieldSet fs,
   value,
   int tagNumber,
   int fieldType,
   ExtensionRegistry? registry,
 ) {
   String expectedType; // for exception message
-  switch (PbFieldType._baseType(fieldType)) {
-    case PbFieldType._BOOL_BIT:
+  switch (PbFieldTypeInternal._baseType(fieldType)) {
+    case PbFieldTypeInternal._BOOL_BIT:
       if (value is bool) {
         return value;
       } else if (value is String) {
@@ -265,20 +265,20 @@ dynamic _convertJsonValue(
       }
       expectedType = 'bool (true, false, "true", "false", 1, 0)';
       break;
-    case PbFieldType._BYTES_BIT:
+    case PbFieldTypeInternal._BYTES_BIT:
       if (value is String) {
         return base64Decode(value);
       }
       expectedType = 'Base64 String';
       break;
-    case PbFieldType._STRING_BIT:
+    case PbFieldTypeInternal._STRING_BIT:
       if (value is String) {
         return value;
       }
       expectedType = 'String';
       break;
-    case PbFieldType._FLOAT_BIT:
-    case PbFieldType._DOUBLE_BIT:
+    case PbFieldTypeInternal._FLOAT_BIT:
+    case PbFieldTypeInternal._DOUBLE_BIT:
       // Allow quoted values, although we don't emit them.
       if (value is double) {
         return value;
@@ -289,7 +289,7 @@ dynamic _convertJsonValue(
       }
       expectedType = 'num or stringified num';
       break;
-    case PbFieldType._ENUM_BIT:
+    case PbFieldTypeInternal._ENUM_BIT:
       // Allow quoted values, although we don't emit them.
       if (value is String) {
         value = int.parse(value);
@@ -302,15 +302,15 @@ dynamic _convertJsonValue(
       }
       expectedType = 'int or stringified int';
       break;
-    case PbFieldType._INT32_BIT:
-    case PbFieldType._SINT32_BIT:
-    case PbFieldType._SFIXED32_BIT:
+    case PbFieldTypeInternal._INT32_BIT:
+    case PbFieldTypeInternal._SINT32_BIT:
+    case PbFieldTypeInternal._SFIXED32_BIT:
       if (value is int) return value;
       if (value is String) return int.parse(value);
       expectedType = 'int or stringified int';
       break;
-    case PbFieldType._UINT32_BIT:
-    case PbFieldType._FIXED32_BIT:
+    case PbFieldTypeInternal._UINT32_BIT:
+    case PbFieldTypeInternal._FIXED32_BIT:
       int? validatedValue;
       if (value is int) validatedValue = value;
       if (value is String) validatedValue = int.parse(value);
@@ -320,17 +320,17 @@ dynamic _convertJsonValue(
       if (validatedValue != null) return validatedValue;
       expectedType = 'int or stringified int';
       break;
-    case PbFieldType._INT64_BIT:
-    case PbFieldType._SINT64_BIT:
-    case PbFieldType._UINT64_BIT:
-    case PbFieldType._FIXED64_BIT:
-    case PbFieldType._SFIXED64_BIT:
+    case PbFieldTypeInternal._INT64_BIT:
+    case PbFieldTypeInternal._SINT64_BIT:
+    case PbFieldTypeInternal._UINT64_BIT:
+    case PbFieldTypeInternal._FIXED64_BIT:
+    case PbFieldTypeInternal._SFIXED64_BIT:
       if (value is int) return Int64(value);
       if (value is String) return Int64.parseInt(value);
       expectedType = 'int or stringified int';
       break;
-    case PbFieldType._GROUP_BIT:
-    case PbFieldType._MESSAGE_BIT:
+    case PbFieldTypeInternal._GROUP_BIT:
+    case PbFieldTypeInternal._MESSAGE_BIT:
       if (value is Map) {
         final messageValue = value as Map<String, dynamic>;
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);

--- a/protobuf/lib/src/protobuf/json.dart
+++ b/protobuf/lib/src/protobuf/json.dart
@@ -26,10 +26,10 @@ Map<String, dynamic> _writeToJsonMap(FieldSet fs) {
       case PbFieldTypeInternal._DOUBLE_BIT:
         final value = fieldValue as double;
         if (value.isNaN) {
-          return _nan;
+          return nan;
         }
         if (value.isInfinite) {
-          return value.isNegative ? _negativeInfinity : _infinity;
+          return value.isNegative ? negativeInfinity : infinity;
         }
         if (fieldValue.toInt() == fieldValue) {
           return fieldValue.toInt();

--- a/protobuf/lib/src/protobuf/message_set.dart
+++ b/protobuf/lib/src/protobuf/message_set.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 const _messageSetItemsTag = 1;
 const _messageSetItemTypeIdTag = 2;

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Type of a function that checks items added to a `PbList`.
 ///

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -204,10 +204,10 @@ class PbList<E> extends ListBase<E> {
 
   @override
   bool operator ==(Object other) =>
-      other is PbList && _areListsEqual(other, this);
+      other is PbList && areListsEqual(other, this);
 
   @override
-  int get hashCode => _HashUtils._hashObjects(_wrappedList);
+  int get hashCode => HashUtils.hashObjects(_wrappedList);
 
   void freeze() {
     if (_isReadOnly) {

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -77,7 +77,7 @@ class PbMap<K, V> extends MapBase<K, V> {
   int get hashCode {
     return _wrappedMap.entries.fold(
       0,
-      (h, entry) => h ^ _HashUtils._hash2(entry.key, entry.value),
+      (h, entry) => h ^ HashUtils.hash2(entry.key, entry.value),
     );
   }
 

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// A [MapBase] implementation used for protobuf `map` fields.
 class PbMap<K, V> extends MapBase<K, V> {
@@ -108,7 +108,7 @@ class PbMap<K, V> extends MapBase<K, V> {
     final length = input.readInt32();
     final oldLimit = input._currentLimit;
     input._currentLimit = input._bufferPos + length;
-    final entryFieldSet = _FieldSet(null, mapEntryMeta);
+    final entryFieldSet = FieldSet(null, mapEntryMeta);
     _mergeFromCodedBufferReader(mapEntryMeta, entryFieldSet, input, registry);
     input.checkLastTagWas(0);
     input._currentLimit = oldLimit;

--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -2,30 +2,30 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
-Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
+Object? _writeToProto3Json(FieldSet fs, TypeRegistry typeRegistry) {
   String? convertToMapKey(dynamic key, int keyType) {
-    final baseType = PbFieldType._baseType(keyType);
+    final baseType = PbFieldTypeInternal._baseType(keyType);
 
     assert(!_isRepeated(keyType));
 
     switch (baseType) {
-      case PbFieldType._BOOL_BIT:
+      case PbFieldTypeInternal._BOOL_BIT:
         return key ? 'true' : 'false';
-      case PbFieldType._STRING_BIT:
+      case PbFieldTypeInternal._STRING_BIT:
         return key;
-      case PbFieldType._UINT64_BIT:
+      case PbFieldTypeInternal._UINT64_BIT:
         return (key as Int64).toStringUnsigned();
-      case PbFieldType._INT32_BIT:
-      case PbFieldType._SINT32_BIT:
-      case PbFieldType._UINT32_BIT:
-      case PbFieldType._FIXED32_BIT:
-      case PbFieldType._SFIXED32_BIT:
-      case PbFieldType._INT64_BIT:
-      case PbFieldType._SINT64_BIT:
-      case PbFieldType._SFIXED64_BIT:
-      case PbFieldType._FIXED64_BIT:
+      case PbFieldTypeInternal._INT32_BIT:
+      case PbFieldTypeInternal._SINT32_BIT:
+      case PbFieldTypeInternal._UINT32_BIT:
+      case PbFieldTypeInternal._FIXED32_BIT:
+      case PbFieldTypeInternal._SFIXED32_BIT:
+      case PbFieldTypeInternal._INT64_BIT:
+      case PbFieldTypeInternal._SINT64_BIT:
+      case PbFieldTypeInternal._SFIXED64_BIT:
+      case PbFieldTypeInternal._FIXED64_BIT:
         return key.toString();
       default:
         throw StateError('Not a valid key type $keyType');
@@ -43,25 +43,25 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
     } else if (_isEnum(fieldType)) {
       return (fieldValue as ProtobufEnum).name;
     } else {
-      final baseType = PbFieldType._baseType(fieldType);
+      final baseType = PbFieldTypeInternal._baseType(fieldType);
       switch (baseType) {
-        case PbFieldType._BOOL_BIT:
+        case PbFieldTypeInternal._BOOL_BIT:
           return fieldValue as bool;
-        case PbFieldType._STRING_BIT:
+        case PbFieldTypeInternal._STRING_BIT:
           return fieldValue;
-        case PbFieldType._INT32_BIT:
-        case PbFieldType._SINT32_BIT:
-        case PbFieldType._UINT32_BIT:
-        case PbFieldType._FIXED32_BIT:
-        case PbFieldType._SFIXED32_BIT:
+        case PbFieldTypeInternal._INT32_BIT:
+        case PbFieldTypeInternal._SINT32_BIT:
+        case PbFieldTypeInternal._UINT32_BIT:
+        case PbFieldTypeInternal._FIXED32_BIT:
+        case PbFieldTypeInternal._SFIXED32_BIT:
           return fieldValue;
-        case PbFieldType._INT64_BIT:
-        case PbFieldType._SINT64_BIT:
-        case PbFieldType._SFIXED64_BIT:
-        case PbFieldType._FIXED64_BIT:
+        case PbFieldTypeInternal._INT64_BIT:
+        case PbFieldTypeInternal._SINT64_BIT:
+        case PbFieldTypeInternal._SFIXED64_BIT:
+        case PbFieldTypeInternal._FIXED64_BIT:
           return fieldValue.toString();
-        case PbFieldType._FLOAT_BIT:
-        case PbFieldType._DOUBLE_BIT:
+        case PbFieldTypeInternal._FLOAT_BIT:
+        case PbFieldTypeInternal._DOUBLE_BIT:
           final double value = fieldValue;
           if (value.isNaN) {
             return _nan;
@@ -73,9 +73,9 @@ Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
             return value.toInt();
           }
           return value;
-        case PbFieldType._UINT64_BIT:
+        case PbFieldTypeInternal._UINT64_BIT:
           return (fieldValue as Int64).toStringUnsigned();
-        case PbFieldType._BYTES_BIT:
+        case PbFieldTypeInternal._BYTES_BIT:
           return base64Encode(fieldValue);
         default:
           throw StateError(
@@ -160,7 +160,7 @@ extension _FindFirst<E> on Iterable<E> {
 /// to [fieldSet].
 void _mergeFromProto3Json(
   Object? json,
-  _FieldSet fieldSet,
+  FieldSet fieldSet,
   TypeRegistry typeRegistry,
   bool ignoreUnknownFields,
   bool supportNamesWithUnderscores,
@@ -173,16 +173,16 @@ void _mergeFromProto3Json(
     permissiveEnums,
   );
 
-  void recursionHelper(Object? json, _FieldSet fieldSet) {
+  void recursionHelper(Object? json, FieldSet fieldSet) {
     Object? convertProto3JsonValue(Object value, FieldInfo fieldInfo) {
       final fieldType = fieldInfo.type;
-      switch (PbFieldType._baseType(fieldType)) {
-        case PbFieldType._BOOL_BIT:
+      switch (PbFieldTypeInternal._baseType(fieldType)) {
+        case PbFieldTypeInternal._BOOL_BIT:
           if (value is bool) {
             return value;
           }
           throw context.parseException('Expected bool value', json);
-        case PbFieldType._BYTES_BIT:
+        case PbFieldTypeInternal._BYTES_BIT:
           if (value is String) {
             Uint8List result;
             try {
@@ -199,13 +199,13 @@ void _mergeFromProto3Json(
             'Expected bytes encoded as base64 String',
             value,
           );
-        case PbFieldType._STRING_BIT:
+        case PbFieldTypeInternal._STRING_BIT:
           if (value is String) {
             return value;
           }
           throw context.parseException('Expected String value', value);
-        case PbFieldType._FLOAT_BIT:
-        case PbFieldType._DOUBLE_BIT:
+        case PbFieldTypeInternal._FLOAT_BIT:
+        case PbFieldTypeInternal._DOUBLE_BIT:
           if (value is double) {
             return value;
           } else if (value is num) {
@@ -221,7 +221,7 @@ void _mergeFromProto3Json(
             'Expected a double represented as a String or number',
             value,
           );
-        case PbFieldType._ENUM_BIT:
+        case PbFieldTypeInternal._ENUM_BIT:
           if (value is String) {
             // TODO(sigurdm): Do we want to avoid linear search here? Measure...
             final result =
@@ -245,8 +245,8 @@ void _mergeFromProto3Json(
             'Expected enum as a string or integer',
             value,
           );
-        case PbFieldType._UINT32_BIT:
-        case PbFieldType._FIXED32_BIT:
+        case PbFieldTypeInternal._UINT32_BIT:
+        case PbFieldTypeInternal._FIXED32_BIT:
           int result;
           if (value is int) {
             result = value;
@@ -259,9 +259,9 @@ void _mergeFromProto3Json(
             );
           }
           return _check32BitUnsignedProto3(result, context);
-        case PbFieldType._INT32_BIT:
-        case PbFieldType._SINT32_BIT:
-        case PbFieldType._SFIXED32_BIT:
+        case PbFieldTypeInternal._INT32_BIT:
+        case PbFieldTypeInternal._SINT32_BIT:
+        case PbFieldTypeInternal._SFIXED32_BIT:
           int result;
           if (value is int) {
             result = value;
@@ -275,7 +275,7 @@ void _mergeFromProto3Json(
           }
           _check32BitSignedProto3(result, context);
           return result;
-        case PbFieldType._UINT64_BIT:
+        case PbFieldTypeInternal._UINT64_BIT:
           Int64 result;
           if (value is int) {
             result = Int64(value);
@@ -288,10 +288,10 @@ void _mergeFromProto3Json(
             );
           }
           return result;
-        case PbFieldType._INT64_BIT:
-        case PbFieldType._SINT64_BIT:
-        case PbFieldType._FIXED64_BIT:
-        case PbFieldType._SFIXED64_BIT:
+        case PbFieldTypeInternal._INT64_BIT:
+        case PbFieldTypeInternal._SINT64_BIT:
+        case PbFieldTypeInternal._FIXED64_BIT:
+        case PbFieldTypeInternal._SFIXED64_BIT:
           if (value is int) return Int64(value);
           if (value is String) {
             Int64 result;
@@ -309,8 +309,8 @@ void _mergeFromProto3Json(
             'Expected int or stringified int',
             value,
           );
-        case PbFieldType._GROUP_BIT:
-        case PbFieldType._MESSAGE_BIT:
+        case PbFieldTypeInternal._GROUP_BIT:
+        case PbFieldTypeInternal._MESSAGE_BIT:
           final subMessage = fieldInfo.subBuilder!();
           recursionHelper(value, subMessage._fieldSet);
           return subMessage;
@@ -320,8 +320,8 @@ void _mergeFromProto3Json(
     }
 
     Object decodeMapKey(String key, int fieldType) {
-      switch (PbFieldType._baseType(fieldType)) {
-        case PbFieldType._BOOL_BIT:
+      switch (PbFieldTypeInternal._baseType(fieldType)) {
+        case PbFieldTypeInternal._BOOL_BIT:
           switch (key) {
             case 'true':
               return true;
@@ -333,26 +333,26 @@ void _mergeFromProto3Json(
                 key,
               );
           }
-        case PbFieldType._STRING_BIT:
+        case PbFieldTypeInternal._STRING_BIT:
           return key;
-        case PbFieldType._UINT64_BIT:
+        case PbFieldTypeInternal._UINT64_BIT:
           // TODO(sigurdm): We do not throw on negative values here.
           // That would probably require going via bignum.
           return _tryParse64BitProto3(json, key, context);
-        case PbFieldType._INT64_BIT:
-        case PbFieldType._SINT64_BIT:
-        case PbFieldType._SFIXED64_BIT:
-        case PbFieldType._FIXED64_BIT:
+        case PbFieldTypeInternal._INT64_BIT:
+        case PbFieldTypeInternal._SINT64_BIT:
+        case PbFieldTypeInternal._SFIXED64_BIT:
+        case PbFieldTypeInternal._FIXED64_BIT:
           return _tryParse64BitProto3(json, key, context);
-        case PbFieldType._INT32_BIT:
-        case PbFieldType._SINT32_BIT:
-        case PbFieldType._FIXED32_BIT:
-        case PbFieldType._SFIXED32_BIT:
+        case PbFieldTypeInternal._INT32_BIT:
+        case PbFieldTypeInternal._SINT32_BIT:
+        case PbFieldTypeInternal._FIXED32_BIT:
+        case PbFieldTypeInternal._SFIXED32_BIT:
           return _check32BitSignedProto3(
             _tryParse32BitProto3(key, context),
             context,
           );
-        case PbFieldType._UINT32_BIT:
+        case PbFieldTypeInternal._UINT32_BIT:
           return _check32BitUnsignedProto3(
             _tryParse32BitProto3(key, context),
             context,

--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -64,10 +64,10 @@ Object? _writeToProto3Json(FieldSet fs, TypeRegistry typeRegistry) {
         case PbFieldTypeInternal._DOUBLE_BIT:
           final double value = fieldValue;
           if (value.isNaN) {
-            return _nan;
+            return nan;
           }
           if (value.isInfinite) {
-            return value.isNegative ? _negativeInfinity : _infinity;
+            return value.isNegative ? negativeInfinity : infinity;
           }
           if (value.toInt() == fieldValue) {
             return value.toInt();

--- a/protobuf/lib/src/protobuf/protobuf_enum.dart
+++ b/protobuf/lib/src/protobuf/protobuf_enum.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: non_constant_identifier_names
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// A base class for all proto enum types.
 ///

--- a/protobuf/lib/src/protobuf/rpc_client.dart
+++ b/protobuf/lib/src/protobuf/rpc_client.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Client side context for [RpcClient]s.
 class ClientContext {

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// A set of unknown fields in a [GeneratedMessage].
 class UnknownFieldSet {
@@ -283,11 +283,11 @@ class UnknownFieldSetField {
       output.writeField(fieldNumber, type, value);
     }
 
-    write(PbFieldType._REPEATED_UINT64, varints);
-    write(PbFieldType._REPEATED_FIXED32, fixed32s);
-    write(PbFieldType._REPEATED_FIXED64, fixed64s);
-    write(PbFieldType._REPEATED_BYTES, lengthDelimited);
-    write(PbFieldType._REPEATED_GROUP, groups);
+    write(PbFieldTypeInternal._REPEATED_UINT64, varints);
+    write(PbFieldTypeInternal._REPEATED_FIXED32, fixed32s);
+    write(PbFieldTypeInternal._REPEATED_FIXED64, fixed64s);
+    write(PbFieldTypeInternal._REPEATED_BYTES, lengthDelimited);
+    write(PbFieldTypeInternal._REPEATED_GROUP, groups);
   }
 
   void addGroup(UnknownFieldSet value) {

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -140,7 +140,7 @@ class UnknownFieldSet {
     if (other is! UnknownFieldSet) return false;
 
     final o = other;
-    return _areMapsEqual(o._fields, _fields);
+    return areMapsEqual(o._fields, _fields);
   }
 
   @override
@@ -159,7 +159,7 @@ class UnknownFieldSet {
   String _toString(String indent) {
     final stringBuffer = StringBuffer();
 
-    for (final tag in _sorted(_fields.keys)) {
+    for (final tag in sorted(_fields.keys)) {
       final field = _fields[tag]!;
       for (final value in field.values) {
         if (value is UnknownFieldSet) {
@@ -230,14 +230,14 @@ class UnknownFieldSetField {
     final o = other;
     if (lengthDelimited.length != o.lengthDelimited.length) return false;
     for (var i = 0; i < lengthDelimited.length; i++) {
-      if (!_areListsEqual(o.lengthDelimited[i], lengthDelimited[i])) {
+      if (!areListsEqual(o.lengthDelimited[i], lengthDelimited[i])) {
         return false;
       }
     }
-    if (!_areListsEqual(o.varints, varints)) return false;
-    if (!_areListsEqual(o.fixed32s, fixed32s)) return false;
-    if (!_areListsEqual(o.fixed64s, fixed64s)) return false;
-    if (!_areListsEqual(o.groups, groups)) return false;
+    if (!areListsEqual(o.varints, varints)) return false;
+    if (!areListsEqual(o.fixed32s, fixed32s)) return false;
+    if (!areListsEqual(o.fixed64s, fixed64s)) return false;
+    if (!areListsEqual(o.groups, groups)) return false;
 
     return true;
   }

--- a/protobuf/lib/src/protobuf/unpack.dart
+++ b/protobuf/lib/src/protobuf/unpack.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 /// Unpacks the message in [value] into [instance].
 ///

--- a/protobuf/lib/src/protobuf/utils.dart
+++ b/protobuf/lib/src/protobuf/utils.dart
@@ -2,38 +2,38 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of 'internal.dart';
+import 'internal.dart';
 
 // TODO(antonm): reconsider later if PbList should take care of equality.
-bool _deepEquals(Object lhs, Object rhs) {
+bool deepEquals(Object lhs, Object rhs) {
   // Some GeneratedMessages implement Map, so test this first.
   if (lhs is GeneratedMessage) return lhs == rhs;
   if (rhs is GeneratedMessage) return false;
-  if ((lhs is List) && (rhs is List)) return _areListsEqual(lhs, rhs);
-  if ((lhs is Map) && (rhs is Map)) return _areMapsEqual(lhs, rhs);
+  if ((lhs is List) && (rhs is List)) return areListsEqual(lhs, rhs);
+  if ((lhs is Map) && (rhs is Map)) return areMapsEqual(lhs, rhs);
   return lhs == rhs;
 }
 
-bool _areListsEqual(List lhs, List rhs) {
+bool areListsEqual(List lhs, List rhs) {
   if (lhs.length != rhs.length) return false;
   for (var i = 0; i < lhs.length; i++) {
-    if (!_deepEquals(lhs[i], rhs[i])) return false;
+    if (!deepEquals(lhs[i], rhs[i])) return false;
   }
   return true;
 }
 
-bool _areMapsEqual(Map lhs, Map rhs) {
+bool areMapsEqual(Map lhs, Map rhs) {
   if (lhs.length != rhs.length) return false;
-  return lhs.keys.every((key) => _deepEquals(lhs[key], rhs[key]));
+  return lhs.keys.every((key) => deepEquals(lhs[key], rhs[key]));
 }
 
-List<T> _sorted<T>(Iterable<T> list) => List.from(list)..sort();
+List<T> sorted<T>(Iterable<T> list) => List.from(list)..sort();
 
-class _HashUtils {
+class HashUtils {
   // Jenkins hash functions copied from
   // https://github.com/google/quiver-dart/blob/master/lib/src/core/hash.dart.
 
-  static int _combine(int hash, int value) {
+  static int combine(int hash, int value) {
     hash = 0x1fffffff & (hash + value);
     hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
     return hash ^ (hash >> 6);
@@ -46,10 +46,10 @@ class _HashUtils {
   }
 
   /// Generates a hash code for multiple [objects].
-  static int _hashObjects(Iterable objects) =>
-      _finish(objects.fold(0, (h, i) => _combine(h, i.hashCode)));
+  static int hashObjects(Iterable objects) =>
+      _finish(objects.fold(0, (h, i) => combine(h, i.hashCode)));
 
   /// Generates a hash code for two objects.
-  static int _hash2(dynamic a, dynamic b) =>
-      _finish(_combine(_combine(0, a.hashCode), b.hashCode));
+  static int hash2(dynamic a, dynamic b) =>
+      _finish(combine(combine(0, a.hashCode), b.hashCode));
 }

--- a/protobuf/lib/src/protobuf/utils.dart
+++ b/protobuf/lib/src/protobuf/utils.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 // TODO(antonm): reconsider later if PbList should take care of equality.
 bool _deepEquals(Object lhs, Object rhs) {

--- a/protobuf/lib/src/protobuf/wire_format.dart
+++ b/protobuf/lib/src/protobuf/wire_format.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-part of '../../protobuf.dart';
+part of 'internal.dart';
 
 const int _TAG_TYPE_BITS = 3;
 const int _TAG_TYPE_MASK = (1 << _TAG_TYPE_BITS) - 1;
@@ -38,32 +38,32 @@ int makeTag(int fieldNumber, int tag) => (fieldNumber << _TAG_TYPE_BITS) | tag;
 
 /// Returns true if the wireType can be merged into the given fieldType.
 bool _wireTypeMatches(int fieldType, int wireType) {
-  switch (PbFieldType._baseType(fieldType)) {
-    case PbFieldType._BOOL_BIT:
-    case PbFieldType._ENUM_BIT:
-    case PbFieldType._INT32_BIT:
-    case PbFieldType._INT64_BIT:
-    case PbFieldType._SINT32_BIT:
-    case PbFieldType._SINT64_BIT:
-    case PbFieldType._UINT32_BIT:
-    case PbFieldType._UINT64_BIT:
+  switch (PbFieldTypeInternal._baseType(fieldType)) {
+    case PbFieldTypeInternal._BOOL_BIT:
+    case PbFieldTypeInternal._ENUM_BIT:
+    case PbFieldTypeInternal._INT32_BIT:
+    case PbFieldTypeInternal._INT64_BIT:
+    case PbFieldTypeInternal._SINT32_BIT:
+    case PbFieldTypeInternal._SINT64_BIT:
+    case PbFieldTypeInternal._UINT32_BIT:
+    case PbFieldTypeInternal._UINT64_BIT:
       return wireType == WIRETYPE_VARINT ||
           wireType == WIRETYPE_LENGTH_DELIMITED;
-    case PbFieldType._FLOAT_BIT:
-    case PbFieldType._FIXED32_BIT:
-    case PbFieldType._SFIXED32_BIT:
+    case PbFieldTypeInternal._FLOAT_BIT:
+    case PbFieldTypeInternal._FIXED32_BIT:
+    case PbFieldTypeInternal._SFIXED32_BIT:
       return wireType == WIRETYPE_FIXED32 ||
           wireType == WIRETYPE_LENGTH_DELIMITED;
-    case PbFieldType._DOUBLE_BIT:
-    case PbFieldType._FIXED64_BIT:
-    case PbFieldType._SFIXED64_BIT:
+    case PbFieldTypeInternal._DOUBLE_BIT:
+    case PbFieldTypeInternal._FIXED64_BIT:
+    case PbFieldTypeInternal._SFIXED64_BIT:
       return wireType == WIRETYPE_FIXED64 ||
           wireType == WIRETYPE_LENGTH_DELIMITED;
-    case PbFieldType._BYTES_BIT:
-    case PbFieldType._STRING_BIT:
-    case PbFieldType._MESSAGE_BIT:
+    case PbFieldTypeInternal._BYTES_BIT:
+    case PbFieldTypeInternal._STRING_BIT:
+    case PbFieldTypeInternal._MESSAGE_BIT:
       return wireType == WIRETYPE_LENGTH_DELIMITED;
-    case PbFieldType._GROUP_BIT:
+    case PbFieldTypeInternal._GROUP_BIT:
       return wireType == WIRETYPE_START_GROUP;
     default:
       return false;

--- a/protobuf/test/codec_test.dart
+++ b/protobuf/test/codec_test.dart
@@ -29,7 +29,7 @@ void main() {
     };
   }
 
-  final int32ToBytes = convertToBytes(PbFieldType.O3);
+  final int32ToBytes = convertToBytes(PbFieldTypeInternal.O3);
 
   test('testInt32RoundTrips', () {
     final roundtrip = roundtripTester(
@@ -60,7 +60,7 @@ void main() {
   test('testSint32', () {
     final roundtrip = roundtripTester(
       fromBytes: (CodedBufferReader reader) => reader.readSint32(),
-      toBytes: convertToBytes(PbFieldType.OS3),
+      toBytes: convertToBytes(PbFieldTypeInternal.OS3),
     );
 
     roundtrip(0, [0x00]);
@@ -72,7 +72,7 @@ void main() {
   test('testSint64', () {
     final roundtrip = roundtripTester(
       fromBytes: (CodedBufferReader reader) => reader.readSint64(),
-      toBytes: convertToBytes(PbFieldType.OS6),
+      toBytes: convertToBytes(PbFieldTypeInternal.OS6),
     );
 
     roundtrip(make64(0), [0x00]);
@@ -84,7 +84,7 @@ void main() {
   test('testFixed32', () {
     final roundtrip = roundtripTester(
       fromBytes: (CodedBufferReader reader) => reader.readFixed32(),
-      toBytes: convertToBytes(PbFieldType.OF3),
+      toBytes: convertToBytes(PbFieldTypeInternal.OF3),
     );
 
     roundtrip(0, [0x00, 0x00, 0x00, 0x00]);
@@ -96,7 +96,7 @@ void main() {
   test('testFixed64', () {
     final roundtrip = roundtripTester(
       fromBytes: (CodedBufferReader reader) => reader.readFixed64(),
-      toBytes: convertToBytes(PbFieldType.OF6),
+      toBytes: convertToBytes(PbFieldTypeInternal.OF6),
     );
 
     roundtrip(make64(0, 0), [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
@@ -126,7 +126,7 @@ void main() {
   test('testSfixed32', () {
     final roundtrip = roundtripTester(
       fromBytes: (CodedBufferReader reader) => reader.readSfixed32(),
-      toBytes: convertToBytes(PbFieldType.OSF3),
+      toBytes: convertToBytes(PbFieldTypeInternal.OSF3),
     );
 
     roundtrip(0, [0x00, 0x00, 0x00, 0x00]);
@@ -138,7 +138,7 @@ void main() {
   test('testSfixed64', () {
     final roundtrip = roundtripTester(
       fromBytes: (CodedBufferReader reader) => reader.readSfixed64(),
-      toBytes: convertToBytes(PbFieldType.OSF6),
+      toBytes: convertToBytes(PbFieldTypeInternal.OSF6),
     );
 
     roundtrip(make64(0), [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
@@ -183,7 +183,7 @@ void main() {
           : equals(expected);
 
   List<int> dataToBytes(ByteData byteData) => Uint8List.view(byteData.buffer);
-  final floatToBytes = convertToBytes(PbFieldType.OF);
+  final floatToBytes = convertToBytes(PbFieldTypeInternal.OF);
   int floatToBits(double value) =>
       makeData(floatToBytes(value)).getUint32(0, Endian.little);
 
@@ -197,7 +197,7 @@ void main() {
     expect(readFloat(bits), doubleEquals(value));
   }
 
-  final doubleToBytes = convertToBytes(PbFieldType.OD);
+  final doubleToBytes = convertToBytes(PbFieldTypeInternal.OD);
 
   void test64(List<int> hilo, double value) {
     // Encode a double to its wire format.
@@ -732,7 +732,7 @@ void main() {
   test('testVarint64', () {
     final roundtrip = roundtripTester(
       fromBytes: (CodedBufferReader reader) => reader.readUint64(),
-      toBytes: convertToBytes(PbFieldType.OU6),
+      toBytes: convertToBytes(PbFieldTypeInternal.OU6),
     );
 
     roundtrip(make64(0), [0x00]);
@@ -794,7 +794,8 @@ void main() {
   });
 
   test('testWriteTo', () {
-    final writer = CodedBufferWriter()..writeField(0, PbFieldType.O3, 1337);
+    final writer =
+        CodedBufferWriter()..writeField(0, PbFieldTypeInternal.O3, 1337);
     expect(writer.lengthInBytes, 3);
     final buffer = Uint8List(5);
     buffer[0] = 0x55;

--- a/protobuf/test/list_test.dart
+++ b/protobuf/test/list_test.dart
@@ -98,7 +98,9 @@ void main() {
   });
 
   test('PbList for signed int32 validates items', () {
-    final List<int> list = PbList(check: getCheckFunction(PbFieldType.P3));
+    final List<int> list = PbList(
+      check: getCheckFunction(PbFieldTypeInternal.P3),
+    );
 
     expect(() {
       list.add(-2147483649);
@@ -126,7 +128,9 @@ void main() {
   });
 
   test('PBList for unsigned int32 validates items', () {
-    final List<int> list = PbList(check: getCheckFunction(PbFieldType.PU3));
+    final List<int> list = PbList(
+      check: getCheckFunction(PbFieldTypeInternal.PU3),
+    );
 
     expect(() {
       list.add(-1);
@@ -154,7 +158,9 @@ void main() {
   });
 
   test('PbList for float validates items', () {
-    final List<double> list = PbList(check: getCheckFunction(PbFieldType.PF));
+    final List<double> list = PbList(
+      check: getCheckFunction(PbFieldTypeInternal.PF),
+    );
 
     expect(() {
       list.add(3.4028234663852886E39);

--- a/protobuf/test/mock_util.dart
+++ b/protobuf/test/mock_util.dart
@@ -9,22 +9,28 @@ import 'package:protobuf/protobuf.dart'
         BuilderInfo,
         CreateBuilderFunc,
         GeneratedMessage,
-        PbFieldType,
+        PbFieldTypeInternal,
         ProtobufEnum;
 
 final mockEnumValues = [ProtobufEnum(1, 'a'), ProtobufEnum(2, 'b')];
 BuilderInfo mockInfo(String className, CreateBuilderFunc create) {
   return BuilderInfo(className, createEmptyInstance: create)
-    ..a(1, 'val', PbFieldType.O3, defaultOrMaker: 42)
-    ..a(2, 'str', PbFieldType.OS)
-    ..a(3, 'child', PbFieldType.OM, defaultOrMaker: create, subBuilder: create)
-    ..p<int>(4, 'int32s', PbFieldType.P3)
-    ..a(5, 'int64', PbFieldType.O6)
+    ..a(1, 'val', PbFieldTypeInternal.O3, defaultOrMaker: 42)
+    ..a(2, 'str', PbFieldTypeInternal.OS)
+    ..a(
+      3,
+      'child',
+      PbFieldTypeInternal.OM,
+      defaultOrMaker: create,
+      subBuilder: create,
+    )
+    ..p<int>(4, 'int32s', PbFieldTypeInternal.P3)
+    ..a(5, 'int64', PbFieldTypeInternal.O6)
     // 6 is reserved for extensions in other tests.
     ..e(
       7,
       'enm',
-      PbFieldType.OE,
+      PbFieldTypeInternal.OE,
       defaultOrMaker: mockEnumValues.first,
       valueOf: (i) => mockEnumValues.firstWhereOrNull((e) => e.value == i),
       enumValues: mockEnumValues,

--- a/protobuf/test/readonly_message_test.dart
+++ b/protobuf/test/readonly_message_test.dart
@@ -3,7 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:protobuf/protobuf.dart'
-    show BuilderInfo, GeneratedMessage, PbFieldType, UnknownFieldSetField;
+    show
+        BuilderInfo,
+        GeneratedMessage,
+        PbFieldTypeInternal,
+        UnknownFieldSetField;
 import 'package:test/test.dart';
 
 Matcher throwsUnsupportedError(Matcher expectedMessage) => throwsA(
@@ -23,9 +27,9 @@ class Rec extends GeneratedMessage {
   @override
   BuilderInfo info_ =
       BuilderInfo('rec')
-        ..a(1, 'value', PbFieldType.O3)
-        ..pc<Rec>(2, 'sub', PbFieldType.PM, subBuilder: Rec.create)
-        ..p<int>(10, 'ints', PbFieldType.P3);
+        ..a(1, 'value', PbFieldTypeInternal.O3)
+        ..pc<Rec>(2, 'sub', PbFieldTypeInternal.PM, subBuilder: Rec.create)
+        ..p<int>(10, 'ints', PbFieldTypeInternal.P3);
 
   int get value => $_get(0, 0);
   set value(int v) {

--- a/protoc_plugin/lib/src/base_type.dart
+++ b/protoc_plugin/lib/src/base_type.dart
@@ -12,7 +12,7 @@ class BaseType {
   /// The name of the Dart type when in the same package.
   final String unprefixed;
 
-  /// The suffix of the constant for this type in PbFieldType.
+  /// The suffix of the constant for this type in PbFieldTypeInternal.
   /// (For example, 'B' for boolean or '3' for int32.)
   final String typeConstantSuffix;
 

--- a/protoc_plugin/lib/src/gen/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/gen/dart_options.pb.dart
@@ -125,7 +125,8 @@ class Imports extends $pb.GeneratedMessage {
       _omitMessageNames ? '' : 'Imports',
       package: const $pb.PackageName(_omitMessageNames ? '' : 'dart_options'),
       createEmptyInstance: create)
-    ..pc<DartMixin>(1, _omitFieldNames ? '' : 'mixins', $pb.PbFieldType.PM,
+    ..pc<DartMixin>(
+        1, _omitFieldNames ? '' : 'mixins', $pb.PbFieldTypeInternal.PM,
         subBuilder: DartMixin.create)
     ..hasRequiredFields = false;
 
@@ -165,44 +166,44 @@ class Dart_options {
       _omitMessageNames ? '' : 'google.protobuf.FileOptions',
       _omitFieldNames ? '' : 'imports',
       28125061,
-      $pb.PbFieldType.OM,
+      $pb.PbFieldTypeInternal.OM,
       defaultOrMaker: Imports.getDefault,
       subBuilder: Imports.create);
   static final defaultMixin = $pb.Extension<$core.String>(
       _omitMessageNames ? '' : 'google.protobuf.FileOptions',
       _omitFieldNames ? '' : 'defaultMixin',
       96128839,
-      $pb.PbFieldType.OS);
+      $pb.PbFieldTypeInternal.OS);
   static final mixin = $pb.Extension<$core.String>(
       _omitMessageNames ? '' : 'google.protobuf.MessageOptions',
       _omitFieldNames ? '' : 'mixin',
       96128839,
-      $pb.PbFieldType.OS);
+      $pb.PbFieldTypeInternal.OS);
   static final overrideGetter = $pb.Extension<$core.bool>(
       _omitMessageNames ? '' : 'google.protobuf.FieldOptions',
       _omitFieldNames ? '' : 'overrideGetter',
       28205290,
-      $pb.PbFieldType.OB);
+      $pb.PbFieldTypeInternal.OB);
   static final overrideSetter = $pb.Extension<$core.bool>(
       _omitMessageNames ? '' : 'google.protobuf.FieldOptions',
       _omitFieldNames ? '' : 'overrideSetter',
       28937366,
-      $pb.PbFieldType.OB);
+      $pb.PbFieldTypeInternal.OB);
   static final overrideHasMethod = $pb.Extension<$core.bool>(
       _omitMessageNames ? '' : 'google.protobuf.FieldOptions',
       _omitFieldNames ? '' : 'overrideHasMethod',
       28937461,
-      $pb.PbFieldType.OB);
+      $pb.PbFieldTypeInternal.OB);
   static final overrideClearMethod = $pb.Extension<$core.bool>(
       _omitMessageNames ? '' : 'google.protobuf.FieldOptions',
       _omitFieldNames ? '' : 'overrideClearMethod',
       28907907,
-      $pb.PbFieldType.OB);
+      $pb.PbFieldTypeInternal.OB);
   static final dartName = $pb.Extension<$core.String>(
       _omitMessageNames ? '' : 'google.protobuf.FieldOptions',
       _omitFieldNames ? '' : 'dartName',
       28700919,
-      $pb.PbFieldType.OS);
+      $pb.PbFieldTypeInternal.OS);
   static void registerAllExtensions($pb.ExtensionRegistry registry) {
     registry.add(imports);
     registry.add(defaultMixin);

--- a/protoc_plugin/lib/src/gen/google/api/client.pb.dart
+++ b/protoc_plugin/lib/src/gen/google/api/client.pb.dart
@@ -53,7 +53,7 @@ class CommonLanguageSettings extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'referenceDocsUri')
     ..pc<ClientLibraryDestination>(
-        2, _omitFieldNames ? '' : 'destinations', $pb.PbFieldType.KE,
+        2, _omitFieldNames ? '' : 'destinations', $pb.PbFieldTypeInternal.KE,
         valueOf: ClientLibraryDestination.valueOf,
         enumValues: ClientLibraryDestination.values,
         defaultEnumValue:
@@ -164,7 +164,7 @@ class ClientLibrarySettings extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'version')
     ..e<$1.LaunchStage>(
-        2, _omitFieldNames ? '' : 'launchStage', $pb.PbFieldType.OE,
+        2, _omitFieldNames ? '' : 'launchStage', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: $1.LaunchStage.LAUNCH_STAGE_UNSPECIFIED,
         valueOf: $1.LaunchStage.valueOf,
         enumValues: $1.LaunchStage.values)
@@ -389,7 +389,7 @@ class Publishing extends $pb.GeneratedMessage {
       package: const $pb.PackageName(_omitMessageNames ? '' : 'google.api'),
       createEmptyInstance: create)
     ..pc<MethodSettings>(
-        2, _omitFieldNames ? '' : 'methodSettings', $pb.PbFieldType.PM,
+        2, _omitFieldNames ? '' : 'methodSettings', $pb.PbFieldTypeInternal.PM,
         subBuilder: MethodSettings.create)
     ..aOS(101, _omitFieldNames ? '' : 'newIssueUri')
     ..aOS(102, _omitFieldNames ? '' : 'documentationUri')
@@ -398,13 +398,13 @@ class Publishing extends $pb.GeneratedMessage {
     ..pPS(105, _omitFieldNames ? '' : 'codeownerGithubTeams')
     ..aOS(106, _omitFieldNames ? '' : 'docTagPrefix')
     ..e<ClientLibraryOrganization>(
-        107, _omitFieldNames ? '' : 'organization', $pb.PbFieldType.OE,
+        107, _omitFieldNames ? '' : 'organization', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker:
             ClientLibraryOrganization.CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED,
         valueOf: ClientLibraryOrganization.valueOf,
         enumValues: ClientLibraryOrganization.values)
-    ..pc<ClientLibrarySettings>(
-        109, _omitFieldNames ? '' : 'librarySettings', $pb.PbFieldType.PM,
+    ..pc<ClientLibrarySettings>(109, _omitFieldNames ? '' : 'librarySettings',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: ClientLibrarySettings.create)
     ..aOS(110, _omitFieldNames ? '' : 'protoReferenceDocumentationUri')
     ..aOS(111, _omitFieldNames ? '' : 'restReferenceDocumentationUri')
@@ -568,8 +568,8 @@ class JavaSettings extends $pb.GeneratedMessage {
     ..m<$core.String, $core.String>(
         2, _omitFieldNames ? '' : 'serviceClassNames',
         entryClassName: 'JavaSettings.ServiceClassNamesEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
+        keyFieldType: $pb.PbFieldTypeInternal.OS,
+        valueFieldType: $pb.PbFieldTypeInternal.OS,
         packageName: const $pb.PackageName('google.api'))
     ..aOM<CommonLanguageSettings>(3, _omitFieldNames ? '' : 'common',
         subBuilder: CommonLanguageSettings.create)
@@ -1055,14 +1055,14 @@ class DotnetSettings extends $pb.GeneratedMessage {
         subBuilder: CommonLanguageSettings.create)
     ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'renamedServices',
         entryClassName: 'DotnetSettings.RenamedServicesEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
+        keyFieldType: $pb.PbFieldTypeInternal.OS,
+        valueFieldType: $pb.PbFieldTypeInternal.OS,
         packageName: const $pb.PackageName('google.api'))
     ..m<$core.String, $core.String>(
         3, _omitFieldNames ? '' : 'renamedResources',
         entryClassName: 'DotnetSettings.RenamedResourcesEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
+        keyFieldType: $pb.PbFieldTypeInternal.OS,
+        valueFieldType: $pb.PbFieldTypeInternal.OS,
         packageName: const $pb.PackageName('google.api'))
     ..pPS(4, _omitFieldNames ? '' : 'ignoredResources')
     ..pPS(5, _omitFieldNames ? '' : 'forcedNamespaceAliases')
@@ -1229,8 +1229,8 @@ class GoSettings extends $pb.GeneratedMessage {
         subBuilder: CommonLanguageSettings.create)
     ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'renamedServices',
         entryClassName: 'GoSettings.RenamedServicesEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
+        keyFieldType: $pb.PbFieldTypeInternal.OS,
+        valueFieldType: $pb.PbFieldTypeInternal.OS,
         packageName: const $pb.PackageName('google.api'))
     ..hasRequiredFields = false;
 
@@ -1313,8 +1313,8 @@ class MethodSettings_LongRunning extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aOM<$0.Duration>(1, _omitFieldNames ? '' : 'initialPollDelay',
         subBuilder: $0.Duration.create)
-    ..a<$core.double>(
-        2, _omitFieldNames ? '' : 'pollDelayMultiplier', $pb.PbFieldType.OF)
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'pollDelayMultiplier',
+        $pb.PbFieldTypeInternal.OF)
     ..aOM<$0.Duration>(3, _omitFieldNames ? '' : 'maxPollDelay',
         subBuilder: $0.Duration.create)
     ..aOM<$0.Duration>(4, _omitFieldNames ? '' : 'totalPollTimeout',
@@ -1590,23 +1590,23 @@ class Client {
       _omitMessageNames ? '' : 'google.protobuf.MethodOptions',
       _omitFieldNames ? '' : 'methodSignature',
       1051,
-      $pb.PbFieldType.PS,
-      check: $pb.getCheckFunction($pb.PbFieldType.PS));
+      $pb.PbFieldTypeInternal.PS,
+      check: $pb.getCheckFunction($pb.PbFieldTypeInternal.PS));
   static final defaultHost = $pb.Extension<$core.String>(
       _omitMessageNames ? '' : 'google.protobuf.ServiceOptions',
       _omitFieldNames ? '' : 'defaultHost',
       1049,
-      $pb.PbFieldType.OS);
+      $pb.PbFieldTypeInternal.OS);
   static final oauthScopes = $pb.Extension<$core.String>(
       _omitMessageNames ? '' : 'google.protobuf.ServiceOptions',
       _omitFieldNames ? '' : 'oauthScopes',
       1050,
-      $pb.PbFieldType.OS);
+      $pb.PbFieldTypeInternal.OS);
   static final apiVersion = $pb.Extension<$core.String>(
       _omitMessageNames ? '' : 'google.protobuf.ServiceOptions',
       _omitFieldNames ? '' : 'apiVersion',
       525000001,
-      $pb.PbFieldType.OS);
+      $pb.PbFieldTypeInternal.OS);
   static void registerAllExtensions($pb.ExtensionRegistry registry) {
     registry.add(methodSignature);
     registry.add(defaultHost);

--- a/protoc_plugin/lib/src/gen/google/api/http.pb.dart
+++ b/protoc_plugin/lib/src/gen/google/api/http.pb.dart
@@ -44,7 +44,8 @@ class Http extends $pb.GeneratedMessage {
       _omitMessageNames ? '' : 'Http',
       package: const $pb.PackageName(_omitMessageNames ? '' : 'google.api'),
       createEmptyInstance: create)
-    ..pc<HttpRule>(1, _omitFieldNames ? '' : 'rules', $pb.PbFieldType.PM,
+    ..pc<HttpRule>(
+        1, _omitFieldNames ? '' : 'rules', $pb.PbFieldTypeInternal.PM,
         subBuilder: HttpRule.create)
     ..aOB(2, _omitFieldNames ? '' : 'fullyDecodeReservedExpansion')
     ..hasRequiredFields = false;
@@ -416,8 +417,8 @@ class HttpRule extends $pb.GeneratedMessage {
     ..aOS(7, _omitFieldNames ? '' : 'body')
     ..aOM<CustomHttpPattern>(8, _omitFieldNames ? '' : 'custom',
         subBuilder: CustomHttpPattern.create)
-    ..pc<HttpRule>(
-        11, _omitFieldNames ? '' : 'additionalBindings', $pb.PbFieldType.PM,
+    ..pc<HttpRule>(11, _omitFieldNames ? '' : 'additionalBindings',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: HttpRule.create)
     ..aOS(12, _omitFieldNames ? '' : 'responseBody')
     ..hasRequiredFields = false;

--- a/protoc_plugin/lib/src/gen/google/api/routing.pb.dart
+++ b/protoc_plugin/lib/src/gen/google/api/routing.pb.dart
@@ -398,8 +398,8 @@ class RoutingRule extends $pb.GeneratedMessage {
       _omitMessageNames ? '' : 'RoutingRule',
       package: const $pb.PackageName(_omitMessageNames ? '' : 'google.api'),
       createEmptyInstance: create)
-    ..pc<RoutingParameter>(
-        2, _omitFieldNames ? '' : 'routingParameters', $pb.PbFieldType.PM,
+    ..pc<RoutingParameter>(2, _omitFieldNames ? '' : 'routingParameters',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: RoutingParameter.create)
     ..hasRequiredFields = false;
 
@@ -562,7 +562,7 @@ class Routing {
       _omitMessageNames ? '' : 'google.protobuf.MethodOptions',
       _omitFieldNames ? '' : 'routing',
       72295729,
-      $pb.PbFieldType.OM,
+      $pb.PbFieldTypeInternal.OM,
       defaultOrMaker: RoutingRule.getDefault,
       subBuilder: RoutingRule.create);
   static void registerAllExtensions($pb.ExtensionRegistry registry) {

--- a/protoc_plugin/lib/src/gen/google/protobuf/compiler/plugin.pb.dart
+++ b/protoc_plugin/lib/src/gen/google/protobuf/compiler/plugin.pb.dart
@@ -51,9 +51,12 @@ class Version extends $pb.GeneratedMessage {
       package: const $pb.PackageName(
           _omitMessageNames ? '' : 'google.protobuf.compiler'),
       createEmptyInstance: create)
-    ..a<$core.int>(1, _omitFieldNames ? '' : 'major', $pb.PbFieldType.O3)
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'minor', $pb.PbFieldType.O3)
-    ..a<$core.int>(3, _omitFieldNames ? '' : 'patch', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        1, _omitFieldNames ? '' : 'major', $pb.PbFieldTypeInternal.O3)
+    ..a<$core.int>(
+        2, _omitFieldNames ? '' : 'minor', $pb.PbFieldTypeInternal.O3)
+    ..a<$core.int>(
+        3, _omitFieldNames ? '' : 'patch', $pb.PbFieldTypeInternal.O3)
     ..aOS(4, _omitFieldNames ? '' : 'suffix')
     ..hasRequiredFields = false;
 
@@ -153,10 +156,12 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
     ..aOM<Version>(3, _omitFieldNames ? '' : 'compilerVersion',
         subBuilder: Version.create)
     ..pc<$0.FileDescriptorProto>(
-        15, _omitFieldNames ? '' : 'protoFile', $pb.PbFieldType.PM,
+        15, _omitFieldNames ? '' : 'protoFile', $pb.PbFieldTypeInternal.PM,
         subBuilder: $0.FileDescriptorProto.create)
     ..pc<$0.FileDescriptorProto>(
-        17, _omitFieldNames ? '' : 'sourceFileDescriptors', $pb.PbFieldType.PM,
+        17,
+        _omitFieldNames ? '' : 'sourceFileDescriptors',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: $0.FileDescriptorProto.create);
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -423,15 +428,15 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
           _omitMessageNames ? '' : 'google.protobuf.compiler'),
       createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'error')
-    ..a<$fixnum.Int64>(
-        2, _omitFieldNames ? '' : 'supportedFeatures', $pb.PbFieldType.OU6,
+    ..a<$fixnum.Int64>(2, _omitFieldNames ? '' : 'supportedFeatures',
+        $pb.PbFieldTypeInternal.OU6,
         defaultOrMaker: $fixnum.Int64.ZERO)
     ..a<$core.int>(
-        3, _omitFieldNames ? '' : 'minimumEdition', $pb.PbFieldType.O3)
+        3, _omitFieldNames ? '' : 'minimumEdition', $pb.PbFieldTypeInternal.O3)
     ..a<$core.int>(
-        4, _omitFieldNames ? '' : 'maximumEdition', $pb.PbFieldType.O3)
+        4, _omitFieldNames ? '' : 'maximumEdition', $pb.PbFieldTypeInternal.O3)
     ..pc<CodeGeneratorResponse_File>(
-        15, _omitFieldNames ? '' : 'file', $pb.PbFieldType.PM,
+        15, _omitFieldNames ? '' : 'file', $pb.PbFieldTypeInternal.PM,
         subBuilder: CodeGeneratorResponse_File.create)
     ..hasRequiredFields = false;
 

--- a/protoc_plugin/lib/src/gen/google/protobuf/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/gen/google/protobuf/descriptor.pb.dart
@@ -47,7 +47,7 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<FileDescriptorProto>(
-        1, _omitFieldNames ? '' : 'file', $pb.PbFieldType.PM,
+        1, _omitFieldNames ? '' : 'file', $pb.PbFieldTypeInternal.PM,
         subBuilder: FileDescriptorProto.create)
     ..hasExtensions = true;
 
@@ -132,27 +132,28 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
     ..aOS(2, _omitFieldNames ? '' : 'package')
     ..pPS(3, _omitFieldNames ? '' : 'dependency')
     ..pc<DescriptorProto>(
-        4, _omitFieldNames ? '' : 'messageType', $pb.PbFieldType.PM,
+        4, _omitFieldNames ? '' : 'messageType', $pb.PbFieldTypeInternal.PM,
         subBuilder: DescriptorProto.create)
     ..pc<EnumDescriptorProto>(
-        5, _omitFieldNames ? '' : 'enumType', $pb.PbFieldType.PM,
+        5, _omitFieldNames ? '' : 'enumType', $pb.PbFieldTypeInternal.PM,
         subBuilder: EnumDescriptorProto.create)
     ..pc<ServiceDescriptorProto>(
-        6, _omitFieldNames ? '' : 'service', $pb.PbFieldType.PM,
+        6, _omitFieldNames ? '' : 'service', $pb.PbFieldTypeInternal.PM,
         subBuilder: ServiceDescriptorProto.create)
     ..pc<FieldDescriptorProto>(
-        7, _omitFieldNames ? '' : 'extension', $pb.PbFieldType.PM,
+        7, _omitFieldNames ? '' : 'extension', $pb.PbFieldTypeInternal.PM,
         subBuilder: FieldDescriptorProto.create)
     ..aOM<FileOptions>(8, _omitFieldNames ? '' : 'options',
         subBuilder: FileOptions.create)
     ..aOM<SourceCodeInfo>(9, _omitFieldNames ? '' : 'sourceCodeInfo',
         subBuilder: SourceCodeInfo.create)
+    ..p<$core.int>(10, _omitFieldNames ? '' : 'publicDependency',
+        $pb.PbFieldTypeInternal.P3)
     ..p<$core.int>(
-        10, _omitFieldNames ? '' : 'publicDependency', $pb.PbFieldType.P3)
-    ..p<$core.int>(
-        11, _omitFieldNames ? '' : 'weakDependency', $pb.PbFieldType.P3)
+        11, _omitFieldNames ? '' : 'weakDependency', $pb.PbFieldTypeInternal.P3)
     ..aOS(12, _omitFieldNames ? '' : 'syntax')
-    ..e<Edition>(14, _omitFieldNames ? '' : 'edition', $pb.PbFieldType.OE,
+    ..e<Edition>(
+        14, _omitFieldNames ? '' : 'edition', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: Edition.EDITION_UNKNOWN,
         valueOf: Edition.valueOf,
         enumValues: Edition.values)
@@ -311,8 +312,9 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
       package:
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..a<$core.int>(1, _omitFieldNames ? '' : 'start', $pb.PbFieldType.O3)
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'end', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        1, _omitFieldNames ? '' : 'start', $pb.PbFieldTypeInternal.O3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'end', $pb.PbFieldTypeInternal.O3)
     ..aOM<ExtensionRangeOptions>(3, _omitFieldNames ? '' : 'options',
         subBuilder: ExtensionRangeOptions.create);
 
@@ -399,8 +401,9 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
       package:
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..a<$core.int>(1, _omitFieldNames ? '' : 'start', $pb.PbFieldType.O3)
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'end', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        1, _omitFieldNames ? '' : 'start', $pb.PbFieldTypeInternal.O3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'end', $pb.PbFieldTypeInternal.O3)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -493,31 +496,31 @@ class DescriptorProto extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..pc<FieldDescriptorProto>(
-        2, _omitFieldNames ? '' : 'field', $pb.PbFieldType.PM,
+        2, _omitFieldNames ? '' : 'field', $pb.PbFieldTypeInternal.PM,
         subBuilder: FieldDescriptorProto.create)
     ..pc<DescriptorProto>(
-        3, _omitFieldNames ? '' : 'nestedType', $pb.PbFieldType.PM,
+        3, _omitFieldNames ? '' : 'nestedType', $pb.PbFieldTypeInternal.PM,
         subBuilder: DescriptorProto.create)
     ..pc<EnumDescriptorProto>(
-        4, _omitFieldNames ? '' : 'enumType', $pb.PbFieldType.PM,
+        4, _omitFieldNames ? '' : 'enumType', $pb.PbFieldTypeInternal.PM,
         subBuilder: EnumDescriptorProto.create)
     ..pc<DescriptorProto_ExtensionRange>(
-        5, _omitFieldNames ? '' : 'extensionRange', $pb.PbFieldType.PM,
+        5, _omitFieldNames ? '' : 'extensionRange', $pb.PbFieldTypeInternal.PM,
         subBuilder: DescriptorProto_ExtensionRange.create)
     ..pc<FieldDescriptorProto>(
-        6, _omitFieldNames ? '' : 'extension', $pb.PbFieldType.PM,
+        6, _omitFieldNames ? '' : 'extension', $pb.PbFieldTypeInternal.PM,
         subBuilder: FieldDescriptorProto.create)
     ..aOM<MessageOptions>(7, _omitFieldNames ? '' : 'options',
         subBuilder: MessageOptions.create)
     ..pc<OneofDescriptorProto>(
-        8, _omitFieldNames ? '' : 'oneofDecl', $pb.PbFieldType.PM,
+        8, _omitFieldNames ? '' : 'oneofDecl', $pb.PbFieldTypeInternal.PM,
         subBuilder: OneofDescriptorProto.create)
     ..pc<DescriptorProto_ReservedRange>(
-        9, _omitFieldNames ? '' : 'reservedRange', $pb.PbFieldType.PM,
+        9, _omitFieldNames ? '' : 'reservedRange', $pb.PbFieldTypeInternal.PM,
         subBuilder: DescriptorProto_ReservedRange.create)
     ..pPS(10, _omitFieldNames ? '' : 'reservedName')
     ..e<SymbolVisibility>(
-        11, _omitFieldNames ? '' : 'visibility', $pb.PbFieldType.OE,
+        11, _omitFieldNames ? '' : 'visibility', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: SymbolVisibility.VISIBILITY_UNSET,
         valueOf: SymbolVisibility.valueOf,
         enumValues: SymbolVisibility.values);
@@ -632,7 +635,8 @@ class ExtensionRangeOptions_Declaration extends $pb.GeneratedMessage {
       package:
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..a<$core.int>(1, _omitFieldNames ? '' : 'number', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        1, _omitFieldNames ? '' : 'number', $pb.PbFieldTypeInternal.O3)
     ..aOS(2, _omitFieldNames ? '' : 'fullName')
     ..aOS(3, _omitFieldNames ? '' : 'type')
     ..aOB(5, _omitFieldNames ? '' : 'reserved')
@@ -753,17 +757,17 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<ExtensionRangeOptions_Declaration>(
-        2, _omitFieldNames ? '' : 'declaration', $pb.PbFieldType.PM,
+        2, _omitFieldNames ? '' : 'declaration', $pb.PbFieldTypeInternal.PM,
         subBuilder: ExtensionRangeOptions_Declaration.create)
     ..e<ExtensionRangeOptions_VerificationState>(
-        3, _omitFieldNames ? '' : 'verification', $pb.PbFieldType.OE,
+        3, _omitFieldNames ? '' : 'verification', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: ExtensionRangeOptions_VerificationState.UNVERIFIED,
         valueOf: ExtensionRangeOptions_VerificationState.valueOf,
         enumValues: ExtensionRangeOptions_VerificationState.values)
     ..aOM<FeatureSet>(50, _omitFieldNames ? '' : 'features',
         subBuilder: FeatureSet.create)
-    ..pc<UninterpretedOption>(
-        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption>(999, _omitFieldNames ? '' : 'uninterpretedOption',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -872,14 +876,15 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOS(2, _omitFieldNames ? '' : 'extendee')
-    ..a<$core.int>(3, _omitFieldNames ? '' : 'number', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        3, _omitFieldNames ? '' : 'number', $pb.PbFieldTypeInternal.O3)
     ..e<FieldDescriptorProto_Label>(
-        4, _omitFieldNames ? '' : 'label', $pb.PbFieldType.OE,
+        4, _omitFieldNames ? '' : 'label', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FieldDescriptorProto_Label.LABEL_OPTIONAL,
         valueOf: FieldDescriptorProto_Label.valueOf,
         enumValues: FieldDescriptorProto_Label.values)
     ..e<FieldDescriptorProto_Type>(
-        5, _omitFieldNames ? '' : 'type', $pb.PbFieldType.OE,
+        5, _omitFieldNames ? '' : 'type', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FieldDescriptorProto_Type.TYPE_DOUBLE,
         valueOf: FieldDescriptorProto_Type.valueOf,
         enumValues: FieldDescriptorProto_Type.values)
@@ -887,7 +892,8 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
     ..aOS(7, _omitFieldNames ? '' : 'defaultValue')
     ..aOM<FieldOptions>(8, _omitFieldNames ? '' : 'options',
         subBuilder: FieldOptions.create)
-    ..a<$core.int>(9, _omitFieldNames ? '' : 'oneofIndex', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        9, _omitFieldNames ? '' : 'oneofIndex', $pb.PbFieldTypeInternal.O3)
     ..aOS(10, _omitFieldNames ? '' : 'jsonName')
     ..aOB(17, _omitFieldNames ? '' : 'proto3Optional');
 
@@ -1160,8 +1166,9 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
       package:
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..a<$core.int>(1, _omitFieldNames ? '' : 'start', $pb.PbFieldType.O3)
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'end', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        1, _omitFieldNames ? '' : 'start', $pb.PbFieldTypeInternal.O3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'end', $pb.PbFieldTypeInternal.O3)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -1245,16 +1252,16 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..pc<EnumValueDescriptorProto>(
-        2, _omitFieldNames ? '' : 'value', $pb.PbFieldType.PM,
+        2, _omitFieldNames ? '' : 'value', $pb.PbFieldTypeInternal.PM,
         subBuilder: EnumValueDescriptorProto.create)
     ..aOM<EnumOptions>(3, _omitFieldNames ? '' : 'options',
         subBuilder: EnumOptions.create)
     ..pc<EnumDescriptorProto_EnumReservedRange>(
-        4, _omitFieldNames ? '' : 'reservedRange', $pb.PbFieldType.PM,
+        4, _omitFieldNames ? '' : 'reservedRange', $pb.PbFieldTypeInternal.PM,
         subBuilder: EnumDescriptorProto_EnumReservedRange.create)
     ..pPS(5, _omitFieldNames ? '' : 'reservedName')
     ..e<SymbolVisibility>(
-        6, _omitFieldNames ? '' : 'visibility', $pb.PbFieldType.OE,
+        6, _omitFieldNames ? '' : 'visibility', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: SymbolVisibility.VISIBILITY_UNSET,
         valueOf: SymbolVisibility.valueOf,
         enumValues: SymbolVisibility.values);
@@ -1355,7 +1362,8 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'number', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        2, _omitFieldNames ? '' : 'number', $pb.PbFieldTypeInternal.O3)
     ..aOM<EnumValueOptions>(3, _omitFieldNames ? '' : 'options',
         subBuilder: EnumValueOptions.create);
 
@@ -1442,7 +1450,7 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..pc<MethodDescriptorProto>(
-        2, _omitFieldNames ? '' : 'method', $pb.PbFieldType.PM,
+        2, _omitFieldNames ? '' : 'method', $pb.PbFieldTypeInternal.PM,
         subBuilder: MethodDescriptorProto.create)
     ..aOM<ServiceOptions>(3, _omitFieldNames ? '' : 'options',
         subBuilder: ServiceOptions.create);
@@ -1693,7 +1701,7 @@ class FileOptions extends $pb.GeneratedMessage {
     ..aOS(1, _omitFieldNames ? '' : 'javaPackage')
     ..aOS(8, _omitFieldNames ? '' : 'javaOuterClassname')
     ..e<FileOptions_OptimizeMode>(
-        9, _omitFieldNames ? '' : 'optimizeFor', $pb.PbFieldType.OE,
+        9, _omitFieldNames ? '' : 'optimizeFor', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FileOptions_OptimizeMode.SPEED,
         valueOf: FileOptions_OptimizeMode.valueOf,
         enumValues: FileOptions_OptimizeMode.values)
@@ -1706,7 +1714,7 @@ class FileOptions extends $pb.GeneratedMessage {
     ..aOB(23, _omitFieldNames ? '' : 'deprecated')
     ..aOB(27, _omitFieldNames ? '' : 'javaStringCheckUtf8')
     ..a<$core.bool>(
-        31, _omitFieldNames ? '' : 'ccEnableArenas', $pb.PbFieldType.OB,
+        31, _omitFieldNames ? '' : 'ccEnableArenas', $pb.PbFieldTypeInternal.OB,
         defaultOrMaker: true)
     ..aOS(36, _omitFieldNames ? '' : 'objcClassPrefix')
     ..aOS(37, _omitFieldNames ? '' : 'csharpNamespace')
@@ -1717,8 +1725,8 @@ class FileOptions extends $pb.GeneratedMessage {
     ..aOS(45, _omitFieldNames ? '' : 'rubyPackage')
     ..aOM<FeatureSet>(50, _omitFieldNames ? '' : 'features',
         subBuilder: FeatureSet.create)
-    ..pc<UninterpretedOption>(
-        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption>(999, _omitFieldNames ? '' : 'uninterpretedOption',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2051,8 +2059,8 @@ class MessageOptions extends $pb.GeneratedMessage {
     ..aOB(11, _omitFieldNames ? '' : 'deprecatedLegacyJsonFieldConflicts')
     ..aOM<FeatureSet>(12, _omitFieldNames ? '' : 'features',
         subBuilder: FeatureSet.create)
-    ..pc<UninterpretedOption>(
-        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption>(999, _omitFieldNames ? '' : 'uninterpretedOption',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2229,7 +2237,8 @@ class FieldOptions_EditionDefault extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..aOS(2, _omitFieldNames ? '' : 'value')
-    ..e<Edition>(3, _omitFieldNames ? '' : 'edition', $pb.PbFieldType.OE,
+    ..e<Edition>(
+        3, _omitFieldNames ? '' : 'edition', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: Edition.EDITION_UNKNOWN,
         valueOf: Edition.valueOf,
         enumValues: Edition.values)
@@ -2310,18 +2319,19 @@ class FieldOptions_FeatureSupport extends $pb.GeneratedMessage {
       package:
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..e<Edition>(
-        1, _omitFieldNames ? '' : 'editionIntroduced', $pb.PbFieldType.OE,
+    ..e<Edition>(1, _omitFieldNames ? '' : 'editionIntroduced',
+        $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: Edition.EDITION_UNKNOWN,
         valueOf: Edition.valueOf,
         enumValues: Edition.values)
-    ..e<Edition>(
-        2, _omitFieldNames ? '' : 'editionDeprecated', $pb.PbFieldType.OE,
+    ..e<Edition>(2, _omitFieldNames ? '' : 'editionDeprecated',
+        $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: Edition.EDITION_UNKNOWN,
         valueOf: Edition.valueOf,
         enumValues: Edition.values)
     ..aOS(3, _omitFieldNames ? '' : 'deprecationWarning')
-    ..e<Edition>(4, _omitFieldNames ? '' : 'editionRemoved', $pb.PbFieldType.OE,
+    ..e<Edition>(
+        4, _omitFieldNames ? '' : 'editionRemoved', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: Edition.EDITION_UNKNOWN,
         valueOf: Edition.valueOf,
         enumValues: Edition.values)
@@ -2450,7 +2460,7 @@ class FieldOptions extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..e<FieldOptions_CType>(
-        1, _omitFieldNames ? '' : 'ctype', $pb.PbFieldType.OE,
+        1, _omitFieldNames ? '' : 'ctype', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FieldOptions_CType.STRING,
         valueOf: FieldOptions_CType.valueOf,
         enumValues: FieldOptions_CType.values)
@@ -2458,7 +2468,7 @@ class FieldOptions extends $pb.GeneratedMessage {
     ..aOB(3, _omitFieldNames ? '' : 'deprecated')
     ..aOB(5, _omitFieldNames ? '' : 'lazy')
     ..e<FieldOptions_JSType>(
-        6, _omitFieldNames ? '' : 'jstype', $pb.PbFieldType.OE,
+        6, _omitFieldNames ? '' : 'jstype', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FieldOptions_JSType.JS_NORMAL,
         valueOf: FieldOptions_JSType.valueOf,
         enumValues: FieldOptions_JSType.values)
@@ -2466,25 +2476,25 @@ class FieldOptions extends $pb.GeneratedMessage {
     ..aOB(15, _omitFieldNames ? '' : 'unverifiedLazy')
     ..aOB(16, _omitFieldNames ? '' : 'debugRedact')
     ..e<FieldOptions_OptionRetention>(
-        17, _omitFieldNames ? '' : 'retention', $pb.PbFieldType.OE,
+        17, _omitFieldNames ? '' : 'retention', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FieldOptions_OptionRetention.RETENTION_UNKNOWN,
         valueOf: FieldOptions_OptionRetention.valueOf,
         enumValues: FieldOptions_OptionRetention.values)
     ..pc<FieldOptions_OptionTargetType>(
-        19, _omitFieldNames ? '' : 'targets', $pb.PbFieldType.PE,
+        19, _omitFieldNames ? '' : 'targets', $pb.PbFieldTypeInternal.PE,
         valueOf: FieldOptions_OptionTargetType.valueOf,
         enumValues: FieldOptions_OptionTargetType.values,
         defaultEnumValue: FieldOptions_OptionTargetType.TARGET_TYPE_UNKNOWN)
-    ..pc<FieldOptions_EditionDefault>(
-        20, _omitFieldNames ? '' : 'editionDefaults', $pb.PbFieldType.PM,
+    ..pc<FieldOptions_EditionDefault>(20,
+        _omitFieldNames ? '' : 'editionDefaults', $pb.PbFieldTypeInternal.PM,
         subBuilder: FieldOptions_EditionDefault.create)
     ..aOM<FeatureSet>(21, _omitFieldNames ? '' : 'features',
         subBuilder: FeatureSet.create)
     ..aOM<FieldOptions_FeatureSupport>(
         22, _omitFieldNames ? '' : 'featureSupport',
         subBuilder: FieldOptions_FeatureSupport.create)
-    ..pc<UninterpretedOption>(
-        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption>(999, _omitFieldNames ? '' : 'uninterpretedOption',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2713,8 +2723,8 @@ class OneofOptions extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aOM<FeatureSet>(1, _omitFieldNames ? '' : 'features',
         subBuilder: FeatureSet.create)
-    ..pc<UninterpretedOption>(
-        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption>(999, _omitFieldNames ? '' : 'uninterpretedOption',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2799,8 +2809,8 @@ class EnumOptions extends $pb.GeneratedMessage {
     ..aOB(6, _omitFieldNames ? '' : 'deprecatedLegacyJsonFieldConflicts')
     ..aOM<FeatureSet>(7, _omitFieldNames ? '' : 'features',
         subBuilder: FeatureSet.create)
-    ..pc<UninterpretedOption>(
-        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption>(999, _omitFieldNames ? '' : 'uninterpretedOption',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -2927,8 +2937,8 @@ class EnumValueOptions extends $pb.GeneratedMessage {
     ..aOM<FieldOptions_FeatureSupport>(
         4, _omitFieldNames ? '' : 'featureSupport',
         subBuilder: FieldOptions_FeatureSupport.create)
-    ..pc<UninterpretedOption>(
-        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption>(999, _omitFieldNames ? '' : 'uninterpretedOption',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -3041,8 +3051,8 @@ class ServiceOptions extends $pb.GeneratedMessage {
     ..aOB(33, _omitFieldNames ? '' : 'deprecated')
     ..aOM<FeatureSet>(34, _omitFieldNames ? '' : 'features',
         subBuilder: FeatureSet.create)
-    ..pc<UninterpretedOption>(
-        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption>(999, _omitFieldNames ? '' : 'uninterpretedOption',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -3131,15 +3141,15 @@ class MethodOptions extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..aOB(33, _omitFieldNames ? '' : 'deprecated')
-    ..e<MethodOptions_IdempotencyLevel>(
-        34, _omitFieldNames ? '' : 'idempotencyLevel', $pb.PbFieldType.OE,
+    ..e<MethodOptions_IdempotencyLevel>(34,
+        _omitFieldNames ? '' : 'idempotencyLevel', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN,
         valueOf: MethodOptions_IdempotencyLevel.valueOf,
         enumValues: MethodOptions_IdempotencyLevel.values)
     ..aOM<FeatureSet>(35, _omitFieldNames ? '' : 'features',
         subBuilder: FeatureSet.create)
-    ..pc<UninterpretedOption>(
-        999, _omitFieldNames ? '' : 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption>(999, _omitFieldNames ? '' : 'uninterpretedOption',
+        $pb.PbFieldTypeInternal.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -3239,7 +3249,7 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aQS(1, _omitFieldNames ? '' : 'namePart')
     ..a<$core.bool>(
-        2, _omitFieldNames ? '' : 'isExtension', $pb.PbFieldType.QB);
+        2, _omitFieldNames ? '' : 'isExtension', $pb.PbFieldTypeInternal.QB);
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   UninterpretedOption_NamePart clone() =>
@@ -3327,17 +3337,17 @@ class UninterpretedOption extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<UninterpretedOption_NamePart>(
-        2, _omitFieldNames ? '' : 'name', $pb.PbFieldType.PM,
+        2, _omitFieldNames ? '' : 'name', $pb.PbFieldTypeInternal.PM,
         subBuilder: UninterpretedOption_NamePart.create)
     ..aOS(3, _omitFieldNames ? '' : 'identifierValue')
-    ..a<$fixnum.Int64>(
-        4, _omitFieldNames ? '' : 'positiveIntValue', $pb.PbFieldType.OU6,
+    ..a<$fixnum.Int64>(4, _omitFieldNames ? '' : 'positiveIntValue',
+        $pb.PbFieldTypeInternal.OU6,
         defaultOrMaker: $fixnum.Int64.ZERO)
     ..aInt64(5, _omitFieldNames ? '' : 'negativeIntValue')
     ..a<$core.double>(
-        6, _omitFieldNames ? '' : 'doubleValue', $pb.PbFieldType.OD)
+        6, _omitFieldNames ? '' : 'doubleValue', $pb.PbFieldTypeInternal.OD)
     ..a<$core.List<$core.int>>(
-        7, _omitFieldNames ? '' : 'stringValue', $pb.PbFieldType.OY)
+        7, _omitFieldNames ? '' : 'stringValue', $pb.PbFieldTypeInternal.OY)
     ..aOS(8, _omitFieldNames ? '' : 'aggregateValue');
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -3514,44 +3524,48 @@ class FeatureSet extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..e<FeatureSet_FieldPresence>(
-        1, _omitFieldNames ? '' : 'fieldPresence', $pb.PbFieldType.OE,
+        1, _omitFieldNames ? '' : 'fieldPresence', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FeatureSet_FieldPresence.FIELD_PRESENCE_UNKNOWN,
         valueOf: FeatureSet_FieldPresence.valueOf,
         enumValues: FeatureSet_FieldPresence.values)
     ..e<FeatureSet_EnumType>(
-        2, _omitFieldNames ? '' : 'enumType', $pb.PbFieldType.OE,
+        2, _omitFieldNames ? '' : 'enumType', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FeatureSet_EnumType.ENUM_TYPE_UNKNOWN,
         valueOf: FeatureSet_EnumType.valueOf,
         enumValues: FeatureSet_EnumType.values)
     ..e<FeatureSet_RepeatedFieldEncoding>(
-        3, _omitFieldNames ? '' : 'repeatedFieldEncoding', $pb.PbFieldType.OE,
+        3,
+        _omitFieldNames ? '' : 'repeatedFieldEncoding',
+        $pb.PbFieldTypeInternal.OE,
         defaultOrMaker:
             FeatureSet_RepeatedFieldEncoding.REPEATED_FIELD_ENCODING_UNKNOWN,
         valueOf: FeatureSet_RepeatedFieldEncoding.valueOf,
         enumValues: FeatureSet_RepeatedFieldEncoding.values)
     ..e<FeatureSet_Utf8Validation>(
-        4, _omitFieldNames ? '' : 'utf8Validation', $pb.PbFieldType.OE,
+        4, _omitFieldNames ? '' : 'utf8Validation', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FeatureSet_Utf8Validation.UTF8_VALIDATION_UNKNOWN,
         valueOf: FeatureSet_Utf8Validation.valueOf,
         enumValues: FeatureSet_Utf8Validation.values)
     ..e<FeatureSet_MessageEncoding>(
-        5, _omitFieldNames ? '' : 'messageEncoding', $pb.PbFieldType.OE,
+        5, _omitFieldNames ? '' : 'messageEncoding', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FeatureSet_MessageEncoding.MESSAGE_ENCODING_UNKNOWN,
         valueOf: FeatureSet_MessageEncoding.valueOf,
         enumValues: FeatureSet_MessageEncoding.values)
     ..e<FeatureSet_JsonFormat>(
-        6, _omitFieldNames ? '' : 'jsonFormat', $pb.PbFieldType.OE,
+        6, _omitFieldNames ? '' : 'jsonFormat', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FeatureSet_JsonFormat.JSON_FORMAT_UNKNOWN,
         valueOf: FeatureSet_JsonFormat.valueOf,
         enumValues: FeatureSet_JsonFormat.values)
-    ..e<FeatureSet_EnforceNamingStyle>(
-        7, _omitFieldNames ? '' : 'enforceNamingStyle', $pb.PbFieldType.OE,
+    ..e<FeatureSet_EnforceNamingStyle>(7,
+        _omitFieldNames ? '' : 'enforceNamingStyle', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker:
             FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN,
         valueOf: FeatureSet_EnforceNamingStyle.valueOf,
         enumValues: FeatureSet_EnforceNamingStyle.values)
     ..e<FeatureSet_VisibilityFeature_DefaultSymbolVisibility>(
-        8, _omitFieldNames ? '' : 'defaultSymbolVisibility', $pb.PbFieldType.OE,
+        8,
+        _omitFieldNames ? '' : 'defaultSymbolVisibility',
+        $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: FeatureSet_VisibilityFeature_DefaultSymbolVisibility
             .DEFAULT_SYMBOL_VISIBILITY_UNKNOWN,
         valueOf: FeatureSet_VisibilityFeature_DefaultSymbolVisibility.valueOf,
@@ -3689,7 +3703,8 @@ class FeatureSetDefaults_FeatureSetEditionDefault extends $pb.GeneratedMessage {
       package:
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..e<Edition>(3, _omitFieldNames ? '' : 'edition', $pb.PbFieldType.OE,
+    ..e<Edition>(
+        3, _omitFieldNames ? '' : 'edition', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: Edition.EDITION_UNKNOWN,
         valueOf: Edition.valueOf,
         enumValues: Edition.values)
@@ -3791,13 +3806,15 @@ class FeatureSetDefaults extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<FeatureSetDefaults_FeatureSetEditionDefault>(
-        1, _omitFieldNames ? '' : 'defaults', $pb.PbFieldType.PM,
+        1, _omitFieldNames ? '' : 'defaults', $pb.PbFieldTypeInternal.PM,
         subBuilder: FeatureSetDefaults_FeatureSetEditionDefault.create)
-    ..e<Edition>(4, _omitFieldNames ? '' : 'minimumEdition', $pb.PbFieldType.OE,
+    ..e<Edition>(
+        4, _omitFieldNames ? '' : 'minimumEdition', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: Edition.EDITION_UNKNOWN,
         valueOf: Edition.valueOf,
         enumValues: Edition.values)
-    ..e<Edition>(5, _omitFieldNames ? '' : 'maximumEdition', $pb.PbFieldType.OE,
+    ..e<Edition>(
+        5, _omitFieldNames ? '' : 'maximumEdition', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: Edition.EDITION_UNKNOWN,
         valueOf: Edition.valueOf,
         enumValues: Edition.values);
@@ -3882,8 +3899,8 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
       package:
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..p<$core.int>(1, _omitFieldNames ? '' : 'path', $pb.PbFieldType.K3)
-    ..p<$core.int>(2, _omitFieldNames ? '' : 'span', $pb.PbFieldType.K3)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'path', $pb.PbFieldTypeInternal.K3)
+    ..p<$core.int>(2, _omitFieldNames ? '' : 'span', $pb.PbFieldTypeInternal.K3)
     ..aOS(3, _omitFieldNames ? '' : 'leadingComments')
     ..aOS(4, _omitFieldNames ? '' : 'trailingComments')
     ..pPS(6, _omitFieldNames ? '' : 'leadingDetachedComments')
@@ -4041,7 +4058,7 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<SourceCodeInfo_Location>(
-        1, _omitFieldNames ? '' : 'location', $pb.PbFieldType.PM,
+        1, _omitFieldNames ? '' : 'location', $pb.PbFieldTypeInternal.PM,
         subBuilder: SourceCodeInfo_Location.create)
     ..hasExtensions = true;
 
@@ -4144,12 +4161,13 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
       package:
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
-    ..p<$core.int>(1, _omitFieldNames ? '' : 'path', $pb.PbFieldType.K3)
+    ..p<$core.int>(1, _omitFieldNames ? '' : 'path', $pb.PbFieldTypeInternal.K3)
     ..aOS(2, _omitFieldNames ? '' : 'sourceFile')
-    ..a<$core.int>(3, _omitFieldNames ? '' : 'begin', $pb.PbFieldType.O3)
-    ..a<$core.int>(4, _omitFieldNames ? '' : 'end', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        3, _omitFieldNames ? '' : 'begin', $pb.PbFieldTypeInternal.O3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'end', $pb.PbFieldTypeInternal.O3)
     ..e<GeneratedCodeInfo_Annotation_Semantic>(
-        5, _omitFieldNames ? '' : 'semantic', $pb.PbFieldType.OE,
+        5, _omitFieldNames ? '' : 'semantic', $pb.PbFieldTypeInternal.OE,
         defaultOrMaker: GeneratedCodeInfo_Annotation_Semantic.NONE,
         valueOf: GeneratedCodeInfo_Annotation_Semantic.valueOf,
         enumValues: GeneratedCodeInfo_Annotation_Semantic.values)
@@ -4256,7 +4274,7 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..pc<GeneratedCodeInfo_Annotation>(
-        1, _omitFieldNames ? '' : 'annotation', $pb.PbFieldType.PM,
+        1, _omitFieldNames ? '' : 'annotation', $pb.PbFieldTypeInternal.PM,
         subBuilder: GeneratedCodeInfo_Annotation.create)
     ..hasRequiredFields = false;
 

--- a/protoc_plugin/lib/src/gen/google/protobuf/duration.pb.dart
+++ b/protoc_plugin/lib/src/gen/google/protobuf/duration.pb.dart
@@ -105,7 +105,8 @@ class Duration extends $pb.GeneratedMessage with $mixin.DurationMixin {
       toProto3Json: $mixin.DurationMixin.toProto3JsonHelper,
       fromProto3Json: $mixin.DurationMixin.fromProto3JsonHelper)
     ..aInt64(1, _omitFieldNames ? '' : 'seconds')
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'nanos', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        2, _omitFieldNames ? '' : 'nanos', $pb.PbFieldTypeInternal.O3)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')

--- a/protoc_plugin/lib/src/protobuf_field.dart
+++ b/protoc_plugin/lib/src/protobuf_field.dart
@@ -181,7 +181,7 @@ class ProtobufField {
   /// Returns the tag number of the underlying proto field.
   int get number => descriptor.number;
 
-  /// Returns the constant in PbFieldType corresponding to this type.
+  /// Returns the constant in PbFieldTypeInternal corresponding to this type.
   String get typeConstant {
     var prefix = 'O';
     if (isRequired) {
@@ -191,7 +191,7 @@ class ProtobufField {
     } else if (isRepeated) {
       prefix = 'P';
     }
-    return '$protobufImportPrefix.PbFieldType.$prefix${baseType.typeConstantSuffix}';
+    return '$protobufImportPrefix.PbFieldTypeInternal.$prefix${baseType.typeConstantSuffix}';
   }
 
   static String _formatArguments(
@@ -260,7 +260,7 @@ class ProtobufField {
             'const $protobufImportPrefix.PackageName(\'$package\')';
       }
     } else if (isRepeated) {
-      if (typeConstant == '$protobufImportPrefix.PbFieldType.PS') {
+      if (typeConstant == '$protobufImportPrefix.PbFieldTypeInternal.PS') {
         invocation = 'pPS';
       } else {
         args.add(typeConstant);
@@ -291,9 +291,11 @@ class ProtobufField {
       } else if (makeDefault == null) {
         switch (type) {
           case '$coreImportPrefix.String':
-            if (typeConstant == '$protobufImportPrefix.PbFieldType.OS') {
+            if (typeConstant ==
+                '$protobufImportPrefix.PbFieldTypeInternal.OS') {
               invocation = 'aOS';
-            } else if (typeConstant == '$protobufImportPrefix.PbFieldType.QS') {
+            } else if (typeConstant ==
+                '$protobufImportPrefix.PbFieldTypeInternal.QS') {
               invocation = 'aQS';
             } else {
               invocation = 'a<$type>';
@@ -301,7 +303,8 @@ class ProtobufField {
             }
             break;
           case '$coreImportPrefix.bool':
-            if (typeConstant == '$protobufImportPrefix.PbFieldType.OB') {
+            if (typeConstant ==
+                '$protobufImportPrefix.PbFieldTypeInternal.OB') {
               invocation = 'aOB';
             } else {
               invocation = 'a<$type>';
@@ -316,7 +319,7 @@ class ProtobufField {
       } else {
         if (makeDefault == '$fixnumImportPrefix.Int64.ZERO' &&
             type == '$fixnumImportPrefix.Int64' &&
-            typeConstant == '$protobufImportPrefix.PbFieldType.O6') {
+            typeConstant == '$protobufImportPrefix.PbFieldTypeInternal.O6') {
           invocation = 'aInt64';
         } else {
           if (baseType.isMessage || baseType.isGroup) {

--- a/protoc_plugin/test/goldens/extension.pb.dart
+++ b/protoc_plugin/test/goldens/extension.pb.dart
@@ -1,4 +1,4 @@
-static final clientInfo = $pb.Extension<$core.String>(_omitMessageNames ? '' : 'Card', _omitFieldNames ? '' : 'clientInfo', 261486461, $pb.PbFieldType.OS);
+static final clientInfo = $pb.Extension<$core.String>(_omitMessageNames ? '' : 'Card', _omitFieldNames ? '' : 'clientInfo', 261486461, $pb.PbFieldTypeInternal.OS);
 
 const $core.bool _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const $core.bool _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/protoc_plugin/test/goldens/messageGenerator.pb.dart
+++ b/protoc_plugin/test/goldens/messageGenerator.pb.dart
@@ -8,8 +8,8 @@ class PhoneNumber extends $pb.GeneratedMessage {
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PhoneNumber', createEmptyInstance: create)
     ..aQS(1, _omitFieldNames ? '' : 'number')
-    ..e<PhoneNumber_PhoneType>(2, _omitFieldNames ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: PhoneNumber_PhoneType.MOBILE, valueOf: PhoneNumber_PhoneType.valueOf, enumValues: PhoneNumber_PhoneType.values)
-    ..a<$core.String>(3, _omitFieldNames ? '' : 'name', $pb.PbFieldType.OS, defaultOrMaker: '\$')
+    ..e<PhoneNumber_PhoneType>(2, _omitFieldNames ? '' : 'type', $pb.PbFieldTypeInternal.OE, defaultOrMaker: PhoneNumber_PhoneType.MOBILE, valueOf: PhoneNumber_PhoneType.valueOf, enumValues: PhoneNumber_PhoneType.values)
+    ..a<$core.String>(3, _omitFieldNames ? '' : 'name', $pb.PbFieldTypeInternal.OS, defaultOrMaker: '\$')
     ..aOS(4, _omitFieldNames ? '' : 'deprecatedField')
   ;
 

--- a/protoc_plugin/test/goldens/messageGenerator.pb.dart.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.pb.dart.meta
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1854
-  end: 1860
+  begin: 1870
+  end: 1876
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1902
-  end: 1908
+  begin: 1918
+  end: 1924
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1988
-  end: 1997
+  begin: 2004
+  end: 2013
 }
 annotation: {
   path: 4
@@ -45,8 +45,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2040
-  end: 2051
+  begin: 2056
+  end: 2067
 }
 annotation: {
   path: 4
@@ -54,8 +54,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2123
-  end: 2127
+  begin: 2139
+  end: 2143
 }
 annotation: {
   path: 4
@@ -63,8 +63,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2168
-  end: 2172
+  begin: 2184
+  end: 2188
 }
 annotation: {
   path: 4
@@ -72,8 +72,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2260
-  end: 2267
+  begin: 2276
+  end: 2283
 }
 annotation: {
   path: 4
@@ -81,8 +81,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2310
-  end: 2319
+  begin: 2326
+  end: 2335
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2382
-  end: 2386
+  begin: 2398
+  end: 2402
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2433
-  end: 2437
+  begin: 2449
+  end: 2453
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2517
-  end: 2524
+  begin: 2533
+  end: 2540
 }
 annotation: {
   path: 4
@@ -117,17 +117,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2567
-  end: 2576
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 2688
-  end: 2703
+  begin: 2583
+  end: 2592
 }
 annotation: {
   path: 4
@@ -135,8 +126,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 2794
-  end: 2809
+  begin: 2704
+  end: 2719
 }
 annotation: {
   path: 4
@@ -144,8 +135,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 2938
-  end: 2956
+  begin: 2810
+  end: 2825
 }
 annotation: {
   path: 4
@@ -153,6 +144,15 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3048
-  end: 3068
+  begin: 2954
+  end: 2972
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 3064
+  end: 3084
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb.dart
+++ b/protoc_plugin/test/goldens/oneMessage.pb.dart
@@ -32,8 +32,9 @@ class PhoneNumber extends $pb.GeneratedMessage {
       _omitMessageNames ? '' : 'PhoneNumber',
       createEmptyInstance: create)
     ..aQS(1, _omitFieldNames ? '' : 'number')
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'type', $pb.PbFieldType.O3)
-    ..a<$core.String>(3, _omitFieldNames ? '' : 'name', $pb.PbFieldType.OS,
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'type', $pb.PbFieldTypeInternal.O3)
+    ..a<$core.String>(
+        3, _omitFieldNames ? '' : 'name', $pb.PbFieldTypeInternal.OS,
         defaultOrMaker: '\$');
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')

--- a/protoc_plugin/test/goldens/oneMessage.pb.dart.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.dart.meta
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2218
-  end: 2224
+  begin: 2234
+  end: 2240
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2266
-  end: 2272
+  begin: 2282
+  end: 2288
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2352
-  end: 2361
+  begin: 2368
+  end: 2377
 }
 annotation: {
   path: 4
@@ -45,17 +45,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2404
-  end: 2415
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: test
-  begin: 2475
-  end: 2479
+  begin: 2420
+  end: 2431
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2521
-  end: 2525
+  begin: 2491
+  end: 2495
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2607
-  end: 2614
+  begin: 2537
+  end: 2541
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2657
-  end: 2666
+  begin: 2623
+  end: 2630
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2673
+  end: 2682
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2729
-  end: 2733
+  begin: 2745
+  end: 2749
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2780
-  end: 2784
+  begin: 2796
+  end: 2800
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2864
-  end: 2871
+  begin: 2880
+  end: 2887
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2914
-  end: 2923
+  begin: 2930
+  end: 2939
 }

--- a/protoc_plugin/test/reserved_names_test.dart
+++ b/protoc_plugin/test/reserved_names_test.dart
@@ -20,7 +20,7 @@ void main() {
   test('GeneratedMessage reserved names are up to date', () {
     final actual = Set<String>.from(GeneratedMessage_reservedNames);
     final expected = findMemberNames(
-      'package:protobuf/protobuf.dart',
+      'package:protobuf/src/protobuf/internal.dart',
       #GeneratedMessage,
     );
 
@@ -30,7 +30,7 @@ void main() {
   test('ProtobufEnum reserved names are up to date', () {
     final actual = Set<String>.from(ProtobufEnum_reservedNames);
     final expected = findMemberNames(
-      'package:protobuf/protobuf.dart',
+      'package:protobuf/src/protobuf/internal.dart',
       #ProtobufEnum,
     );
 
@@ -39,7 +39,7 @@ void main() {
 
   test("ReadonlyMessageMixin doesn't add any reserved names", () {
     final mixinNames = findMemberNames(
-      'package:protobuf/protobuf.dart',
+      'package:protobuf/src/protobuf/internal.dart',
       #ReadonlyMessageMixin,
     );
     final reservedNames = Set<String>.from(GeneratedMessage_reservedNames);


### PR DESCRIPTION
This is the first part of the PRs that sync internal JSON decoding chages.

To be able to conditionally import different JSON decoders, this splits the
monolithic protobuf package into libraries.

These parts are now libraries:

- consts.dart
- json_parsing_context.dart
- permissive_compare.dart
- type_registry.dart
- utils.dart

These changes are not useful on their own, they're to prepare the library for
the rest of the PRs and to keep the PRs small and easier to review.