### PR TITLE
workspace, formatting, and proto version updates

### DIFF
--- a/benchmarks/pubspec.yaml
+++ b/benchmarks/pubspec.yaml
@@ -24,5 +24,5 @@ dev_dependencies:
   lints: '>=5.0.0 <7.0.0'
   path: ^1.8.2
   pool: ^1.5.1
-  protoc_plugin:
-    path: '../protoc_plugin'
+  # Used from the workspace.
+  protoc_plugin: any

--- a/benchmarks/tool/compile_protos.sh
+++ b/benchmarks/tool/compile_protos.sh
@@ -27,5 +27,3 @@ protoc --dart_out=lib/generated --plugin=protoc-gen-dart=tool/run_protoc_plugin.
 protoc --dart_out=lib/generated --plugin=protoc-gen-dart=tool/run_protoc_plugin.sh \
     -I$BENCHMARK_DIR/protos/query_benchmark \
     $BENCHMARK_DIR/protos/query_benchmark/*.proto
-
-dart format lib/generated

--- a/tool/setup.sh
+++ b/tool/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 wget -O protoc.zip \
-  https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protoc-3.17.3-linux-x86_64.zip
+  https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protoc-31.0-linux-x86_64.zip
 unzip -d protoc protoc.zip
 
 if [[ -z "${GITHUB_ENV}" ]]; then


### PR DESCRIPTION
A few misc repo updates:

- for the benchmarks, use the `protoc_plugin` version from the workspace
- no longer dart format the benchmark protos (they are generated formatted now)
- provision the CI bots w/ a more recent version of protobuf (`v31.0`)
