### PR TITLE
Make name argument to BuilderInfo.add<T> nullable (for tree shaking purposes)

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Make `BuilderInfo` methods accept `GeneratedMessage Function()` typed
   closures.
+* Make `BuilderInfo.add` accept nullable name (for tree shaking purposes).
 
 ## 6.0.0
 

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -56,7 +56,7 @@ class BuilderInfo {
 
   void add<T>(
     int tagNumber,
-    String name,
+    String? name,
     int? fieldType,
     dynamic defaultOrMaker,
     CreateBuilderFunc? subBuilder,
@@ -69,7 +69,7 @@ class BuilderInfo {
     } else {
       final index = byIndex.length;
       final fieldInfo = FieldInfo<T>(
-        name,
+        name!,
         tagNumber,
         index,
         fieldType!,


### PR DESCRIPTION
When TFA tree shakes a proto field it will replace calls to specific methods with calls to `BuilderInfo.add(0, null, null, ...)`. The implementation of `add<>()` checks whether the tag is 0 and if so adds an unused field (which doesn't require type or name).

The parameter should be nullable, otherwise the TFA transformation creates unsound kernel AST (it passes `null` to a parameter that requires non-nullable `String`).