### PR TITLE
Fix non-proto3 JSON format double decoding

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -3,9 +3,12 @@
 * Improve performance of `GeneratedMessage.deepCopy`. ([#742])
 * Fix unknown enum handling in `GeneratedMessage.mergeFromProto3Json` when
   the `ignoreUnknownFields` optional argument is `true`. ([#853])
+* Fix decoding doubles in `GeneratedMessage.mergeFromJson` and
+  `GeneratedMessage.mergeFromJsonMap` with dart2wasm. ([#1043])
 
 [#742]: https://github.com/google/protobuf.dart/pull/742
 [#853]: https://github.com/google/protobuf.dart/pull/853
+[#1043]: https://github.com/google/protobuf.dart/pull/1043
 
 ## 4.2.0
 

--- a/protobuf/lib/src/protobuf/json/json_web.dart
+++ b/protobuf/lib/src/protobuf/json/json_web.dart
@@ -389,7 +389,7 @@ Object? _convertRawJsValue(
       // Allow quoted values, although we don't emit them.
       if (value.isA<JSNumber>()) {
         final jsNum = value._as<JSNumber>();
-        return _Number._isInteger(jsNum) ? jsNum.toDartInt : jsNum.toDartDouble;
+        return jsNum.toDartDouble;
       } else if (value.isA<JSString>()) {
         return double.parse(value._as<JSString>().toDart);
       }


### PR DESCRIPTION
When the field type is a proto `float` or `double` we always use a Dart `double` for the value. Trying to set the field an `int` causes an assertion failure in `FieldSet`.

This code is also a bit inconsistent in itself: when the jspblite2 value is a string it decodes as `double`, but when it's a number it tries to convert to an `int`. So if the value is a string `"1"` it stores as `double` but if it's the number `1` it tries to convert to double.

This isn't an issue with dart2js as with dart2js `int` and `double` are the same thing, but it causes assertion failures when this library is used with dart2wasm which distinguishes `int`s and `double`s.

Fix by always storing proto `float`s and `double`s as Dart `double`s.

cl/799924250