### PR TITLE
Fix JS interop annotations

### DIFF
--- a/protobuf/lib/src/protobuf/json/json_web.dart
+++ b/protobuf/lib/src/protobuf/json/json_web.dart
@@ -14,16 +14,16 @@ import '../utils.dart';
 
 @JS('JSON')
 extension type _JSON._(JSObject _) implements JSObject {
-  @JS('JSON.stringify')
+  @JS('stringify')
   external static JSString _stringify(JSObject value);
 
-  @JS('JSON.parse')
+  @JS('parse')
   external static JSAny? _parse(JSString text);
 }
 
 @JS('Number')
 extension type _Number._(JSObject _) implements JSObject {
-  @JS('Number.isInteger')
+  @JS('isInteger')
   external static bool _isInteger(JSAny value);
 }
 


### PR DESCRIPTION
In a declaration like

```dart
@JS('JSON')
extension type _JSON._(JSObject _) implements JSObject {
  @JS('JSON.stringify')
  external static JSString _stringify(JSObject value);
}
```

When I call `_JSON._stringify(...)`, dart2js calls `JSON.stringify`, but dart2wasm calls `JSON.JSON.stringify`, which is wrong.

Reading [1] it looks like the annotation `JSON.stringify` should just be `stringify`. If I do that the code works with both dart2wasm and dart2js.

(I've reported dart2wasm's handling of the annotations above and we'll work on a fix for it on dart2wasm.)

This change is not tested on the CI because when compiling with dart2wasm we use the JS decoder library used by the VM, which doesn't use JS interop. I tested this manually with the patch:

```diff
diff --git a/protobuf/lib/src/protobuf/json/json.dart b/protobuf/lib/src/protobuf/json/json.dart
index 05d1ac1..70b6a7c 100644
--- a/protobuf/lib/src/protobuf/json/json.dart
+++ b/protobuf/lib/src/protobuf/json/json.dart
@@ -13,7 +13,7 @@ import '../utils.dart';
 // Use json_vm.dart with VM and dart2wasm, json_web.dart with dart2js.
 // json_web.dart uses JS interop for parsing, and JS interop is too slow on
 // Wasm. VM's patch performs better in Wasm.
-export 'json_vm.dart' if (dart.library.html) 'json_web.dart';
+export 'json_vm.dart' if (dart.library.js_interop) 'json_web.dart';

 Map<String, dynamic> writeToJsonMap(FieldSet fs) {
   dynamic convertToMap(dynamic fieldValue, int fieldType) {
```

[1]: https://dart.dev/interop/js-interop/usage#js