### PR TITLE
Make proto3_json.dart aware of well known types

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.2.0-wip
+## 5.0.0-wip
 
 * Internal refactoring to split the package into libraries. This allows
   conditionally importing different libraries and improving performance by
@@ -10,6 +10,9 @@
 
 * Improve performance of `GeneratedMessage` members: `writeToJsonMap`,
   `writeToJson`, `mergeFromJson`, `mergeFromJsonMap`. ([#1028])
+
+* Remove `BuilderInfo.fromProto3Json` and `BuilderInfo.toProto3Json` as a part
+  of an internal refactoring.
 
 [#1026]: https://github.com/google/protobuf.dart/pull/1026
 [#1027]: https://github.com/google/protobuf.dart/pull/1027

--- a/protobuf/lib/protobuf.dart
+++ b/protobuf/lib/protobuf.dart
@@ -18,4 +18,6 @@ export 'src/protobuf/internal.dart'
         GeneratedMessageInternalExtension,
         MapFieldInfoInternalExtension,
         mapKeyFieldNumber,
-        mapValueFieldNumber;
+        mapValueFieldNumber,
+        mergeFromProto3JsonAny,
+        writeToProto3JsonAny;

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -42,24 +42,17 @@ class BuilderInfo {
   List<FieldInfo>? _sortedByTag;
 
   // For well-known types.
-  final Object? Function(GeneratedMessage message, TypeRegistry typeRegistry)?
-  toProto3Json;
-  final Function(
-    GeneratedMessage targetMessage,
-    Object json,
-    TypeRegistry typeRegistry,
-    JsonParsingContext context,
-  )?
-  fromProto3Json;
+  final WellKnownType? _wellKnownType;
+
   final CreateBuilderFunc? createEmptyInstance;
 
   BuilderInfo(
     String? messageName, {
     PackageName package = const PackageName(''),
     this.createEmptyInstance,
-    this.toProto3Json,
-    this.fromProto3Json,
-  }) : qualifiedMessageName = '${package.prefix}$messageName';
+    WellKnownType? wellKnownType,
+  }) : qualifiedMessageName = '${package.prefix}$messageName',
+       _wellKnownType = wellKnownType;
 
   void add<T>(
     int tagNumber,

--- a/protobuf/lib/src/protobuf/internal.dart
+++ b/protobuf/lib/src/protobuf/internal.dart
@@ -18,6 +18,7 @@ import 'package:meta/meta.dart' show UseResult;
 import 'consts.dart';
 import 'json/json.dart' as json_lib;
 import 'json_parsing_context.dart';
+import 'mixins/well_known.dart';
 import 'permissive_compare.dart';
 import 'type_registry.dart';
 import 'utils.dart';

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 4.2.0-wip
+version: 5.0.0-wip
 description: >-
   Runtime library for protocol buffers support. Use with package:protoc_plugin
   to generate Dart code for your '.proto' files.

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 5.0.0-wip
+version: 5.0.0
 description: >-
   Runtime library for protocol buffers support. Use with package:protoc_plugin
   to generate Dart code for your '.proto' files.

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 23.0.0
+
+* Update generated code for protobuf-5.0.0.
+
 ## 22.5.0
 
 * Generated files are now formatted using the Dart formatter. The code is

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 23.0.0
 
-* Update generated code for protobuf-5.0.0.
+* Update generated code for protobuf 5.0.0.
 
 ## 22.5.0
 
@@ -46,30 +46,30 @@
 
   We now parse and generate code cooresponding to the proto options
   `google.api.default_host` and `google.api.oauth_scopes`:
-  
+
   ```proto
   service Firestore {
     option (google.api.default_host) = "firestore.googleapis.com";
     option (google.api.oauth_scopes) =
         "https://www.googleapis.com/auth/cloud-platform,"
         "https://www.googleapis.com/auth/datastore";
-  
+
     ...
   ```
-  
+
   Will generate as:
-  
+
   ```dart
   class FirestoreClient extends $grpc.Client {
     /// The hostname for this service.
     static const $core.String defaultHost = 'firestore.googleapis.com';
-  
+
     /// OAuth scopes needed for the client.
     static const $core.List<$core.String> oauthScopes = [
       'https://www.googleapis.com/auth/cloud-platform',
       'https://www.googleapis.com/auth/datastore',
     ];
-  
+
     ...
   ```
 * Minimum SDK dependency bumped from 3.3.0 to 3.6.0. ([#1001])

--- a/protoc_plugin/lib/mixins.dart
+++ b/protoc_plugin/lib/mixins.dart
@@ -38,9 +38,11 @@ class PbMixin {
   /// Typically used for static helpers since you cannot mix in static members.
   final List<String>? injectedHelpers;
 
-  /// Whether the mixin should have static methods for converting to and from
-  /// proto3 Json.
-  final bool hasProto3JsonHelpers;
+  /// The well known type name.
+  ///
+  /// Values should match enumerations in the `WellKnownType` enum from
+  /// `package:protobuf`.
+  final String? wellKnownType;
 
   const PbMixin(
     this.name, {
@@ -48,7 +50,7 @@ class PbMixin {
     this.parent,
     this.reservedNames,
     this.injectedHelpers,
-    this.hasProto3JsonHelpers = false,
+    this.wellKnownType,
   });
 
   /// Returns the mixin and its ancestors, in the order they should be applied.

--- a/protoc_plugin/lib/src/gen/google/protobuf/duration.pb.dart
+++ b/protoc_plugin/lib/src/gen/google/protobuf/duration.pb.dart
@@ -102,8 +102,7 @@ class Duration extends $pb.GeneratedMessage with $mixin.DurationMixin {
       package:
           const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create,
-      toProto3Json: $mixin.DurationMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.DurationMixin.fromProto3JsonHelper)
+      wellKnownType: $mixin.WellKnownType.duration)
     ..aInt64(1, _omitFieldNames ? '' : 'seconds')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'nanos', $pb.PbFieldType.O3)
     ..hasRequiredFields = false;

--- a/protoc_plugin/lib/src/message_generator.dart
+++ b/protoc_plugin/lib/src/message_generator.dart
@@ -356,9 +356,8 @@ class MessageGenerator extends ProtobufContainer {
     final packageClause =
         package == '' ? '' : ', package: $conditionalPackageName';
     final proto3JsonClause =
-        (mixin?.hasProto3JsonHelpers ?? false)
-            ? ', toProto3Json: $mixinImportPrefix.${mixin!.name}.toProto3JsonHelper, '
-                'fromProto3Json: $mixinImportPrefix.${mixin!.name}.fromProto3JsonHelper'
+        (mixin?.wellKnownType != null)
+            ? ', wellKnownType: $mixinImportPrefix.WellKnownType.${mixin!.wellKnownType}'
             : '';
 
     final String extendedClass;

--- a/protoc_plugin/lib/src/well_known_types.dart
+++ b/protoc_plugin/lib/src/well_known_types.dart
@@ -28,7 +28,7 @@ static Any pack($protobufImportPrefix.GeneratedMessage message,
   return result;
 }''',
     ],
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'any',
   ),
   'google.protobuf.Timestamp': PbMixin(
     'TimestampMixin',
@@ -44,7 +44,7 @@ static Timestamp fromDateTime($coreImportPrefix.DateTime dateTime) {
   return result;
 }''',
     ],
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'timestamp',
   ),
   'google.protobuf.Duration': PbMixin(
     'DurationMixin',
@@ -67,71 +67,71 @@ static Duration fromDart($coreImportPrefix.Duration duration) => Duration()
   ..nanos = (duration.inMicroseconds % $coreImportPrefix.Duration.microsecondsPerSecond) * 1000;
 ''',
     ],
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'duration',
   ),
   'google.protobuf.Struct': PbMixin(
     'StructMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'struct',
   ),
   'google.protobuf.Value': PbMixin(
     'ValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'value',
   ),
   'google.protobuf.ListValue': PbMixin(
     'ListValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'listValue',
   ),
   'google.protobuf.DoubleValue': PbMixin(
     'DoubleValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'doubleValue',
   ),
   'google.protobuf.FloatValue': PbMixin(
     'FloatValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'floatValue',
   ),
   'google.protobuf.Int64Value': PbMixin(
     'Int64ValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'int64Value',
   ),
   'google.protobuf.UInt64Value': PbMixin(
     'UInt64ValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'uint64Value',
   ),
   'google.protobuf.Int32Value': PbMixin(
     'Int32ValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'int32Value',
   ),
   'google.protobuf.UInt32Value': PbMixin(
     'UInt32ValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'uint32Value',
   ),
   'google.protobuf.BoolValue': PbMixin(
     'BoolValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'boolValue',
   ),
   'google.protobuf.StringValue': PbMixin(
     'StringValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'stringValue',
   ),
   'google.protobuf.BytesValue': PbMixin(
     'BytesValueMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'bytesValue',
   ),
   'google.protobuf.FieldMask': PbMixin(
     'FieldMaskMixin',
     importFrom: _wellKnownImportPath,
-    hasProto3JsonHelpers: true,
+    wellKnownType: 'fieldMask',
   ),
 };

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   dart_style: ^3.0.0
   fixnum: ^1.0.0
   path: ^1.8.0
-  protobuf: ^4.1.0
+  protobuf: ^5.0.0
   pub_semver: ^2.2.0
 
 dev_dependencies:

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 22.5.0
+version: 23.0.0
 description: A protobuf protoc compiler plugin used to generate Dart code.
 repository: https://github.com/google/protobuf.dart/tree/master/protoc_plugin
 


### PR DESCRIPTION
This syncs cl/629836458.

From the CL:

This removes the requirement for proto3_json.dart to invoke outside code
(either via BuilderInfo or inheritance). This also improves tree shaking
of the proto3json helpers, since the proto3json callbacks attached to
BuilderInfo no longer retain those helpers.