### PR TITLE
Compile dart2wasm benchmarks with --no-strip-wasm

### DIFF
--- a/benchmarks/tool/compile_benchmarks.dart
+++ b/benchmarks/tool/compile_benchmarks.dart
@@ -216,6 +216,7 @@ List<String> wasmProcessArgs(String sourceFile) {
     'wasm',
     sourceFile,
     '-O2',
+    '--no-strip-wasm',
     '-o',
     'out/$baseNameNoExt.wasm',
   ];


### PR DESCRIPTION
Keep the symbols to get useful perf outputs.