### PR TITLE
Add sinks to benchmarks to prevent smart tools eliminating benchmarked code

### DIFF
--- a/benchmarks/bin/from_binary.dart
+++ b/benchmarks/bin/from_binary.dart
@@ -11,6 +11,11 @@ import 'package:protobuf_benchmarks/generated/google_message1_proto3.pb.dart'
     as p3;
 import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
 import 'package:protobuf_benchmarks/readfile.dart';
+import 'package:protobuf/protobuf.dart';
+
+GeneratedMessage? sink1;
+GeneratedMessage? sink2;
+GeneratedMessage? sink3;
 
 class Benchmark extends BenchmarkBase {
   final Uint8List _message1Proto2Input;
@@ -28,9 +33,9 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    p2.GoogleMessage1.fromBuffer(_message1Proto2Input);
-    p3.GoogleMessage1.fromBuffer(_message1Proto3Input);
-    GoogleMessage2.fromBuffer(_message2Input);
+    sink1 = p2.GoogleMessage1.fromBuffer(_message1Proto2Input);
+    sink2 = p3.GoogleMessage1.fromBuffer(_message1Proto3Input);
+    sink3 = GoogleMessage2.fromBuffer(_message2Input);
   }
 }
 
@@ -48,4 +53,10 @@ void main() {
     message1Proto3Input,
     message2Input,
   ).report();
+
+  if (int.parse('1') == 0) {
+    print(sink1);
+    print(sink2);
+    print(sink3);
+  }
 }

--- a/benchmarks/bin/from_json_string.dart
+++ b/benchmarks/bin/from_json_string.dart
@@ -9,6 +9,11 @@ import 'package:protobuf_benchmarks/generated/google_message1_proto3.pb.dart'
     as p3;
 import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
 import 'package:protobuf_benchmarks/readfile.dart';
+import 'package:protobuf/protobuf.dart';
+
+GeneratedMessage? sink1;
+GeneratedMessage? sink2;
+GeneratedMessage? sink3;
 
 class Benchmark extends BenchmarkBase {
   final String _message1Proto2JsonString;
@@ -29,9 +34,9 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    p2.GoogleMessage1.fromJson(_message1Proto2JsonString);
-    p3.GoogleMessage1.fromJson(_message1Proto3JsonString);
-    GoogleMessage2.fromJson(_message2JsonString);
+    sink1 = p2.GoogleMessage1.fromJson(_message1Proto2JsonString);
+    sink2 = p3.GoogleMessage1.fromJson(_message1Proto3JsonString);
+    sink3 = GoogleMessage2.fromJson(_message2JsonString);
   }
 }
 
@@ -49,4 +54,10 @@ void main() {
     message1Proto3Input,
     message2Input,
   ).report();
+
+  if (int.parse('1') == 0) {
+    print(sink1);
+    print(sink2);
+    print(sink3);
+  }
 }

--- a/benchmarks/bin/from_proto3_json_object.dart
+++ b/benchmarks/bin/from_proto3_json_object.dart
@@ -9,6 +9,11 @@ import 'package:protobuf_benchmarks/generated/google_message1_proto3.pb.dart'
     as p3;
 import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
 import 'package:protobuf_benchmarks/readfile.dart';
+import 'package:protobuf/protobuf.dart';
+
+GeneratedMessage? sink1;
+GeneratedMessage? sink2;
+GeneratedMessage? sink3;
 
 class Benchmark extends BenchmarkBase {
   final Object? _message1Proto2Proto3JsonObject;
@@ -29,13 +34,14 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    p2.GoogleMessage1.create().mergeFromProto3Json(
-      _message1Proto2Proto3JsonObject,
-    );
-    p3.GoogleMessage1.create().mergeFromProto3Json(
-      _message1Proto3Proto3JsonObject,
-    );
-    GoogleMessage2.create().mergeFromProto3Json(_message2Proto3JsonObject);
+    sink1 =
+        p2.GoogleMessage1.create()
+          ..mergeFromProto3Json(_message1Proto2Proto3JsonObject);
+    sink2 =
+        p3.GoogleMessage1.create()
+          ..mergeFromProto3Json(_message1Proto3Proto3JsonObject);
+    sink3 =
+        GoogleMessage2.create()..mergeFromProto3Json(_message2Proto3JsonObject);
   }
 }
 
@@ -53,4 +59,10 @@ void main() {
     message1Proto3Input,
     message2Input,
   ).report();
+
+  if (int.parse('1') == 0) {
+    print(sink1);
+    print(sink2);
+    print(sink3);
+  }
 }

--- a/benchmarks/bin/from_proto3_json_string.dart
+++ b/benchmarks/bin/from_proto3_json_string.dart
@@ -11,6 +11,11 @@ import 'package:protobuf_benchmarks/generated/google_message1_proto3.pb.dart'
     as p3;
 import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
 import 'package:protobuf_benchmarks/readfile.dart';
+import 'package:protobuf/protobuf.dart';
+
+GeneratedMessage? sink1;
+GeneratedMessage? sink2;
+GeneratedMessage? sink3;
 
 class Benchmark extends BenchmarkBase {
   final String _message1Proto2Proto3JsonString;
@@ -34,15 +39,15 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    p2.GoogleMessage1.create().mergeFromProto3Json(
-      jsonDecode(_message1Proto2Proto3JsonString),
-    );
-    p3.GoogleMessage1.create().mergeFromProto3Json(
-      jsonDecode(_message1Proto3Proto3JsonString),
-    );
-    GoogleMessage2.create().mergeFromProto3Json(
-      jsonDecode(_message2Proto3JsonString),
-    );
+    sink1 =
+        p2.GoogleMessage1.create()
+          ..mergeFromProto3Json(jsonDecode(_message1Proto2Proto3JsonString));
+    sink2 =
+        p3.GoogleMessage1.create()
+          ..mergeFromProto3Json(jsonDecode(_message1Proto3Proto3JsonString));
+    sink3 =
+        GoogleMessage2.create()
+          ..mergeFromProto3Json(jsonDecode(_message2Proto3JsonString));
   }
 }
 
@@ -60,4 +65,10 @@ void main() {
     message1Proto3Input,
     message2Input,
   ).report();
+
+  if (int.parse('1') == 0) {
+    print(sink1);
+    print(sink2);
+    print(sink3);
+  }
 }

--- a/benchmarks/bin/hash_code.dart
+++ b/benchmarks/bin/hash_code.dart
@@ -10,6 +10,10 @@ import 'package:protobuf_benchmarks/generated/google_message1_proto3.pb.dart'
 import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
 import 'package:protobuf_benchmarks/readfile.dart';
 
+int sink1 = 0;
+int sink2 = 0;
+int sink3 = 0;
+
 class Benchmark extends BenchmarkBase {
   final p2.GoogleMessage1 _message1Proto2;
   final p3.GoogleMessage1 _message1Proto3;
@@ -26,9 +30,9 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    _message1Proto2.hashCode;
-    _message1Proto3.hashCode;
-    _message2.hashCode;
+    sink1 = _message1Proto2.hashCode;
+    sink2 = _message1Proto3.hashCode;
+    sink3 = _message2.hashCode;
   }
 }
 
@@ -46,4 +50,10 @@ void main() {
     message1Proto3Input,
     message2Input,
   ).report();
+
+  if (int.parse('1') == 0) {
+    print(sink1);
+    print(sink2);
+    print(sink3);
+  }
 }

--- a/benchmarks/bin/query_decode_binary.dart
+++ b/benchmarks/bin/query_decode_binary.dart
@@ -5,6 +5,9 @@
 import 'package:protobuf_benchmarks/benchmark_base.dart';
 import 'package:protobuf_benchmarks/generated/f0.pb.dart' as f0;
 import 'package:protobuf_benchmarks/readfile.dart';
+import 'package:protobuf/protobuf.dart';
+
+GeneratedMessage? sink;
 
 class Benchmark extends BenchmarkBase {
   final List<int> _input;
@@ -13,11 +16,15 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    f0.A0.fromBuffer(_input);
+    sink = f0.A0.fromBuffer(_input);
   }
 }
 
 void main() {
   final List<int> encoded = readfile('datasets/query_benchmark.pb');
   Benchmark('query_decode_binary', encoded).report();
+
+  if (int.parse('1') == 0) {
+    print(sink);
+  }
 }

--- a/benchmarks/bin/query_decode_json.dart
+++ b/benchmarks/bin/query_decode_json.dart
@@ -5,6 +5,9 @@
 import 'package:protobuf_benchmarks/benchmark_base.dart';
 import 'package:protobuf_benchmarks/generated/f0.pb.dart' as f0;
 import 'package:protobuf_benchmarks/readfile.dart';
+import 'package:protobuf/protobuf.dart';
+
+GeneratedMessage? sink;
 
 class Benchmark extends BenchmarkBase {
   final String _input;
@@ -14,11 +17,15 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    f0.A0.fromJson(_input);
+    sink = f0.A0.fromJson(_input);
   }
 }
 
 void main() {
   final List<int> encoded = readfile('datasets/query_benchmark.pb');
   Benchmark('query_decode_json', encoded).report();
+
+  if (int.parse('1') == 0) {
+    print(sink);
+  }
 }

--- a/benchmarks/bin/query_encode_binary.dart
+++ b/benchmarks/bin/query_encode_binary.dart
@@ -6,6 +6,10 @@ import 'package:protobuf_benchmarks/benchmark_base.dart';
 import 'package:protobuf_benchmarks/generated/f0.pb.dart' as f0;
 import 'package:protobuf_benchmarks/readfile.dart';
 
+import 'dart:typed_data';
+
+Uint8List? sink;
+
 class Benchmark extends BenchmarkBase {
   final f0.A0 _input;
 
@@ -13,11 +17,15 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    _input.writeToBuffer();
+    sink = _input.writeToBuffer();
   }
 }
 
 void main() {
   final List<int> encoded = readfile('datasets/query_benchmark.pb');
   Benchmark('query_encode_binary', encoded).report();
+
+  if (int.parse('1') == 0) {
+    print(sink);
+  }
 }

--- a/benchmarks/bin/query_encode_json.dart
+++ b/benchmarks/bin/query_encode_json.dart
@@ -6,6 +6,8 @@ import 'package:protobuf_benchmarks/benchmark_base.dart';
 import 'package:protobuf_benchmarks/generated/f0.pb.dart' as f0;
 import 'package:protobuf_benchmarks/readfile.dart';
 
+String? sink;
+
 class Benchmark extends BenchmarkBase {
   final f0.A0 _input;
 
@@ -13,11 +15,15 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    _input.writeToJson();
+    sink = _input.writeToJson();
   }
 }
 
 void main() {
   final List<int> encoded = readfile('datasets/query_benchmark.pb');
   Benchmark('query_encode_json', encoded).report();
+
+  if (int.parse('1') == 0) {
+    print(sink);
+  }
 }

--- a/benchmarks/bin/query_set_nested_value.dart
+++ b/benchmarks/bin/query_set_nested_value.dart
@@ -9,6 +9,8 @@ import 'package:protobuf_benchmarks/generated/f19.pb.dart' as f19;
 import 'package:protobuf_benchmarks/generated/f2.pb.dart' as f2;
 import 'package:protobuf_benchmarks/readfile.dart';
 
+GeneratedMessage? sink;
+
 class Benchmark extends BenchmarkBase {
   final f0.A0 _input;
 
@@ -17,8 +19,7 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    // ignore: unused_result
-    _input.rebuild((f0.A0 a0Builder) {
+    sink = _input.rebuild((f0.A0 a0Builder) {
       a0Builder.a4.last = a0Builder.a4.last.rebuild((f2.A1 a1builder) {
         a1builder.a378 = a1builder.a378.rebuild(
           (f19.A220 a220builder) => a220builder.a234 = 'new_value',
@@ -31,4 +32,8 @@ class Benchmark extends BenchmarkBase {
 void main() {
   final List<int> encoded = readfile('datasets/query_benchmark.pb');
   Benchmark('query_set_nested_value', encoded).report();
+
+  if (int.parse('1') == 0) {
+    print(sink);
+  }
 }

--- a/benchmarks/bin/repeated_field.dart
+++ b/benchmarks/bin/repeated_field.dart
@@ -8,6 +8,9 @@ import 'package:fixnum/fixnum.dart';
 import 'package:protobuf_benchmarks/benchmark_base.dart';
 import 'package:protobuf_benchmarks/generated/f12.pb.dart' as f12;
 import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
+import 'package:protobuf/protobuf.dart';
+
+GeneratedMessage? sink;
 
 class RepeatedBenchmark extends BenchmarkBase {
   final Uint8List _buffer;
@@ -16,7 +19,9 @@ class RepeatedBenchmark extends BenchmarkBase {
     : _buffer = message.writeToBuffer();
 
   @override
-  void run() => GoogleMessage2.fromBuffer(_buffer);
+  void run() {
+    sink = GoogleMessage2.fromBuffer(_buffer);
+  }
 }
 
 class RepeatedEnumBenchmark extends BenchmarkBase {
@@ -26,7 +31,9 @@ class RepeatedEnumBenchmark extends BenchmarkBase {
     : _buffer = message.writeToBuffer();
 
   @override
-  void run() => f12.A58.fromBuffer(_buffer);
+  void run() {
+    sink = f12.A58.fromBuffer(_buffer);
+  }
 }
 
 void main() {
@@ -46,4 +53,8 @@ void main() {
     'repeated_enum',
     f12.A58(a306: List<f12.A322>.generate(kSize, (_) => f12.A322.A324)),
   ).report();
+
+  if (int.parse('1') == 0) {
+    print(sink);
+  }
 }

--- a/benchmarks/bin/to_binary.dart
+++ b/benchmarks/bin/to_binary.dart
@@ -10,6 +10,12 @@ import 'package:protobuf_benchmarks/generated/google_message1_proto3.pb.dart'
 import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
 import 'package:protobuf_benchmarks/readfile.dart';
 
+import 'dart:typed_data';
+
+Uint8List? sink1;
+Uint8List? sink2;
+Uint8List? sink3;
+
 class Benchmark extends BenchmarkBase {
   final p2.GoogleMessage1 _message1Proto2;
   final p3.GoogleMessage1 _message1Proto3;
@@ -26,9 +32,9 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    _message1Proto2.writeToBuffer();
-    _message1Proto3.writeToBuffer();
-    _message2.writeToBuffer();
+    sink1 = _message1Proto2.writeToBuffer();
+    sink2 = _message1Proto3.writeToBuffer();
+    sink3 = _message2.writeToBuffer();
   }
 }
 
@@ -46,4 +52,10 @@ void main() {
     message1Proto3Input,
     message2Input,
   ).report();
+
+  if (int.parse('1') == 0) {
+    print(sink1);
+    print(sink2);
+    print(sink3);
+  }
 }

--- a/benchmarks/bin/to_json_string.dart
+++ b/benchmarks/bin/to_json_string.dart
@@ -10,6 +10,10 @@ import 'package:protobuf_benchmarks/generated/google_message1_proto3.pb.dart'
 import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
 import 'package:protobuf_benchmarks/readfile.dart';
 
+String? sink1;
+String? sink2;
+String? sink3;
+
 class Benchmark extends BenchmarkBase {
   final p2.GoogleMessage1 _message1Proto2;
   final p3.GoogleMessage1 _message1Proto3;
@@ -26,9 +30,9 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    _message1Proto2.writeToJson();
-    _message1Proto3.writeToJson();
-    _message2.writeToJson();
+    sink1 = _message1Proto2.writeToJson();
+    sink2 = _message1Proto3.writeToJson();
+    sink3 = _message2.writeToJson();
   }
 }
 
@@ -46,4 +50,10 @@ void main() {
     message1Proto3Input,
     message2Input,
   ).report();
+
+  if (int.parse('1') == 0) {
+    print(sink1);
+    print(sink2);
+    print(sink3);
+  }
 }

--- a/benchmarks/bin/to_proto3_json_object.dart
+++ b/benchmarks/bin/to_proto3_json_object.dart
@@ -10,6 +10,10 @@ import 'package:protobuf_benchmarks/generated/google_message1_proto3.pb.dart'
 import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
 import 'package:protobuf_benchmarks/readfile.dart';
 
+Object? sink1;
+Object? sink2;
+Object? sink3;
+
 class Benchmark extends BenchmarkBase {
   final p2.GoogleMessage1 _message1Proto2;
   final p3.GoogleMessage1 _message1Proto3;
@@ -26,9 +30,9 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    _message1Proto2.toProto3Json();
-    _message1Proto3.toProto3Json();
-    _message2.toProto3Json();
+    sink1 = _message1Proto2.toProto3Json();
+    sink2 = _message1Proto3.toProto3Json();
+    sink3 = _message2.toProto3Json();
   }
 }
 
@@ -46,4 +50,10 @@ void main() {
     message1Proto3Input,
     message2Input,
   ).report();
+
+  if (int.parse('1') == 0) {
+    print(sink1);
+    print(sink2);
+    print(sink3);
+  }
 }

--- a/benchmarks/bin/to_proto3_json_string.dart
+++ b/benchmarks/bin/to_proto3_json_string.dart
@@ -12,6 +12,10 @@ import 'package:protobuf_benchmarks/generated/google_message1_proto3.pb.dart'
 import 'package:protobuf_benchmarks/generated/google_message2.pb.dart';
 import 'package:protobuf_benchmarks/readfile.dart';
 
+String? sink1;
+String? sink2;
+String? sink3;
+
 class Benchmark extends BenchmarkBase {
   final p2.GoogleMessage1 _message1Proto2;
   final p3.GoogleMessage1 _message1Proto3;
@@ -28,9 +32,9 @@ class Benchmark extends BenchmarkBase {
 
   @override
   void run() {
-    jsonEncode(_message1Proto2.toProto3Json());
-    jsonEncode(_message1Proto3.toProto3Json());
-    jsonEncode(_message2.toProto3Json());
+    sink1 = jsonEncode(_message1Proto2.toProto3Json());
+    sink2 = jsonEncode(_message1Proto3.toProto3Json());
+    sink3 = jsonEncode(_message2.toProto3Json());
   }
 }
 
@@ -48,4 +52,10 @@ void main() {
     message1Proto3Input,
     message2Input,
   ).report();
+
+  if (int.parse('1') == 0) {
+    print(sink1);
+    print(sink2);
+    print(sink3);
+  }
 }


### PR DESCRIPTION
In `binary_decode_packed` benchmarks we used "sink" variables to write the decoded values, and printed these sinks at the end to make sure they're not dropped.

Do the same in the rest of the benchmarks to make sure no code is eliminated by a sufficiently smart compiler or VM.

Just as a sanity check I compared the numbers before and after this change, when compiled to Wasm with `-O2`. The numbers do not change in a consistent (reproducible) and significant way. It's still good to be safe and use the benchmark results to avoid dropping code.