### PR TITLE
CI: Run all of the checks on every change

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -4,16 +4,8 @@ permissions: read-all
 on:
   pull_request:
     branches:
-    paths:
-      - '.github/workflows/benchmarks.yaml'
-      - 'benchmarks/**'
-      - 'tool/setup.sh'
   push:
     branches: [ master ]
-    paths:
-      - '.github/workflows/benchmarks.yaml'
-      - 'benchmarks/**'
-      - 'tool/setup.sh'
   schedule:
     - cron: '0 0 * * 0' # weekly
 
@@ -26,7 +18,7 @@ jobs:
     strategy:
       matrix:
         sdk: dev
-    
+
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c

--- a/.github/workflows/protobuf.yaml
+++ b/.github/workflows/protobuf.yaml
@@ -4,14 +4,8 @@ permissions: read-all
 on:
   pull_request:
     branches:
-    paths:
-      - '.github/workflows/protobuf.yaml'
-      - 'protobuf/**'
   push:
     branches: [ master ]
-    paths:
-      - '.github/workflows/protobuf.yaml'
-      - 'protobuf/**'
   schedule:
     - cron: '0 0 * * 0' # weekly
 

--- a/.github/workflows/protoc_plugin.yaml
+++ b/.github/workflows/protoc_plugin.yaml
@@ -4,16 +4,8 @@ permissions: read-all
 on:
   pull_request:
     branches:
-    paths:
-      - '.github/workflows/protoc_plugin.yaml'
-      - 'protoc_plugin/**'
-      - 'tool/setup.sh'
   push:
     branches: [ master ]
-    paths:
-      - '.github/workflows/protoc_plugin.yaml'
-      - 'protoc_plugin/**'
-      - 'tool/setup.sh'
   schedule:
     - cron: '0 0 * * 0' # weekly
 


### PR DESCRIPTION
Drop paths in workflow specs to run all of the checks on every change.

Dependencies between directories in this project is a bit tricky. protoc_plugin uses protobuf, which is already incorrect in the paths currently. Benchmarks also depend on both the plugin and the library.

Instead of manually specifying and maintaining tricky dependencies just run all of the checks on all changes. No need to optimize this and risk missing checks until CI time becomes a problem.