### PR TITLE
Remove redundant `break` statements in switch cases

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -58,19 +58,14 @@ void _mergeFromCodedBufferReader(
     switch (fieldType) {
       case PbFieldType.OPTIONAL_BOOL:
         fs._setFieldUnchecked(meta, fi, input.readBool());
-        break;
       case PbFieldType.OPTIONAL_BYTES:
         fs._setFieldUnchecked(meta, fi, input.readBytes());
-        break;
       case PbFieldType.OPTIONAL_STRING:
         fs._setFieldUnchecked(meta, fi, input.readString());
-        break;
       case PbFieldType.OPTIONAL_FLOAT:
         fs._setFieldUnchecked(meta, fi, input.readFloat());
-        break;
       case PbFieldType.OPTIONAL_DOUBLE:
         fs._setFieldUnchecked(meta, fi, input.readDouble());
-        break;
       case PbFieldType.OPTIONAL_ENUM:
         final rawValue = input.readEnum();
         final value = meta._decodeEnum(tagNumber, registry, rawValue);
@@ -80,7 +75,6 @@ void _mergeFromCodedBufferReader(
         } else {
           fs._setFieldUnchecked(meta, fi, value);
         }
-        break;
       case PbFieldType.OPTIONAL_GROUP:
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         final oldValue = fs._getFieldOrNull(fi);
@@ -89,37 +83,26 @@ void _mergeFromCodedBufferReader(
         }
         input.readGroup(tagNumber, subMessage, registry);
         fs._setFieldUnchecked(meta, fi, subMessage);
-        break;
       case PbFieldType.OPTIONAL_INT32:
         fs._setFieldUnchecked(meta, fi, input.readInt32());
-        break;
       case PbFieldType.OPTIONAL_INT64:
         fs._setFieldUnchecked(meta, fi, input.readInt64());
-        break;
       case PbFieldType.OPTIONAL_SINT32:
         fs._setFieldUnchecked(meta, fi, input.readSint32());
-        break;
       case PbFieldType.OPTIONAL_SINT64:
         fs._setFieldUnchecked(meta, fi, input.readSint64());
-        break;
       case PbFieldType.OPTIONAL_UINT32:
         fs._setFieldUnchecked(meta, fi, input.readUint32());
-        break;
       case PbFieldType.OPTIONAL_UINT64:
         fs._setFieldUnchecked(meta, fi, input.readUint64());
-        break;
       case PbFieldType.OPTIONAL_FIXED32:
         fs._setFieldUnchecked(meta, fi, input.readFixed32());
-        break;
       case PbFieldType.OPTIONAL_FIXED64:
         fs._setFieldUnchecked(meta, fi, input.readFixed64());
-        break;
       case PbFieldType.OPTIONAL_SFIXED32:
         fs._setFieldUnchecked(meta, fi, input.readSfixed32());
-        break;
       case PbFieldType.OPTIONAL_SFIXED64:
         fs._setFieldUnchecked(meta, fi, input.readSfixed64());
-        break;
       case PbFieldType.OPTIONAL_MESSAGE:
         final GeneratedMessage? oldValue = fs._getFieldOrNull(fi);
         if (oldValue != null) {
@@ -129,7 +112,6 @@ void _mergeFromCodedBufferReader(
           input.readMessage(subMessage, registry);
           fs._setFieldUnchecked(meta, fi, subMessage);
         }
-        break;
       case PbFieldType.REPEATED_BOOL:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -149,17 +131,14 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readBool());
         }
-        break;
       case PbFieldType.REPEATED_BYTES:
         final list = fs._ensureRepeatedField(meta, fi);
         list._checkModifiable('add');
         list._addUnchecked(input.readBytes());
-        break;
       case PbFieldType.REPEATED_STRING:
         final list = fs._ensureRepeatedField(meta, fi);
         list._checkModifiable('add');
         list._addUnchecked(input.readString());
-        break;
       case PbFieldType.REPEATED_FLOAT:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -176,7 +155,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readFloat());
         }
-        break;
       case PbFieldType.REPEATED_DOUBLE:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -193,7 +171,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readDouble());
         }
-        break;
       case PbFieldType.REPEATED_ENUM:
         final list = fs._ensureRepeatedField(meta, fi);
         _readPackableToListEnum(
@@ -205,13 +182,11 @@ void _mergeFromCodedBufferReader(
           tagNumber,
           registry,
         );
-        break;
       case PbFieldType.REPEATED_GROUP:
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readGroup(tagNumber, subMessage, registry);
         final list = fs._ensureRepeatedField(meta, fi);
         list.add(subMessage);
-        break;
       case PbFieldType.REPEATED_INT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -228,7 +203,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readInt32());
         }
-        break;
       case PbFieldType.REPEATED_INT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -245,7 +219,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readInt64());
         }
-        break;
       case PbFieldType.REPEATED_SINT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -262,7 +235,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readSint32());
         }
-        break;
       case PbFieldType.REPEATED_SINT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -279,7 +251,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readSint64());
         }
-        break;
       case PbFieldType.REPEATED_UINT32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -296,7 +267,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readUint32());
         }
-        break;
       case PbFieldType.REPEATED_UINT64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -313,7 +283,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readUint64());
         }
-        break;
       case PbFieldType.REPEATED_FIXED32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -330,7 +299,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readFixed32());
         }
-        break;
       case PbFieldType.REPEATED_FIXED64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -347,7 +315,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readFixed64());
         }
-        break;
       case PbFieldType.REPEATED_SFIXED32:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -364,7 +331,6 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readSfixed32());
         }
-        break;
       case PbFieldType.REPEATED_SFIXED64:
         final list = fs._ensureRepeatedField(meta, fi);
         if (wireType == WIRETYPE_LENGTH_DELIMITED) {
@@ -381,20 +347,17 @@ void _mergeFromCodedBufferReader(
           list._checkModifiable('add');
           list._addUnchecked(input.readSfixed64());
         }
-        break;
       case PbFieldType.REPEATED_MESSAGE:
         final subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readMessage(subMessage, registry);
         final list = fs._ensureRepeatedField(meta, fi);
         list.add(subMessage);
-        break;
       case PbFieldType.MAP:
         final mapFieldInfo = fi as MapFieldInfo;
         final mapEntryMeta = mapFieldInfo.mapEntryBuilderInfo;
         fs
             ._ensureMapField(meta, mapFieldInfo)
             ._mergeEntry(mapEntryMeta, input, registry);
-        break;
       default:
         throw UnsupportedError('Unknown field type $fieldType');
     }

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -355,7 +355,6 @@ class CodedBufferWriter {
     switch (valueType) {
       case PbFieldType.BOOL_BIT:
         _writeVarint32(value ? 1 : 0);
-        break;
       case PbFieldType.BYTES_BIT:
         final List<int> bytes = value;
         if (bytes is Uint8List) {
@@ -365,7 +364,6 @@ class CodedBufferWriter {
         } else {
           _writeBytesNoTag(Uint8List.fromList(bytes));
         }
-        break;
       case PbFieldType.STRING_BIT:
         final String string = value;
         if (string.isEmpty) {
@@ -373,17 +371,13 @@ class CodedBufferWriter {
         } else {
           _writeBytesNoTag(const Utf8Encoder().convert(string));
         }
-        break;
       case PbFieldType.DOUBLE_BIT:
         _writeDouble(value);
-        break;
       case PbFieldType.FLOAT_BIT:
         _writeFloat(value);
-        break;
       case PbFieldType.ENUM_BIT:
         final ProtobufEnum enum_ = value;
         _writeVarint32(enum_.value & 0xffffffff);
-        break;
       case PbFieldType.GROUP_BIT:
         // `value` is `UnknownFieldSet` or `GeneratedMessage`. Test for
         // `UnknownFieldSet` as it doesn't have subtypes, so the type test will
@@ -398,43 +392,31 @@ class CodedBufferWriter {
           final GeneratedMessage message = value;
           message.writeToCodedBufferWriter(this);
         }
-        break;
       case PbFieldType.INT32_BIT:
         _writeVarint64(Int64(value));
-        break;
       case PbFieldType.INT64_BIT:
         _writeVarint64(value);
-        break;
       case PbFieldType.SINT32_BIT:
         _writeVarint32(_encodeZigZag32(value));
-        break;
       case PbFieldType.SINT64_BIT:
         _writeVarint64(_encodeZigZag64(value));
-        break;
       case PbFieldType.UINT32_BIT:
         _writeVarint32(value);
-        break;
       case PbFieldType.UINT64_BIT:
         _writeVarint64(value);
-        break;
       case PbFieldType.FIXED32_BIT:
         _writeInt32(value);
-        break;
       case PbFieldType.FIXED64_BIT:
         _writeInt64(value);
-        break;
       case PbFieldType.SFIXED32_BIT:
         _writeInt32(value);
-        break;
       case PbFieldType.SFIXED64_BIT:
         _writeInt64(value);
-        break;
       case PbFieldType.MESSAGE_BIT:
         final mark = _startLengthDelimited();
         final GeneratedMessage msg = value;
         msg.writeToCodedBufferWriter(this);
         _endLengthDelimited(mark);
-        break;
     }
   }
 


### PR DESCRIPTION
These make internal linter sad.