### PR TITLE
Run plugin with asserts when building test protos

### DIFF
--- a/protoc_plugin/Makefile
+++ b/protoc_plugin/Makefile
@@ -3,7 +3,7 @@ PLUGIN_SRC = \
 	lib/**/*.dart
 
 OUTPUT_DIR=test/gen
-PLUGIN_NAME=protoc-gen-dart
+PLUGIN_NAME=protoc-gen-dart-debug
 PLUGIN_PATH=bin/$(PLUGIN_NAME)
 
 TEST_PROTO_LIST = \

--- a/protoc_plugin/bin/protoc-gen-dart-debug
+++ b/protoc_plugin/bin/protoc-gen-dart-debug
@@ -1,0 +1,3 @@
+#!/bin/bash
+BINDIR=$(dirname "$0")
+dart --enable-asserts "$BINDIR/protoc_plugin.dart" -c "$@"

--- a/protoc_plugin/lib/src/protobuf_field.dart
+++ b/protoc_plugin/lib/src/protobuf_field.dart
@@ -393,7 +393,6 @@ class ProtobufField {
 
   /// Returns a function expression that returns the field's default value.
   String? generateDefaultFunction({bool omitIfFirstEnumValue = false}) {
-    assert(!isRepeated);
     switch (descriptor.type) {
       case FieldDescriptorProto_Type.TYPE_BOOL:
         return _getDefaultAsBoolExpr(null);


### PR DESCRIPTION
Currently we run the tests with assertions but that doesn't cover some of the code paths.

When building the test protos we don't run the plugin with assertions.

Add a new executable `protoc-gen-dart-debug` that is the same as `protoc-gen-dart`, but passes `--enable-asserts` to Dart. Use it when building test protos.

This triggers an assertion which was reported in #608. The assertion is clearly wrong (we call the function for repeated fields a few lines above the assertion) and no one knows or remembers why it's there. Remove the assertion.

Closes #608.