### PR TITLE
Sync some of the internal changes

### DIFF
--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -25,10 +25,19 @@ typedef ValueOfFunc = ProtobufEnum? Function(int value);
 /// `GeneratedMessage_reservedNames` and should be unlikely to be used in a
 /// proto file.
 abstract class GeneratedMessage {
-  FieldSet? __fieldSet;
+  // The pragma tells dart2js that the late checks for `__fieldSet` are
+  // unnecessary. The field is always initialized before use, but dart2js can't
+  // see that. One problem is that `this.info_` is called before the
+  // initializing assignment, and potentially one of the many overrides for
+  // `get:info_` could access the field before it is initialized, or call one of
+  // the methods that accesses the field. The code generated for the `get:info_`
+  // methods does not do this, but it is hard to determine from first
+  // principles.
+  @pragma('dart2js:late:trust')
+  late final FieldSet __fieldSet;
 
-  @pragma('dart2js:tryInline')
-  FieldSet get _fieldSet => __fieldSet!;
+  @pragma('dart2js:prefer-inline')
+  FieldSet get _fieldSet => __fieldSet;
 
   GeneratedMessage() {
     __fieldSet = FieldSet(this, info_);

--- a/protobuf/lib/src/protobuf/internal.dart
+++ b/protobuf/lib/src/protobuf/internal.dart
@@ -27,10 +27,10 @@ import 'type_registry.dart';
 import 'utils.dart';
 
 export 'annotations.dart' show TagNumber, GrpcServiceName;
+export 'exceptions.dart' show InvalidProtocolBufferException;
 export 'pb_list.dart' show PbList;
 export 'pb_map.dart' show PbMap;
 export 'type_registry.dart' show TypeRegistry;
-export 'exceptions.dart' show InvalidProtocolBufferException;
 
 part 'builder_info.dart';
 part 'coded_buffer.dart';

--- a/protobuf/lib/src/protobuf/json/json.dart
+++ b/protobuf/lib/src/protobuf/json/json.dart
@@ -276,19 +276,16 @@ dynamic _convertJsonValue(
         }
       }
       expectedType = 'bool (true, false, "true", "false", 1, 0)';
-      break;
     case PbFieldType.BYTES_BIT:
       if (value is String) {
         return base64Decode(value);
       }
       expectedType = 'Base64 String';
-      break;
     case PbFieldType.STRING_BIT:
       if (value is String) {
         return value;
       }
       expectedType = 'String';
-      break;
     case PbFieldType.FLOAT_BIT:
     case PbFieldType.DOUBLE_BIT:
       // Allow quoted values, although we don't emit them.
@@ -300,7 +297,6 @@ dynamic _convertJsonValue(
         return double.parse(value);
       }
       expectedType = 'num or stringified num';
-      break;
     case PbFieldType.ENUM_BIT:
       // Allow quoted values, although we don't emit them.
       if (value is String) {
@@ -313,14 +309,12 @@ dynamic _convertJsonValue(
         return meta.decodeEnum(tagNumber, registry, value);
       }
       expectedType = 'int or stringified int';
-      break;
     case PbFieldType.INT32_BIT:
     case PbFieldType.SINT32_BIT:
     case PbFieldType.SFIXED32_BIT:
       if (value is int) return value;
       if (value is String) return int.parse(value);
       expectedType = 'int or stringified int';
-      break;
     case PbFieldType.UINT32_BIT:
     case PbFieldType.FIXED32_BIT:
       int? validatedValue;
@@ -331,7 +325,6 @@ dynamic _convertJsonValue(
       }
       if (validatedValue != null) return validatedValue;
       expectedType = 'int or stringified int';
-      break;
     case PbFieldType.INT64_BIT:
     case PbFieldType.SINT64_BIT:
     case PbFieldType.UINT64_BIT:
@@ -340,7 +333,6 @@ dynamic _convertJsonValue(
       if (value is int) return Int64(value);
       if (value is String) return Int64.parseInt(value);
       expectedType = 'int or stringified int';
-      break;
     case PbFieldType.GROUP_BIT:
     case PbFieldType.MESSAGE_BIT:
       if (value is Map) {
@@ -350,7 +342,6 @@ dynamic _convertJsonValue(
         return subMessage;
       }
       expectedType = 'nested message or group';
-      break;
     default:
       throw ArgumentError('Unknown type $fieldType');
   }

--- a/protobuf/lib/src/protobuf/json/json_web.dart
+++ b/protobuf/lib/src/protobuf/json/json_web.dart
@@ -174,7 +174,7 @@ JSObject _writeToRawJs(FieldSet fs) {
   }
   final unknownJsonData = fs.unknownJsonData;
   if (unknownJsonData != null) {
-    unknownJsonData.forEach((key, value) {
+    unknownJsonData.forEach((String key, Object? value) {
       result.setProperty(key.toJS, value.jsify());
     });
   }

--- a/protobuf/lib/src/protobuf/mixins/well_known.dart
+++ b/protobuf/lib/src/protobuf/mixins/well_known.dart
@@ -537,7 +537,7 @@ mixin ListValueMixin implements GeneratedMessage {
     if (json is List) {
       final subBuilder = message.info_.subBuilder(_valueFieldTagNumber)!;
       for (var i = 0; i < json.length; i++) {
-        final Object element = json[i];
+        final Object? element = json[i];
         final v = subBuilder() as ValueMixin;
         context.addListIndex(i);
         ValueMixin.fromProto3JsonHelper(v, element, typeRegistry, context);

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -404,12 +404,12 @@ class UnknownFieldSetField {
   }
 
   UnknownFieldSetField _deepCopy() {
-    final List<List<int>> newLengthDelimited = List.from(_lengthDelimited);
-    final List<Int64> newVarints = List.from(_varints);
-    final List<int> newFixed32s = List.from(_fixed32s);
-    final List<Int64> newFixed64s = List.from(_fixed64s);
+    final newLengthDelimited = List<List<int>>.from(_lengthDelimited);
+    final newVarints = List<Int64>.from(_varints);
+    final newFixed32s = List<int>.from(_fixed32s);
+    final newFixed64s = List<Int64>.from(_fixed64s);
 
-    final List<UnknownFieldSet> newGroups = [];
+    final newGroups = <UnknownFieldSet>[];
     for (final group in _groups) {
       newGroups.add(group._deepCopy());
     }


### PR DESCRIPTION
- Remove redundant `break`s in `switch` statements.

- Move type annotations from variables to lists:
  `final T x = [...]` to `final x = <T>[...]`

- Copy a dart2js optimization when accessing `GeneratedMessage._fieldSet`

- Sort exports in `internal.dart`.