### PR TITLE
Generalize argument type of `PbList.from` from `List<T>` to `Iterable<T>`

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix unknown enum handling in `GeneratedMessage.mergeFromProto3Json` when
   the `ignoreUnknownFields` optional argument is `true`. ([#853])
 * Add `BuilderInfo` methods to support protoc-plugin 23.0.0. ([#1047])
+* Generalize argument type of `PbList.from` from `List<T>` to `Iterable<T>`.
 
 [#742]: https://github.com/google/protobuf.dart/pull/742
 [#853]: https://github.com/google/protobuf.dart/pull/853

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -40,8 +40,8 @@ class PbList<E> extends ListBase<E> {
       _check = _checkNotNull,
       _isReadOnly = true;
 
-  PbList.from(List<E> from)
-    : _wrappedList = List<E>.from(from),
+  PbList.from(Iterable<E> from)
+    : _wrappedList = List<E>.of(from),
       _check = _checkNotNull;
 
   @override


### PR DESCRIPTION
This is more consistent with `List.from` and also more efficient as we can avoid redundant `List` allocations when we have an `Iterable` instead of a `List`. This commonly happens when we create a `PbList` from a chain of `map`, `where` etc. calls.

Also update the the factory body to use `List.of` instead of `List.from` as we know the `Iterable`'s element type. (`List.from` takes `Iterable<dynamic>`, `List.of` takes `Iterable<T>`)

cl/810421932