### PR TITLE
Sync cl/658131451

### DIFF
--- a/protoc_plugin/lib/src/protobuf_field.dart
+++ b/protoc_plugin/lib/src/protobuf_field.dart
@@ -262,6 +262,16 @@ class ProtobufField {
     } else if (isRepeated) {
       if (typeConstant == '$protobufImportPrefix.PbFieldType.PS') {
         invocation = 'pPS';
+      } else if (typeConstant == '$protobufImportPrefix.PbFieldType.PE') {
+        invocation = 'pPE<$type>';
+        named['enumValues'] = '$type.values';
+        final makeDefault = generateDefaultFunction(omitIfFirstEnumValue: true);
+        if (makeDefault != null) {
+          named['defaultEnumValue'] = makeDefault;
+        }
+      } else if (typeConstant == '$protobufImportPrefix.PbFieldType.PM') {
+        invocation = 'pPM<$type>';
+        named['subBuilder'] = '$type.create';
       } else {
         args.add(typeConstant);
         if (baseType.isMessage || baseType.isGroup || baseType.isEnum) {
@@ -273,6 +283,7 @@ class ProtobufField {
         if (baseType.isMessage || baseType.isGroup) {
           named['subBuilder'] = '$type.create';
         } else if (baseType.isEnum) {
+          // TODO: remove this branch.
           named['valueOf'] = '$type.valueOf';
           named['enumValues'] = '$type.values';
           named['defaultEnumValue'] = generateDefaultFunction();
@@ -280,14 +291,27 @@ class ProtobufField {
       }
     } else {
       // Singular field.
-      final makeDefault = generateDefaultFunction();
+      final makeDefault = generateDefaultFunction(omitIfFirstEnumValue: true);
 
       if (baseType.isEnum) {
-        args.add(typeConstant);
-        named['defaultOrMaker'] = makeDefault;
-        named['valueOf'] = '$type.valueOf';
+        invocation = 'aE<$type>';
+        if (typeConstant != '$protobufImportPrefix.PbFieldType.OE') {
+          named['fieldType'] = typeConstant;
+        }
+        if (makeDefault != null) named['defaultOrMaker'] = makeDefault;
         named['enumValues'] = '$type.values';
-        invocation = 'e<$type>';
+      } else if (type == '$coreImportPrefix.int') {
+        invocation = 'aI';
+        if (typeConstant != '$protobufImportPrefix.PbFieldType.O3') {
+          named['fieldType'] = typeConstant;
+        }
+        if (makeDefault != null) named['defaultOrMaker'] = makeDefault;
+      } else if (type == '$coreImportPrefix.double') {
+        invocation = 'aD';
+        if (typeConstant != '$protobufImportPrefix.PbFieldType.OD') {
+          named['fieldType'] = typeConstant;
+        }
+        if (makeDefault != null) named['defaultOrMaker'] = makeDefault;
       } else if (makeDefault == null) {
         switch (type) {
           case '$coreImportPrefix.String':
@@ -360,7 +384,7 @@ class ProtobufField {
   }
 
   /// Returns a function expression that returns the field's default value.
-  String? generateDefaultFunction() {
+  String? generateDefaultFunction({bool omitIfFirstEnumValue = false}) {
     assert(!isRepeated);
     switch (descriptor.type) {
       case FieldDescriptorProto_Type.TYPE_BOOL:
@@ -422,6 +446,7 @@ class ProtobufField {
             descriptor.defaultValue.isNotEmpty) {
           return '$className.${descriptor.defaultValue}';
         } else if (gen._canonicalValues.isNotEmpty) {
+          if (omitIfFirstEnumValue) return null;
           return '$className.${gen.dartNames[gen._canonicalValues[0].name]}';
         }
         return null;

--- a/protoc_plugin/test/goldens/messageGenerator.pb.dart
+++ b/protoc_plugin/test/goldens/messageGenerator.pb.dart
@@ -8,7 +8,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PhoneNumber', createEmptyInstance: create)
     ..aQS(1, _omitFieldNames ? '' : 'number')
-    ..e<PhoneNumber_PhoneType>(2, _omitFieldNames ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: PhoneNumber_PhoneType.MOBILE, valueOf: PhoneNumber_PhoneType.valueOf, enumValues: PhoneNumber_PhoneType.values)
+    ..aE<PhoneNumber_PhoneType>(2, _omitFieldNames ? '' : 'type', enumValues: PhoneNumber_PhoneType.values)
     ..a<$core.String>(3, _omitFieldNames ? '' : 'name', $pb.PbFieldType.OS, defaultOrMaker: '\$')
     ..aOS(4, _omitFieldNames ? '' : 'deprecatedField')
   ;

--- a/protoc_plugin/test/goldens/messageGenerator.pb.dart.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.pb.dart.meta
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1827
-  end: 1833
+  begin: 1722
+  end: 1728
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1875
-  end: 1881
+  begin: 1770
+  end: 1776
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1961
-  end: 1970
+  begin: 1856
+  end: 1865
 }
 annotation: {
   path: 4
@@ -45,8 +45,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2013
-  end: 2024
+  begin: 1908
+  end: 1919
 }
 annotation: {
   path: 4
@@ -54,8 +54,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2096
-  end: 2100
+  begin: 1991
+  end: 1995
 }
 annotation: {
   path: 4
@@ -63,8 +63,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2141
-  end: 2145
+  begin: 2036
+  end: 2040
 }
 annotation: {
   path: 4
@@ -72,8 +72,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2233
-  end: 2240
+  begin: 2128
+  end: 2135
 }
 annotation: {
   path: 4
@@ -81,8 +81,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2283
-  end: 2292
+  begin: 2178
+  end: 2187
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2355
-  end: 2359
+  begin: 2250
+  end: 2254
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2406
-  end: 2410
+  begin: 2301
+  end: 2305
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2490
-  end: 2497
+  begin: 2385
+  end: 2392
 }
 annotation: {
   path: 4
@@ -117,17 +117,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2540
-  end: 2549
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 2661
-  end: 2676
+  begin: 2435
+  end: 2444
 }
 annotation: {
   path: 4
@@ -135,8 +126,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 2767
-  end: 2782
+  begin: 2556
+  end: 2571
 }
 annotation: {
   path: 4
@@ -144,8 +135,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 2911
-  end: 2929
+  begin: 2662
+  end: 2677
 }
 annotation: {
   path: 4
@@ -153,6 +144,15 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3021
-  end: 3041
+  begin: 2806
+  end: 2824
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 2916
+  end: 2936
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb.dart
+++ b/protoc_plugin/test/goldens/oneMessage.pb.dart
@@ -32,7 +32,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
       _omitMessageNames ? '' : 'PhoneNumber',
       createEmptyInstance: create)
     ..aQS(1, _omitFieldNames ? '' : 'number')
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'type', $pb.PbFieldType.O3)
+    ..aI(2, _omitFieldNames ? '' : 'type')
     ..a<$core.String>(3, _omitFieldNames ? '' : 'name', $pb.PbFieldType.OS,
         defaultOrMaker: '\$');
 

--- a/protoc_plugin/test/goldens/oneMessage.pb.dart.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.dart.meta
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2191
-  end: 2197
+  begin: 2161
+  end: 2167
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2239
-  end: 2245
+  begin: 2209
+  end: 2215
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2325
-  end: 2334
+  begin: 2295
+  end: 2304
 }
 annotation: {
   path: 4
@@ -45,17 +45,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2377
-  end: 2388
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: test
-  begin: 2448
-  end: 2452
+  begin: 2347
+  end: 2358
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2494
-  end: 2498
+  begin: 2418
+  end: 2422
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2580
-  end: 2587
+  begin: 2464
+  end: 2468
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2630
-  end: 2639
+  begin: 2550
+  end: 2557
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2600
+  end: 2609
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2702
-  end: 2706
+  begin: 2672
+  end: 2676
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2753
-  end: 2757
+  begin: 2723
+  end: 2727
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2837
-  end: 2844
+  begin: 2807
+  end: 2814
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2887
-  end: 2896
+  begin: 2857
+  end: 2866
 }


### PR DESCRIPTION
(Not my CL, I'm just syncing it to open source)

CL description: (slightly edited)

Use a map to cache the `valueOf` function for enums.

This is a generated-code size optimization.

The main change is to generate the valueOf functions for protobuf enums programatically, rather than (1) use the per-enum `FooPbEnum.valueOf` static function tear-foo which (2) uses a per-enum static variable that is lazily initialized to map from int value to the protobuf enum value.

With ~1000 protobuf enums, this allows most of the `valueOf` static function tear-off closures to tree-shaken, together with their functions and the code for the initializer of the map.

The secondary change is to use more specialized 'add' methods to `BuilderInfo`, allowing many fields to be 'defined' with a call with fewer arguments.

Together, these changes reduce the size of the main unit of an app by about 1.3%, and would have a similar effect on native targets.

This change requires https://github.com/dart-lang/sdk/commit/175dc05db3cd626874c17ceb03336065a03375bb, which was released with Dart 3.6.0.