### PR TITLE
various CI workflow updates

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -8,12 +8,13 @@ on:
   schedule:
     - cron: "0 0 * * 0" # weekly
 
+defaults:
+  run:
+    working-directory: benchmarks
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: benchmarks
     strategy:
       fail-fast: false
       matrix:
@@ -25,15 +26,15 @@ jobs:
         with:
           sdk: ${{matrix.sdk}}
 
+      - run: ../tool/setup.sh
+
       - run: dart pub get
+
+      - run: ./tool/compile_protos.sh
 
       - run: dart analyze --fatal-infos
 
       - run: dart format --output=none --set-exit-if-changed .
         if: ${{ matrix.sdk == 'dev' }}
-
-      - run: ./../tool/setup.sh
-
-      - run: ./tool/compile_protos.sh
 
       - run: dart tool/compile_benchmarks.dart

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -3,11 +3,10 @@ permissions: read-all
 
 on:
   pull_request:
-    branches:
   push:
-    branches: [ master ]
+    branches: [master]
   schedule:
-    - cron: '0 0 * * 0' # weekly
+    - cron: "0 0 * * 0" # weekly
 
 jobs:
   build:
@@ -16,8 +15,9 @@ jobs:
       run:
         working-directory: benchmarks
     strategy:
+      fail-fast: false
       matrix:
-        sdk: dev
+        sdk: [dev]
 
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
@@ -30,6 +30,7 @@ jobs:
       - run: dart analyze --fatal-infos
 
       - run: dart format --output=none --set-exit-if-changed .
+        if: ${{ matrix.sdk == 'dev' }}
 
       - run: ./../tool/setup.sh
 

--- a/.github/workflows/protobuf.yaml
+++ b/.github/workflows/protobuf.yaml
@@ -3,11 +3,10 @@ permissions: read-all
 
 on:
   pull_request:
-    branches:
   push:
-    branches: [ master ]
+    branches: [master]
   schedule:
-    - cron: '0 0 * * 0' # weekly
+    - cron: "0 0 * * 0" # weekly
 
 jobs:
   validate-protobuf:
@@ -15,6 +14,7 @@ jobs:
       run:
         working-directory: protobuf
     strategy:
+      fail-fast: false
       matrix:
         sdk: [stable, dev]
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -32,9 +32,8 @@ jobs:
       - run: dart analyze --fatal-infos
 
       - run: dart format --output=none --set-exit-if-changed .
+        if: ${{ matrix.sdk == 'dev' }}
 
       - run: dart test
-
       - run: dart test -p chrome -c dart2js
-
       - run: dart test -p chrome -c dart2wasm

--- a/.github/workflows/protobuf.yaml
+++ b/.github/workflows/protobuf.yaml
@@ -8,11 +8,12 @@ on:
   schedule:
     - cron: "0 0 * * 0" # weekly
 
+defaults:
+  run:
+    working-directory: protobuf
+
 jobs:
-  validate-protobuf:
-    defaults:
-      run:
-        working-directory: protobuf
+  build:
     strategy:
       fail-fast: false
       matrix:
@@ -26,6 +27,8 @@ jobs:
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
         with:
           sdk: ${{matrix.sdk}}
+
+      - run: ../tool/setup.sh
 
       - run: dart pub get
 

--- a/.github/workflows/protoc_plugin.yaml
+++ b/.github/workflows/protoc_plugin.yaml
@@ -8,12 +8,13 @@ on:
   schedule:
     - cron: "0 0 * * 0" # weekly
 
+defaults:
+  run:
+    working-directory: protoc_plugin
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: protoc_plugin
     strategy:
       fail-fast: false
       matrix:
@@ -24,9 +25,9 @@ jobs:
         with:
           sdk: ${{matrix.sdk}}
 
-      - run: dart pub get
+      - run: ../tool/setup.sh
 
-      - run: ./../tool/setup.sh
+      - run: dart pub get
 
       - run: make protos
 

--- a/.github/workflows/protoc_plugin.yaml
+++ b/.github/workflows/protoc_plugin.yaml
@@ -3,11 +3,10 @@ permissions: read-all
 
 on:
   pull_request:
-    branches:
   push:
-    branches: [ master ]
+    branches: [master]
   schedule:
-    - cron: '0 0 * * 0' # weekly
+    - cron: "0 0 * * 0" # weekly
 
 jobs:
   build:
@@ -16,6 +15,7 @@ jobs:
       run:
         working-directory: protoc_plugin
     strategy:
+      fail-fast: false
       matrix:
         sdk: [stable, dev]
     steps:
@@ -33,9 +33,8 @@ jobs:
       - run: dart analyze --fatal-infos
 
       - run: dart format --output=none --set-exit-if-changed lib
+        if: ${{ matrix.sdk == 'dev' }}
 
       - run: dart test
-
       - run: dart test -p chrome -c dart2js
-
       - run: dart test -p chrome -c dart2wasm


### PR DESCRIPTION
Various CI workflow updates:

- continue the workflows even if a variant fails (`fail-fast: false`)
- only check formatting on a single sdk version (for situations where the formatter changes)
- generate benchmark protos before we analyze the `benchmarks` package
- misc yaml formatting and whitespace changes
